### PR TITLE
Fix live game board opening flash by seeding initial position from FEN

### DIFF
--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -918,7 +918,7 @@ class ChessBoardScreenNotifierNew
           isPreviewActive
               ? (currentState?.analysisState.currentMoveIndex ?? lastMoveIndex)
               : shouldForceLatestPosition
-              ? ((isLiveGame || startAtLastMove) ? lastMoveIndex : -1)
+              ? lastMoveIndex
               : (wasViewingLastMove
                   ? lastMoveIndex // Jump to new last move if user was already viewing last
                   : currentState?.analysisState.currentMoveIndex ??

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -186,6 +186,10 @@ class ChessBoardScreenNotifierNew
       );
     }
 
+    // For live games, seed the board with the current live FEN so it renders
+    // the actual position immediately instead of flashing Chess.initial.
+    final liveFenPosition = _tryParseLiveFenPlaceholder();
+
     state = AsyncValue.data(
       ChessBoardStateNew(
         game: game,
@@ -202,6 +206,10 @@ class ChessBoardScreenNotifierNew
         variationComments: Map<String, String>.from(
           variationComments,
         ), // Restore comments
+        position: liveFenPosition,
+        analysisState: liveFenPosition != null
+            ? AnalysisBoardState(position: liveFenPosition)
+            : const AnalysisBoardState(),
       ),
     );
     parseMoves();
@@ -6107,6 +6115,20 @@ class ChessBoardScreenNotifierNew
   }
 
   String _normalizeFen(String fen) => fen.split(' ').take(4).join(' ');
+
+  /// Parse the live game FEN into a display-only placeholder position.
+  /// Returns null for non-live games, missing FEN, or parse failures.
+  Position? _tryParseLiveFenPlaceholder() {
+    if (!game.gameStatus.isOngoing) return null;
+    final fen = game.fen;
+    if (fen == null || fen.trim().isEmpty) return null;
+    try {
+      final setup = Setup.parseFen(fen.trim());
+      return Chess.fromSetup(setup);
+    } catch (_) {
+      return null;
+    }
+  }
 
   /// Generate a "threat FEN" by flipping the side to move
   /// This allows analyzing what the opponent threatens on the current position

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -907,12 +907,10 @@ class ChessBoardScreenNotifierNew
           hasNewMoves && !shouldForceLatestPosition && !wasViewingLastMove;
 
       // Determine which move index to display:
-      // - For live games on initial load: show latest move
-      // - For non-live games on initial load: start from beginning (move index -1)
+      // - On initial load: always show latest move
       // - If user was viewing last move: jump to new last move
       // - If user was viewing an earlier move AND it's not initial load: stay at current position (don't jump)
       final isPreviewActive = currentState?.isPvPreviewActive == true;
-      final isLiveGame = game.gameStatus.isOngoing;
 
       final newMoveIndex =
           isPreviewActive

--- a/test/chess_board_live_fen_placeholder_test.dart
+++ b/test/chess_board_live_fen_placeholder_test.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:chessever2/providers/engine_settings_provider.dart';
+import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/repository/supabase/game/game_stream_repository.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/// A fake that satisfies the GameRepository type without touching Supabase.
+/// getGamePgn() never completes, keeping parseMoves() suspended so we can
+/// assert on the initial placeholder state.
+class _NeverResolvingGameRepository implements GameRepository {
+  @override
+  Future<String?> getGamePgn(String gameId) => Completer<String?>().future;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// GamebaseRepository whose methods return null / empty by default.
+class _FakeGamebaseRepository extends GamebaseRepository {
+  _FakeGamebaseRepository()
+      : super(Dio(), baseUrl: 'http://localhost', apiKey: 'test');
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// GameStreamRepository that returns empty streams (no Supabase Realtime).
+class _FakeGameStreamRepository extends GameStreamRepository {
+  @override
+  Stream<Map<String, dynamic>?> subscribeToGameUpdates(String gameId) =>
+      const Stream.empty();
+
+  @override
+  Stream<String?> subscribeToPgn(String gameId) => const Stream.empty();
+
+  @override
+  Stream<String?> subscribeToLastMove(String gameId) => const Stream.empty();
+
+  @override
+  Stream<String?> subscribeToFen(String gameId) => const Stream.empty();
+
+  @override
+  Stream<String?> subscribeToStatus(String gameId) => const Stream.empty();
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+GamesTourModel _dummyGame({
+  String? fen,
+  GameStatus gameStatus = GameStatus.ongoing,
+}) {
+  final player = PlayerCard(
+    name: 'Player',
+    federation: 'TR',
+    title: '',
+    rating: 0,
+    countryCode: 'TR',
+    team: null,
+  );
+  return GamesTourModel(
+    gameId: 'test-game-1',
+    whitePlayer: player,
+    blackPlayer: player,
+    whiteTimeDisplay: '--:--',
+    blackTimeDisplay: '--:--',
+    whiteClockCentiseconds: 0,
+    blackClockCentiseconds: 0,
+    gameStatus: gameStatus,
+    roundId: 'r1',
+    tourId: 't1',
+    fen: fen,
+  );
+}
+
+ProviderContainer _createContainer() {
+  return ProviderContainer(
+    overrides: [
+      engineSettingsProviderNew.overrideWith(
+        () => _FakeEngineSettingsNotifier(),
+      ),
+      gameRepositoryProvider
+          .overrideWithValue(_NeverResolvingGameRepository()),
+      gamebaseRepositoryProvider
+          .overrideWithValue(_FakeGamebaseRepository()),
+      gameStreamRepositoryProvider
+          .overrideWithValue(_FakeGameStreamRepository()),
+    ],
+  );
+}
+
+class _FakeEngineSettingsNotifier extends AsyncNotifier<EngineSettings>
+    implements EngineSettingsNotifierNew {
+  @override
+  Future<EngineSettings> build() async => const EngineSettings();
+
+  // Stub remaining methods required by EngineSettingsNotifierNew.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('Live FEN placeholder initialization', () {
+    test('ongoing game with valid FEN seeds analysisState.position', () {
+      // Use a mid-game FEN where dartchess won't normalise away the en-passant
+      // square (no legal en-passant capture exists after 1.e4, so dartchess
+      // strips it). A Sicilian position avoids that ambiguity.
+      const fen =
+          'rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2';
+      final game = _dummyGame(fen: fen);
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final params = ChessBoardProviderParams(game: game, index: 0);
+      final stateAsync = container.read(chessBoardScreenProviderNew(params));
+      final state = stateAsync.value;
+
+      expect(state, isNotNull, reason: 'Initial state should be data, not loading');
+      expect(state!.isLoadingMoves, isTrue);
+
+      // The placeholder position should match the FEN we provided.
+      expect(state.position, isNotNull);
+      expect(state.position!.fen, fen);
+
+      // analysisState should also be seeded.
+      expect(state.analysisState.position.fen, fen);
+    });
+
+    test('ongoing game with null FEN falls back to Chess.initial', () {
+      final game = _dummyGame(fen: null);
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final params = ChessBoardProviderParams(game: game, index: 0);
+      final state =
+          container.read(chessBoardScreenProviderNew(params)).value;
+
+      expect(state, isNotNull);
+      expect(state!.position, isNull);
+      expect(state.analysisState.position, Chess.initial);
+    });
+
+    test('ongoing game with blank FEN falls back to Chess.initial', () {
+      final game = _dummyGame(fen: '   ');
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final params = ChessBoardProviderParams(game: game, index: 0);
+      final state =
+          container.read(chessBoardScreenProviderNew(params)).value;
+
+      expect(state, isNotNull);
+      expect(state!.position, isNull);
+      expect(state.analysisState.position, Chess.initial);
+    });
+
+    test('finished game with valid FEN does not seed placeholder', () {
+      const fen =
+          'rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2';
+      final game = _dummyGame(fen: fen, gameStatus: GameStatus.whiteWins);
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final params = ChessBoardProviderParams(game: game, index: 0);
+      final state =
+          container.read(chessBoardScreenProviderNew(params)).value;
+
+      expect(state, isNotNull);
+      expect(state!.position, isNull);
+      expect(state.analysisState.position, Chess.initial);
+    });
+
+    test('ongoing game with invalid FEN falls back to Chess.initial', () {
+      final game = _dummyGame(fen: 'not-a-valid-fen');
+      final container = _createContainer();
+      addTearDown(container.dispose);
+
+      final params = ChessBoardProviderParams(game: game, index: 0);
+      final state =
+          container.read(chessBoardScreenProviderNew(params)).value;
+
+      expect(state, isNotNull);
+      expect(state!.position, isNull);
+      expect(state.analysisState.position, Chess.initial);
+    });
+  });
+}


### PR DESCRIPTION
Seed the live chessboard’s initial render from game.fen instead of the default starting position. This removes the brief flash to Chess.initial when opening ongoing games, while keeping PGN parsing as the source of truth for move history, navigation, and live auto-follow behavior.