### PR TITLE
Add local-only auto-pin preferences with user-scoped SQLite storage

### DIFF
--- a/lib/providers/auto_pin_preferences_provider.dart
+++ b/lib/providers/auto_pin_preferences_provider.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+import 'package:chessever2/providers/auth_state_provider.dart';
+import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
+import 'package:chessever2/repository/sqlite/app_database.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final autoPinPreferencesProvider = AsyncNotifierProvider<
+  AutoPinPreferencesNotifier,
+  AutoPinPreferences
+>(AutoPinPreferencesNotifier.new);
+
+class AutoPinPreferencesNotifier extends AsyncNotifier<AutoPinPreferences> {
+  bool _listening = false;
+
+  AutoPinPreferencesRepository get _repo =>
+      AutoPinPreferencesRepository(AppDatabase.instance);
+
+  String? get _userId => ref.read(currentUserProvider)?.id;
+
+  @override
+  Future<AutoPinPreferences> build() async {
+    if (!_listening) {
+      _listening = true;
+      ref.listen(currentUserProvider, (prev, next) {
+        if (prev?.id != next?.id) {
+          unawaited(_reloadForUser());
+        }
+      });
+    }
+
+    return _repo.loadPreferences(_userId);
+  }
+
+  Future<void> _reloadForUser() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() => _repo.loadPreferences(_userId));
+  }
+
+  Future<void> setFavoritePlayersAutoPin(bool enabled) async {
+    final current = state.valueOrNull ?? AutoPinPreferences.defaults;
+    final updated = current.copyWith(favoritePlayersAutoPinEnabled: enabled);
+    state = AsyncValue.data(updated);
+    await _repo.setFavoritePlayersAutoPin(enabled, _userId);
+  }
+
+  Future<void> setCountrymenAutoPin(bool enabled) async {
+    final current = state.valueOrNull ?? AutoPinPreferences.defaults;
+    final updated = current.copyWith(countrymenAutoPinEnabled: enabled);
+    state = AsyncValue.data(updated);
+    await _repo.setCountrymenAutoPin(enabled, _userId);
+  }
+}

--- a/lib/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart
+++ b/lib/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart
@@ -36,6 +36,9 @@ class AutoPinPreferencesRepository {
 
   AutoPinPreferencesRepository(this._db);
 
+  static String _encodeBool(bool value) => value ? '1' : '0';
+  static bool _decodeBool(String value) => value == '1';
+
   // ---- Global preferences (user-scoped) ----
 
   Future<AutoPinPreferences> loadPreferences(String? userId) async {
@@ -114,7 +117,7 @@ class AutoPinPreferencesRepository {
       );
 
       if (entry != null) {
-        return entry.value == '1';
+        return _decodeBool(entry.value);
       }
 
       // Compatibility fallback: read legacy unscoped key
@@ -123,7 +126,7 @@ class AutoPinPreferencesRepository {
         // Copy to user-scoped cache
         await _db.setCache(
           key: _tourDisabledKey(tourId),
-          value: legacyValue ? '1' : '0',
+          value: _encodeBool(legacyValue),
           userId: userId,
         );
         return legacyValue;
@@ -144,7 +147,7 @@ class AutoPinPreferencesRepository {
     try {
       await _db.setCache(
         key: _tourDisabledKey(tourId),
-        value: disabled ? '1' : '0',
+        value: _encodeBool(disabled),
         userId: userId,
       );
     } catch (e) {

--- a/lib/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart
+++ b/lib/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart
@@ -1,0 +1,154 @@
+import 'dart:convert';
+
+import 'package:chessever2/repository/sqlite/app_database.dart';
+import 'package:flutter/foundation.dart';
+
+class AutoPinPreferences {
+  final bool favoritePlayersAutoPinEnabled;
+  final bool countrymenAutoPinEnabled;
+
+  const AutoPinPreferences({
+    this.favoritePlayersAutoPinEnabled = true,
+    this.countrymenAutoPinEnabled = false,
+  });
+
+  static const defaults = AutoPinPreferences();
+
+  AutoPinPreferences copyWith({
+    bool? favoritePlayersAutoPinEnabled,
+    bool? countrymenAutoPinEnabled,
+  }) {
+    return AutoPinPreferences(
+      favoritePlayersAutoPinEnabled:
+          favoritePlayersAutoPinEnabled ?? this.favoritePlayersAutoPinEnabled,
+      countrymenAutoPinEnabled:
+          countrymenAutoPinEnabled ?? this.countrymenAutoPinEnabled,
+    );
+  }
+}
+
+class AutoPinPreferencesRepository {
+  static const String _prefsKey = 'auto_pin_preferences';
+  static const String _tourDisabledKeyPrefix = 'auto_pin_disabled_';
+  static const String _legacyTourKeyPrefix = 'autoPinFavGames_';
+
+  final AppDatabase _db;
+
+  AutoPinPreferencesRepository(this._db);
+
+  // ---- Global preferences (user-scoped) ----
+
+  Future<AutoPinPreferences> loadPreferences(String? userId) async {
+    try {
+      final entry = await _db.getCache(
+        key: _prefsKey,
+        userId: userId,
+      );
+      if (entry == null) return AutoPinPreferences.defaults;
+
+      final map = jsonDecode(entry.value) as Map<String, dynamic>;
+      return AutoPinPreferences(
+        favoritePlayersAutoPinEnabled:
+            map['favoritePlayersAutoPinEnabled'] as bool? ??
+                AutoPinPreferences.defaults.favoritePlayersAutoPinEnabled,
+        countrymenAutoPinEnabled:
+            map['countrymenAutoPinEnabled'] as bool? ??
+                AutoPinPreferences.defaults.countrymenAutoPinEnabled,
+      );
+    } catch (e) {
+      debugPrint('[AutoPinPrefs] Error loading: $e');
+      return AutoPinPreferences.defaults;
+    }
+  }
+
+  Future<void> _savePreferences(
+    AutoPinPreferences prefs,
+    String? userId,
+  ) async {
+    try {
+      final json = jsonEncode({
+        'favoritePlayersAutoPinEnabled': prefs.favoritePlayersAutoPinEnabled,
+        'countrymenAutoPinEnabled': prefs.countrymenAutoPinEnabled,
+      });
+      await _db.setCache(key: _prefsKey, value: json, userId: userId);
+    } catch (e) {
+      debugPrint('[AutoPinPrefs] Error saving: $e');
+    }
+  }
+
+  Future<void> setFavoritePlayersAutoPin(
+    bool enabled,
+    String? userId,
+  ) async {
+    final current = await loadPreferences(userId);
+    await _savePreferences(
+      current.copyWith(favoritePlayersAutoPinEnabled: enabled),
+      userId,
+    );
+  }
+
+  Future<void> setCountrymenAutoPin(bool enabled, String? userId) async {
+    final current = await loadPreferences(userId);
+    await _savePreferences(
+      current.copyWith(countrymenAutoPinEnabled: enabled),
+      userId,
+    );
+  }
+
+  // ---- Per-tournament auto-pin disable (user-scoped) ----
+
+  String _tourDisabledKey(String tourId) =>
+      '$_tourDisabledKeyPrefix$tourId';
+
+  String _legacyTourKey(String tourId) =>
+      '$_legacyTourKeyPrefix$tourId';
+
+  Future<bool> getTournamentAutoPinDisabled(
+    String tourId,
+    String? userId,
+  ) async {
+    try {
+      final entry = await _db.getCache(
+        key: _tourDisabledKey(tourId),
+        userId: userId,
+      );
+
+      if (entry != null) {
+        return entry.value == '1';
+      }
+
+      // Compatibility fallback: read legacy unscoped key
+      final legacyValue = await _db.getBool(_legacyTourKey(tourId));
+      if (legacyValue != null) {
+        // Copy to user-scoped cache
+        await _db.setCache(
+          key: _tourDisabledKey(tourId),
+          value: legacyValue ? '1' : '0',
+          userId: userId,
+        );
+        return legacyValue;
+      }
+
+      return false;
+    } catch (e) {
+      debugPrint('[AutoPinPrefs] Error reading tour disabled: $e');
+      return false;
+    }
+  }
+
+  Future<void> setTournamentAutoPinDisabled(
+    String tourId,
+    bool disabled,
+    String? userId,
+  ) async {
+    try {
+      await _db.setCache(
+        key: _tourDisabledKey(tourId),
+        value: disabled ? '1' : '0',
+        userId: userId,
+      );
+    } catch (e) {
+      debugPrint('[AutoPinPrefs] Error setting tour disabled: $e');
+    }
+  }
+}

--- a/lib/screens/chessboard/chess_board_settings_page.dart
+++ b/lib/screens/chessboard/chess_board_settings_page.dart
@@ -1,5 +1,7 @@
+import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
 import 'package:chessever2/providers/engine_settings_provider.dart';
 import 'package:chessever2/providers/board_settings_provider_new.dart';
+import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/board_customization_utils.dart';
@@ -453,6 +455,12 @@ class _ChessBoardSettingsPageState
               ),
             ),
 
+            // Auto Pin Section
+            SizedBox(height: 24.h),
+            _SectionLabel(title: 'Auto Pin'),
+            SizedBox(height: 12.h),
+            _buildAutoPinSection(),
+
             // Board Settings Section
             SizedBox(height: 24.h),
             _SectionLabel(title: 'Board Settings'),
@@ -637,6 +645,100 @@ class _ChessBoardSettingsPageState
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildAutoPinSection() {
+    final autoPinAsync = ref.watch(autoPinPreferencesProvider);
+    final prefs = autoPinAsync.valueOrNull ?? AutoPinPreferences.defaults;
+    final notifier = ref.read(autoPinPreferencesProvider.notifier);
+
+    return Column(
+      children: [
+        _SettingCard(
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Favorite Players',
+                      style: AppTypography.textMdMedium.copyWith(
+                        color: kWhiteColor,
+                        fontSize: 13.f,
+                      ),
+                    ),
+                    SizedBox(height: 4.h),
+                    Text(
+                      'Automatically pin games of your favorite players.',
+                      style: AppTypography.textSmRegular.copyWith(
+                        color: kWhiteColor70,
+                        fontSize: 11.f,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch.adaptive(
+                value: prefs.favoritePlayersAutoPinEnabled,
+                thumbColor: WidgetStatePropertyAll(kPrimaryColor),
+                trackColor: WidgetStateProperty.resolveWith(
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : kDividerColor.withValues(alpha: 0.5),
+                ),
+                onChanged: (value) {
+                  _trackPersist(notifier.setFavoritePlayersAutoPin(value));
+                },
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 18.h),
+        _SettingCard(
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Countrymen',
+                      style: AppTypography.textMdMedium.copyWith(
+                        color: kWhiteColor,
+                        fontSize: 13.f,
+                      ),
+                    ),
+                    SizedBox(height: 4.h),
+                    Text(
+                      'Automatically pin games of players from your country.',
+                      style: AppTypography.textSmRegular.copyWith(
+                        color: kWhiteColor70,
+                        fontSize: 11.f,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch.adaptive(
+                value: prefs.countrymenAutoPinEnabled,
+                thumbColor: WidgetStatePropertyAll(kPrimaryColor),
+                trackColor: WidgetStateProperty.resolveWith(
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : kDividerColor.withValues(alpha: 0.5),
+                ),
+                onChanged: (value) {
+                  _trackPersist(notifier.setCountrymenAutoPin(value));
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
@@ -85,7 +85,8 @@ class _AutoPinLogController {
                         countryCode,
                       );
                 })
-                .map((e) => e.gameId);
+                .map((e) => e.gameId)
+                .toList();
 
         // Skip if every game matches (entire field is same country)
         if (countryGames.length < gamesList.length) {

--- a/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
@@ -36,7 +36,7 @@ class _AutoPinLogController {
     }
 
     final prefs =
-        ref.read(autoPinPreferencesProvider).valueOrNull ??
+        await ref.read(autoPinPreferencesProvider.future) ??
         AutoPinPreferences.defaults;
 
     if (!prefs.favoritePlayersAutoPinEnabled &&

--- a/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
+import 'package:chessever2/providers/auth_state_provider.dart';
+import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
 import 'package:chessever2/providers/country_dropdown_provider.dart';
+import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
 import 'package:chessever2/repository/sqlite/app_database.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_provider.dart';
@@ -15,25 +18,39 @@ final autoPinLogicProvider = AutoDisposeProvider<_AutoPinLogController>(
   (ref) => _AutoPinLogController(ref),
 );
 
-const _autoPinFavKey = 'autoPinFavGames';
-
 class _AutoPinLogController {
   _AutoPinLogController(this.ref);
 
   final Ref ref;
-  String _getTournamentKey(String tourId) => '${_autoPinFavKey}_$tourId';
+
+  AutoPinPreferencesRepository get _repo =>
+      AutoPinPreferencesRepository(AppDatabase.instance);
+
+  String? get _userId => ref.read(currentUserProvider)?.id;
 
   Future<(bool, List<String>)> getAutoPinnedGames(String tourId) async {
-    final shouldHidePin = await _getHidePin(tourId);
+    final shouldHidePin =
+        await _repo.getTournamentAutoPinDisabled(tourId, _userId);
     if (shouldHidePin) {
       return (true, <String>[]);
-    } else {
-      final countryCode = await _resolveCountryCode();
+    }
+
+    final prefs =
+        ref.read(autoPinPreferencesProvider).valueOrNull ??
+        AutoPinPreferences.defaults;
+
+    if (!prefs.favoritePlayersAutoPinEnabled &&
+        !prefs.countrymenAutoPinEnabled) {
+      return (false, <String>[]);
+    }
+
+    final gamesList = _getAllGamesIncludingStages(tourId);
+
+    final allPinIds = <String>{};
+
+    // Favorite players auto-pin
+    if (prefs.favoritePlayersAutoPinEnabled) {
       final players = await ref.read(tournamentFavoritePlayersProvider.future);
-
-      // Collect games from ALL stages in multi-stage knockouts
-      final gamesList = _getAllGamesIncludingStages(tourId);
-
       final favPlayers =
           gamesList
               .where((games) {
@@ -48,38 +65,36 @@ class _AutoPinLogController {
                           games.blackPlayer.federation == player.countryCode,
                     );
               })
-              .map((e) => e.gameId)
-              .toList();
-
-      if (countryCode == null || countryCode.isEmpty) {
-        print(
-          '⚠️ Auto-pin: Country unavailable, falling back to favorites only',
-        );
-        return (false, [...favPlayers]);
-      }
-
-      final filteredGames =
-          gamesList
-              .where((game) {
-                // Use the matcher to compare regardless of ISO format
-                return CountryCodeMatcher.matches(
-                      game.whitePlayer.countryCode,
-                      countryCode,
-                    ) ||
-                    CountryCodeMatcher.matches(
-                      game.blackPlayer.countryCode,
-                      countryCode,
-                    );
-              })
-              .map((e) => e.gameId)
-              .toList();
-
-      if (filteredGames.length == gamesList.length) {
-        return (false, [...favPlayers]);
-      }
-
-      return (false, [...favPlayers, ...filteredGames]);
+              .map((e) => e.gameId);
+      allPinIds.addAll(favPlayers);
     }
+
+    // Countrymen auto-pin
+    if (prefs.countrymenAutoPinEnabled) {
+      final countryCode = await _resolveCountryCode();
+      if (countryCode != null && countryCode.isNotEmpty) {
+        final countryGames =
+            gamesList
+                .where((game) {
+                  return CountryCodeMatcher.matches(
+                        game.whitePlayer.countryCode,
+                        countryCode,
+                      ) ||
+                      CountryCodeMatcher.matches(
+                        game.blackPlayer.countryCode,
+                        countryCode,
+                      );
+                })
+                .map((e) => e.gameId);
+
+        // Skip if every game matches (entire field is same country)
+        if (countryGames.length < gamesList.length) {
+          allPinIds.addAll(countryGames);
+        }
+      }
+    }
+
+    return (false, allPinIds.toList());
   }
 
   Future<String?> _resolveCountryCode() async {
@@ -89,7 +104,6 @@ class _AutoPinLogController {
     final cachedCountryCode = await db.getString('selected_country_code');
 
     if (cachedCountryCode != null && cachedCountryCode.isNotEmpty) {
-      // Use cached country code (works immediately)
       print('🎯 Auto-pin: Using cached country code: $cachedCountryCode');
       return cachedCountryCode;
     }
@@ -198,26 +212,11 @@ class _AutoPinLogController {
   }
 
   Future<void> enableAutoPin(String tourId) async {
-    await _shouldHidePin(tourId: tourId, shouldHide: false);
+    await _repo.setTournamentAutoPinDisabled(tourId, false, _userId);
   }
 
   Future<void> disableAutoPin(String tourId) async {
-    await _shouldHidePin(tourId: tourId, shouldHide: true);
-  }
-
-  Future<void> _shouldHidePin({
-    required String tourId,
-    required bool shouldHide,
-  }) async {
-    final key = _getTournamentKey(tourId);
-    final db = AppDatabase.instance;
-    await db.setBool(key, shouldHide);
-  }
-
-  Future<bool> _getHidePin(String tourId) async {
-    final key = _getTournamentKey(tourId);
-    final db = AppDatabase.instance;
-    return await db.getBool(key) ?? false;
+    await _repo.setTournamentAutoPinDisabled(tourId, true, _userId);
   }
 }
 

--- a/lib/screens/tour_detail/games_tour/providers/games_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_pin_provider.dart
@@ -1,4 +1,6 @@
+import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
 import 'package:chessever2/providers/country_dropdown_provider.dart';
+import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
 import 'package:chessever2/repository/local_storage/tournament/games/pin_games_local_storage.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
 import 'package:chessever2/screens/standings/player_standing_model.dart';
@@ -66,6 +68,7 @@ class _GamesPinController extends StateNotifier<GamesPinState> {
     _listenToKnockoutStages();
     _listenToCountrySelection();
     _listenToPrimaryGames();
+    _listenToAutoPinPreferences();
   }
 
   final Ref ref;
@@ -177,6 +180,22 @@ class _GamesPinController extends StateNotifier<GamesPinState> {
 
       computeAutoPins();
     });
+  }
+
+  void _listenToAutoPinPreferences() {
+    ref.listen<AsyncValue<AutoPinPreferences>>(
+      autoPinPreferencesProvider,
+      (previous, next) {
+        final prev = previous?.valueOrNull;
+        final curr = next.valueOrNull;
+        if (curr == null) return;
+        if (prev?.favoritePlayersAutoPinEnabled !=
+                curr.favoritePlayersAutoPinEnabled ||
+            prev?.countrymenAutoPinEnabled != curr.countrymenAutoPinEnabled) {
+          computeAutoPins();
+        }
+      },
+    );
   }
 
   bool _didGameListChange(


### PR DESCRIPTION
Introduce two global auto-pin toggles (Favorite Players: on by default, 
Countrymen: off by default) stored in user-scoped SQLite cache_store. 
Move per-tournament auto-pin disable to user-scoped storage with legacy key compatibility fallback. 
Add Auto Pin section to Board Settings page.