### PR TITLE
Migrate legacy 5s engine thinking time to unlimited

### DIFF
--- a/DYNAMIC_ENGINE_TEST_GUIDE.md
+++ b/DYNAMIC_ENGINE_TEST_GUIDE.md
@@ -26,7 +26,7 @@ When you change engine settings, the system should:
 
 ```
 🔄 ═══ ENGINE SETTINGS CHANGED ═══
-   Previous: searchTime=5s
+   Previous: searchTime=∞
    New: searchTime=10s
    SearchDuration: 10s
    MaxDepth: 30

--- a/lib/providers/engine_settings_provider.dart
+++ b/lib/providers/engine_settings_provider.dart
@@ -378,6 +378,8 @@ final engineSettingsProviderNew =
 
 class EngineSettingsNotifierNew extends AsyncNotifier<EngineSettings> {
   static const String _cacheKey = 'cached_engine_settings';
+  static const String _legacySearchTimeMigrationKey =
+      'legacy_search_time_migrated_v1';
 
   SupabaseClient get _supabase => Supabase.instance.client;
 
@@ -429,11 +431,15 @@ class EngineSettingsNotifierNew extends AsyncNotifier<EngineSettings> {
         maxArrowsOnBoard: model.maxArrowsOnBoard,
       );
 
+      // One-time legacy migration (search_time_index 0 → 5)
+      final migrated =
+          await _migrateLegacySearchTimeIfNeeded(settings, userId);
+
       // Cache locally
-      await _cacheSettings(settings);
+      await _cacheSettings(migrated);
 
       debugPrint('[EngineSettings] Fetched settings from Supabase');
-      return settings;
+      return migrated;
     } catch (e, st) {
       debugPrint('[EngineSettings] Error fetching from Supabase: $e');
       debugPrint('[EngineSettings] Stack: $st');
@@ -663,8 +669,8 @@ class EngineSettingsNotifierNew extends AsyncNotifier<EngineSettings> {
         showDepthOverlay: map['showDepthOverlay'] as bool? ?? true,
         showPvArrows: map['showPvArrows'] as bool? ?? true,
         showEngineAnalysis: map['showEngineAnalysis'] as bool? ?? true,
-        searchTimeIndex: map['searchTimeIndex'] as int? ?? 2,
-        principalVariationIndex: map['principalVariationIndex'] as int? ?? 2,
+        searchTimeIndex: map['searchTimeIndex'] as int? ?? 5,
+        principalVariationIndex: map['principalVariationIndex'] as int? ?? 4,
         maxArrowsOnBoard: map['maxArrowsOnBoard'] as int? ?? 2,
       );
       debugPrint('[EngineSettings] Loaded settings from cache');
@@ -673,6 +679,35 @@ class EngineSettingsNotifierNew extends AsyncNotifier<EngineSettings> {
       debugPrint('[EngineSettings] Error getting cached settings: $e');
       return const EngineSettings();
     }
+  }
+
+  /// One-time migration: if the user has search_time_index=0 and hasn't been
+  /// migrated yet, rewrite to 5 (unlimited). Sets a per-user flag in SQLite
+  /// so later manual choices of 5s are preserved.
+  Future<EngineSettings> _migrateLegacySearchTimeIfNeeded(
+    EngineSettings settings,
+    String userId,
+  ) async {
+    final db = AppDatabase.instance;
+    final flagKey = '${_legacySearchTimeMigrationKey}_$userId';
+    final alreadyMigrated = await db.getBool(flagKey) ?? false;
+
+    if (alreadyMigrated) return settings;
+
+    if (settings.searchTimeIndex == 0) {
+      final migrated = settings.copyWith(searchTimeIndex: 5);
+      debugPrint(
+        '[EngineSettings] Migrating legacy searchTimeIndex 0 → 5',
+      );
+      await _saveToSupabase(migrated, userId);
+      // Flag set ONLY after Supabase write succeeds — retry on next load if it fails
+      await db.setBool(flagKey, true);
+      return migrated;
+    }
+
+    // Non-zero value, no rewrite needed — just set the flag
+    await db.setBool(flagKey, true);
+    return settings;
   }
 
   /// Clear cache (useful on sign out)


### PR DESCRIPTION
Add a one-time per-user migration that rewrites legacy saved search_time_index=0 values to unlimited while preserving future user-selected 5s values, and align cached engine fallback defaults with the current unlimited default.