### PR TITLE
pipeline GIF export and reduce share-card memory usage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -236,7 +236,9 @@ Future<void> main() async {
         ).timeout(
           const Duration(seconds: 5),
           onTimeout: () {
-            _e2eStartupLog('SentryFlutter.init timed out, running app directly');
+            _e2eStartupLog(
+              'SentryFlutter.init timed out, running app directly',
+            );
             debugPrint(
               '⚠️ SentryFlutter.init() timed out - starting app anyway',
             );

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -10502,6 +10502,7 @@ class _ShareGameScreen extends ConsumerWidget {
           state.analysisState.movePointer.length == 1,
       gameId: game.gameId, // Pass game ID for correct eval display
       onClose: () => Navigator.of(context).pop(),
+      startingFen: state.analysisState.startingPosition?.fen,
     );
   }
 }

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -229,10 +229,8 @@ Future<void> _showShareOverlay(
       background: baseColorScheme.background,
       whiteCoordBackground: baseColorScheme.whiteCoordBackground,
       blackCoordBackground: baseColorScheme.blackCoordBackground,
-      // Hide all highlights for clean screenshots
-      lastMove: HighlightDetails(
-        solidColor: baseColorScheme.lightSquare.withValues(alpha: 0),
-      ),
+      // Show last-move highlights in screenshots and GIF frames
+      lastMove: baseColorScheme.lastMove,
       selected: HighlightDetails(
         solidColor: baseColorScheme.lightSquare.withValues(alpha: 0),
       ),

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -98,7 +98,7 @@ Future<void> _showShareOverlay(
   GamesTourModel game,
 ) async {
   // ---------------------------------------------------------------------------
-  // Resolve PGN move history (3-tier fallback)
+  // Resolve PGN move history (3-tier fallback, parse-and-accept)
   // ---------------------------------------------------------------------------
   String resolvedPgn = '';
   List<String> moveSans = const [];
@@ -106,55 +106,84 @@ Future<void> _showShareOverlay(
   int currentMoveIndex = -1;
   String? startingFen;
 
+  // Collect candidate PGNs from all tiers as (source, pgn) pairs.
+  // Each tier is wrapped in try/catch so a network failure doesn't block later tiers.
+  final candidates = <(String source, String pgn)>[];
+
   // Tier 1: game.pgn (already available on the model)
   try {
     if (pgnHasMoves(game.pgn)) {
-      resolvedPgn = game.pgn!;
+      candidates.add(('game.pgn', game.pgn!.trim()));
     }
   } catch (_) {}
 
   // Tier 2: Supabase getGamePgn
-  if (resolvedPgn.isEmpty) {
-    try {
-      final fetched =
-          await ref.read(gameRepositoryProvider).getGamePgn(game.gameId);
-      if (pgnHasMoves(fetched)) {
-        resolvedPgn = fetched!;
-      }
-    } catch (_) {}
-  }
+  try {
+    final fetched =
+        await ref.read(gameRepositoryProvider).getGamePgn(game.gameId);
+    if (pgnHasMoves(fetched)) {
+      candidates.add(('Supabase', fetched!.trim()));
+    }
+  } catch (_) {}
 
-  // Tier 3: Gamebase getGameWithPgn → buildPgnFromGamebaseData
-  if (resolvedPgn.isEmpty) {
-    try {
-      final gameWithPgn =
-          await ref.read(gamebaseRepositoryProvider).getGameWithPgn(game.gameId);
-      if (gameWithPgn != null) {
+  // Tier 3: Gamebase getGameWithPgn — prefer .pgn, then buildPgnFromGamebaseData
+  try {
+    final gameWithPgn =
+        await ref.read(gamebaseRepositoryProvider).getGameWithPgn(game.gameId);
+    if (gameWithPgn != null) {
+      if (pgnHasMoves(gameWithPgn.pgn)) {
+        candidates.add(('Gamebase.pgn', gameWithPgn.pgn!.trim()));
+      } else {
         final built = buildPgnFromGamebaseData(gameWithPgn.data);
         if (pgnHasMoves(built)) {
-          resolvedPgn = built!;
+          candidates.add(('Gamebase.data', built!.trim()));
         }
       }
-    } catch (_) {}
-  }
+    }
+  } catch (_) {}
 
-  // Parse PGN into SANs, moveTimes, and startingPos (offloaded to isolate)
-  if (resolvedPgn.isNotEmpty) {
-    try {
-      final parseResult = await compute(parsePgnWorker, resolvedPgn);
-      moveSans = parseResult.moveSans;
-      moveTimes = parseResult.moveTimes;
-      currentMoveIndex = moveSans.isNotEmpty ? moveSans.length - 1 : -1;
-      // Only set startingFen if it's a non-standard start position
-      final startFen = parseResult.startingPos.fen;
-      if (startFen !=
-          'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1') {
-        startingFen = startFen;
-      }
-    } catch (_) {
-      // Parse failed — overlay opens but GIF will be unavailable
+  // Deduplicate by PGN content so the same string isn't parsed twice
+  final seen = <String>{};
+  final uniqueCandidates = <(String, String)>[];
+  for (final c in candidates) {
+    if (seen.add(c.$2)) {
+      uniqueCandidates.add(c);
     }
   }
+
+  // Parse-and-accept: accept the first candidate that yields non-empty moveSans
+  for (final (source, pgn) in uniqueCandidates) {
+    try {
+      final parseResult = await compute(parsePgnWorker, pgn);
+      if (parseResult.moveSans.isNotEmpty) {
+        resolvedPgn = pgn;
+        moveSans = parseResult.moveSans;
+        moveTimes = parseResult.moveTimes;
+        currentMoveIndex = moveSans.length - 1;
+        // Only set startingFen if it's a non-standard start position
+        final startFen = parseResult.startingPos.fen;
+        if (startFen !=
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1') {
+          startingFen = startFen;
+        }
+        if (kDebugMode) {
+          debugPrint('GIF share: accepted PGN from $source '
+              '(${moveSans.length} moves)');
+        }
+        break;
+      } else {
+        if (kDebugMode) {
+          debugPrint('GIF share: $source PGN parsed but yielded 0 moves');
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('GIF share: $source PGN parse failed: $e');
+      }
+    }
+  }
+  // On total failure: all remain empty/default — overlay opens but GIF
+  // is unavailable. resolvedPgn stays '' (non-null String).
 
   // Guard: widget may have been disposed during async gap
   if (!context.mounted) return;

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -3,6 +3,8 @@ import 'package:chessever2/providers/board_settings_provider_new.dart';
 import 'package:chessever2/providers/engine_settings_provider.dart';
 import 'package:chessever2/providers/live_game_subscription_provider.dart';
 import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new_worker.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/chessboard/widgets/evaluation_bar_widget.dart';
 import 'package:chessever2/screens/chessboard/widgets/player_first_row_detail_widget.dart';
@@ -14,6 +16,7 @@ import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/string_utils.dart';
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -85,12 +88,80 @@ bool _shouldShowEvalBar(WidgetRef ref) {
       (settings?.showEngineGauge ?? true);
 }
 
-/// Shows the share overlay for a game from the grid/list view
-void _showShareOverlay(
+/// Shows the share overlay for a game from the grid/list view.
+///
+/// Resolves PGN data via a 3-tier fallback (local → Supabase → Gamebase)
+/// before opening the overlay, so that GIF export has move history.
+Future<void> _showShareOverlay(
   BuildContext context,
   WidgetRef ref,
   GamesTourModel game,
-) {
+) async {
+  // ---------------------------------------------------------------------------
+  // Resolve PGN move history (3-tier fallback)
+  // ---------------------------------------------------------------------------
+  String resolvedPgn = '';
+  List<String> moveSans = const [];
+  List<String> moveTimes = const [];
+  int currentMoveIndex = -1;
+  String? startingFen;
+
+  // Tier 1: game.pgn (already available on the model)
+  try {
+    if (pgnHasMoves(game.pgn)) {
+      resolvedPgn = game.pgn!;
+    }
+  } catch (_) {}
+
+  // Tier 2: Supabase getGamePgn
+  if (resolvedPgn.isEmpty) {
+    try {
+      final fetched =
+          await ref.read(gameRepositoryProvider).getGamePgn(game.gameId);
+      if (pgnHasMoves(fetched)) {
+        resolvedPgn = fetched!;
+      }
+    } catch (_) {}
+  }
+
+  // Tier 3: Gamebase getGameWithPgn → buildPgnFromGamebaseData
+  if (resolvedPgn.isEmpty) {
+    try {
+      final gameWithPgn =
+          await ref.read(gamebaseRepositoryProvider).getGameWithPgn(game.gameId);
+      if (gameWithPgn != null) {
+        final built = buildPgnFromGamebaseData(gameWithPgn.data);
+        if (pgnHasMoves(built)) {
+          resolvedPgn = built!;
+        }
+      }
+    } catch (_) {}
+  }
+
+  // Parse PGN into SANs, moveTimes, and startingPos (offloaded to isolate)
+  if (resolvedPgn.isNotEmpty) {
+    try {
+      final parseResult = await compute(parsePgnWorker, resolvedPgn);
+      moveSans = parseResult.moveSans;
+      moveTimes = parseResult.moveTimes;
+      currentMoveIndex = moveSans.isNotEmpty ? moveSans.length - 1 : -1;
+      // Only set startingFen if it's a non-standard start position
+      final startFen = parseResult.startingPos.fen;
+      if (startFen !=
+          'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1') {
+        startingFen = startFen;
+      }
+    } catch (_) {
+      // Parse failed — overlay opens but GIF will be unavailable
+    }
+  }
+
+  // Guard: widget may have been disposed during async gap
+  if (!context.mounted) return;
+
+  // ---------------------------------------------------------------------------
+  // Build board settings and open overlay
+  // ---------------------------------------------------------------------------
   final boardSettingsAsync = ref.read(boardSettingsProviderNew);
   final boardSettingsNew =
       boardSettingsAsync.valueOrNull ?? const BoardSettingsNew();
@@ -134,8 +205,6 @@ void _showShareOverlay(
           ? StringUtils.formatRoundLabel(game.roundSlug)
           : null;
 
-  // For grid/list view, we show the current position (latest move)
-  // We don't have full move history, so moveSans will be empty
   final positionFen = _resolveFen(game.fen);
   final lastMove = _uciToMove(game.lastMove ?? '');
 
@@ -149,8 +218,9 @@ void _showShareOverlay(
             boardSettings: chessboardSettings,
             positionFen: positionFen,
             lastMove: lastMove,
-            pgn: '',
-            moveSans: const [], // No move history available from grid view
+            pgn: resolvedPgn,
+            moveSans: moveSans,
+            moveTimes: moveTimes,
             whitePlayerName: game.whitePlayer.name,
             blackPlayerName: game.blackPlayer.name,
             whitePlayerCountry: game.whitePlayer.federation,
@@ -163,7 +233,7 @@ void _showShareOverlay(
             blackPlayerClock: game.blackTimeDisplay,
             tournamentName: tournamentName,
             roundInfo: roundInfo,
-            currentMoveIndex: -1, // No specific move index
+            currentMoveIndex: currentMoveIndex,
             evaluation: null, // No evaluation available from grid view
             mate: 0,
             isFlipped: false,
@@ -173,6 +243,7 @@ void _showShareOverlay(
                 game.gameStatus != GameStatus.unknown,
             onClose: () => Navigator.of(context).pop(),
             gameId: game.gameId,
+            startingFen: startingFen,
           ),
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
         return FadeTransition(opacity: animation, child: child);

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -111,36 +111,54 @@ Future<void> _showShareOverlay(
   final candidates = <(String source, String pgn)>[];
 
   // Tier 1: game.pgn (already available on the model)
+  debugPrint('GIF share [${game.gameId}]: Tier 1 game.pgn '
+      '${game.pgn == null ? "null" : "(${game.pgn!.length} chars)"} '
+      'hasMoves=${pgnHasMoves(game.pgn)}');
   try {
     if (pgnHasMoves(game.pgn)) {
       candidates.add(('game.pgn', game.pgn!.trim()));
     }
-  } catch (_) {}
+  } catch (e) {
+    debugPrint('GIF share [${game.gameId}]: Tier 1 failed: $e');
+  }
 
   // Tier 2: Supabase getGamePgn
   try {
     final fetched =
         await ref.read(gameRepositoryProvider).getGamePgn(game.gameId);
+    debugPrint('GIF share [${game.gameId}]: Tier 2 Supabase '
+        '${fetched == null ? "null" : "(${fetched.length} chars)"} '
+        'hasMoves=${pgnHasMoves(fetched)}');
     if (pgnHasMoves(fetched)) {
       candidates.add(('Supabase', fetched!.trim()));
     }
-  } catch (_) {}
+  } catch (e) {
+    debugPrint('GIF share [${game.gameId}]: Tier 2 failed: $e');
+  }
 
-  // Tier 3: Gamebase getGameWithPgn — prefer .pgn, then buildPgnFromGamebaseData
-  try {
-    final gameWithPgn =
-        await ref.read(gamebaseRepositoryProvider).getGameWithPgn(game.gameId);
-    if (gameWithPgn != null) {
-      if (pgnHasMoves(gameWithPgn.pgn)) {
-        candidates.add(('Gamebase.pgn', gameWithPgn.pgn!.trim()));
-      } else {
-        final built = buildPgnFromGamebaseData(gameWithPgn.data);
-        if (pgnHasMoves(built)) {
-          candidates.add(('Gamebase.data', built!.trim()));
+  // Tier 3: Gamebase getGameWithPgn — only for Gamebase-sourced games
+  // Non-Gamebase IDs (e.g. broadcast IDs like mrqvQ9VS) produce HTTP 400.
+  if (_isGamebasePreviewGame(game)) {
+    debugPrint('GIF share [${game.gameId}]: Tier 3 Gamebase attempted');
+    try {
+      final gameWithPgn =
+          await ref.read(gamebaseRepositoryProvider).getGameWithPgn(game.gameId);
+      if (gameWithPgn != null) {
+        if (pgnHasMoves(gameWithPgn.pgn)) {
+          candidates.add(('Gamebase.pgn', gameWithPgn.pgn!.trim()));
+        } else {
+          final built = buildPgnFromGamebaseData(gameWithPgn.data);
+          if (pgnHasMoves(built)) {
+            candidates.add(('Gamebase.data', built!.trim()));
+          }
         }
       }
+    } catch (e) {
+      debugPrint('GIF share [${game.gameId}]: Tier 3 failed: $e');
     }
-  } catch (_) {}
+  } else {
+    debugPrint('GIF share [${game.gameId}]: Tier 3 skipped (not gamebase)');
+  }
 
   // Deduplicate by PGN content so the same string isn't parsed twice
   final seen = <String>{};
@@ -150,6 +168,9 @@ Future<void> _showShareOverlay(
       uniqueCandidates.add(c);
     }
   }
+
+  debugPrint('GIF share [${game.gameId}]: ${uniqueCandidates.length} '
+      'candidate(s) after dedup');
 
   // Parse-and-accept: accept the first candidate that yields non-empty moveSans
   for (final (source, pgn) in uniqueCandidates) {
@@ -166,22 +187,20 @@ Future<void> _showShareOverlay(
             'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1') {
           startingFen = startFen;
         }
-        if (kDebugMode) {
-          debugPrint('GIF share: accepted PGN from $source '
-              '(${moveSans.length} moves)');
-        }
+        debugPrint('GIF share [${game.gameId}]: accepted PGN from $source '
+            '(${moveSans.length} moves)');
         break;
       } else {
-        if (kDebugMode) {
-          debugPrint('GIF share: $source PGN parsed but yielded 0 moves');
-        }
+        debugPrint('GIF share [${game.gameId}]: $source PGN parsed '
+            'but yielded 0 moves');
       }
     } catch (e) {
-      if (kDebugMode) {
-        debugPrint('GIF share: $source PGN parse failed: $e');
-      }
+      debugPrint('GIF share [${game.gameId}]: $source PGN parse failed: $e');
     }
   }
+
+  debugPrint('GIF share [${game.gameId}]: '
+      '${moveSans.isNotEmpty ? "resolved ${moveSans.length} moves" : "NO MOVES RESOLVED"}');
   // On total failure: all remain empty/default — overlay opens but GIF
   // is unavailable. resolvedPgn stays '' (non-null String).
 

--- a/lib/screens/chessboard/widgets/gif_export_worker.dart
+++ b/lib/screens/chessboard/widgets/gif_export_worker.dart
@@ -138,9 +138,7 @@ List<int> sampleFrameIndices({
   must.add(currentMoveIndex);
 
   // Include up to 8 moves before current
-  for (int i = currentMoveIndex - 1;
-      i >= 0 && i > currentMoveIndex - 9;
-      i--) {
+  for (int i = currentMoveIndex - 1; i >= 0 && i > currentMoveIndex - 9; i--) {
     must.add(i);
   }
 
@@ -228,9 +226,7 @@ void gifEncoderWorker(SendPort mainSendPort) {
         gif.addFrame(image, duration: message.durationCs);
         mainSendPort.send(GifWorkerFrameAccepted(message.frameIndex));
       } catch (e) {
-        mainSendPort.send(
-          GifWorkerError('Frame ${message.frameIndex}: $e'),
-        );
+        mainSendPort.send(GifWorkerError('Frame ${message.frameIndex}: $e'));
       }
     } else if (message is GifWorkerFinish) {
       try {

--- a/lib/screens/chessboard/widgets/gif_export_worker.dart
+++ b/lib/screens/chessboard/widgets/gif_export_worker.dart
@@ -68,7 +68,8 @@ class GifWorkerFrameAccepted extends GifWorkerResponse {
 }
 
 class GifWorkerDone extends GifWorkerResponse {
-  final Uint8List gifBytes;
+  /// Zero-copy transfer of the finished GIF bytes.
+  final TransferableTypedData gifBytes;
   GifWorkerDone(this.gifBytes);
 }
 
@@ -239,7 +240,9 @@ void gifEncoderWorker(SendPort mainSendPort) {
             GifWorkerError('GifEncoder.finish() returned null/empty'),
           );
         } else {
-          mainSendPort.send(GifWorkerDone(result));
+          mainSendPort.send(
+            GifWorkerDone(TransferableTypedData.fromList([result])),
+          );
         }
       } catch (e) {
         mainSendPort.send(GifWorkerError('Finish error: $e'));

--- a/lib/screens/chessboard/widgets/gif_export_worker.dart
+++ b/lib/screens/chessboard/widgets/gif_export_worker.dart
@@ -1,0 +1,292 @@
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+// ---------------------------------------------------------------------------
+// Export profile
+// ---------------------------------------------------------------------------
+
+/// Describes which frames to capture and at what quality.
+class GifExportProfile {
+  /// Device-pixel ratio for rasterization.
+  final double pixelRatio;
+
+  /// Move indices (0-based into the truncated move list) to capture.
+  final List<int> frameIndices;
+
+  /// Pre-computed durations in centiseconds.
+  /// Length = frameIndices.length + 1 (index 0 = initial position frame).
+  final List<int> frameDurations;
+
+  const GifExportProfile({
+    required this.pixelRatio,
+    required this.frameIndices,
+    required this.frameDurations,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Worker message protocol
+// ---------------------------------------------------------------------------
+
+/// Commands sent from the UI isolate to the encoder worker.
+sealed class GifWorkerCommand {}
+
+class GifWorkerFrameData extends GifWorkerCommand {
+  final TransferableTypedData rgba;
+  final int width;
+  final int height;
+  final int durationCs;
+  final int frameIndex; // output-frame index (0 = initial, 1..n = sampled)
+
+  GifWorkerFrameData({
+    required this.rgba,
+    required this.width,
+    required this.height,
+    required this.durationCs,
+    required this.frameIndex,
+  });
+}
+
+class GifWorkerFinish extends GifWorkerCommand {}
+
+class GifWorkerCancel extends GifWorkerCommand {}
+
+/// Responses sent from the encoder worker back to the UI isolate.
+sealed class GifWorkerResponse {}
+
+class GifWorkerReady extends GifWorkerResponse {
+  final SendPort workerSendPort;
+  GifWorkerReady(this.workerSendPort);
+}
+
+class GifWorkerFrameAccepted extends GifWorkerResponse {
+  /// Output-frame index (0 = initial, 1..n = sampled moves).
+  final int frameIndex;
+  GifWorkerFrameAccepted(this.frameIndex);
+}
+
+class GifWorkerDone extends GifWorkerResponse {
+  final Uint8List gifBytes;
+  GifWorkerDone(this.gifBytes);
+}
+
+class GifWorkerError extends GifWorkerResponse {
+  final String message;
+  GifWorkerError(this.message);
+}
+
+// ---------------------------------------------------------------------------
+// Frame planner
+// ---------------------------------------------------------------------------
+
+/// Builds an export profile for the given game length.
+///
+/// [moveCount] is the number of moves to animate (length of the truncated
+/// move list).  [currentMoveIndex] should be `moveCount - 1` (the last move
+/// in the truncated list).
+GifExportProfile planGifExport({
+  required int moveCount,
+  required int currentMoveIndex,
+}) {
+  assert(moveCount > 0);
+  assert(currentMoveIndex >= 0 && currentMoveIndex < moveCount);
+
+  late final double pixelRatio;
+  late final List<int> frameIndices;
+
+  if (moveCount <= 60) {
+    pixelRatio = 1.5;
+    frameIndices = List.generate(moveCount, (i) => i);
+  } else if (moveCount <= 100) {
+    pixelRatio = 1.25;
+    frameIndices = List.generate(moveCount, (i) => i);
+  } else {
+    pixelRatio = 1.0;
+    // 60 total output frames = 1 initial + 59 sampled moves
+    frameIndices = sampleFrameIndices(
+      totalMoves: moveCount,
+      targetMoveFrames: 59,
+      currentMoveIndex: currentMoveIndex,
+    );
+  }
+
+  final durations = _computeDurations(frameIndices);
+  return GifExportProfile(
+    pixelRatio: pixelRatio,
+    frameIndices: frameIndices,
+    frameDurations: durations,
+  );
+}
+
+/// Selects [targetMoveFrames] move indices to keep, always including move 0,
+/// [currentMoveIndex], and the previous 8 moves.  Remaining slots are filled
+/// by even sampling from earlier moves.
+List<int> sampleFrameIndices({
+  required int totalMoves,
+  required int targetMoveFrames,
+  required int currentMoveIndex,
+}) {
+  final must = <int>{};
+
+  // Always include first move
+  must.add(0);
+
+  // Always include current move (last animated position)
+  must.add(currentMoveIndex);
+
+  // Include up to 8 moves before current
+  for (int i = currentMoveIndex - 1;
+      i >= 0 && i > currentMoveIndex - 9;
+      i--) {
+    must.add(i);
+  }
+
+  // Fill remaining slots by even sampling from the gap before the
+  // must-include tail region.
+  final remaining = targetMoveFrames - must.length;
+  if (remaining > 0) {
+    final gapEnd = (currentMoveIndex - 9).clamp(0, totalMoves);
+    final candidates = <int>[];
+    for (int i = 1; i < gapEnd; i++) {
+      if (!must.contains(i)) candidates.add(i);
+    }
+
+    if (candidates.isNotEmpty) {
+      final count = remaining.clamp(0, candidates.length);
+      final step = candidates.length / count;
+      for (int i = 0; i < count; i++) {
+        must.add(candidates[(i * step).floor()]);
+      }
+    }
+  }
+
+  final sorted = must.toList()..sort();
+  return sorted;
+}
+
+/// Precomputes per-frame durations (centiseconds).
+///
+/// Returns a list of length `frameIndices.length + 1` where index 0
+/// is the initial-position frame and indices 1..n correspond to the
+/// sampled move frames.
+///
+/// Each frame holds for `80 * gap_to_next_captured` cs, except the last
+/// frame which always gets 300cs (3 s hold).
+List<int> _computeDurations(List<int> frameIndices) {
+  // Conceptual indices: initial = -1, then frameIndices[0], [1], ...
+  final allIndices = <int>[-1, ...frameIndices];
+  final durations = <int>[];
+
+  for (int i = 0; i < allIndices.length; i++) {
+    if (i == allIndices.length - 1) {
+      // Last frame: 3 second hold
+      durations.add(300);
+    } else {
+      final gap = allIndices[i + 1] - allIndices[i];
+      durations.add(80 * gap);
+    }
+  }
+
+  return durations;
+}
+
+// ---------------------------------------------------------------------------
+// Worker isolate entry point
+// ---------------------------------------------------------------------------
+
+/// Top-level function that runs in a dedicated isolate.
+///
+/// Protocol:
+/// 1. Sends [GifWorkerReady] with its [SendPort].
+/// 2. Receives [GifWorkerFrameData] messages, encodes each incrementally,
+///    and replies with [GifWorkerFrameAccepted].
+/// 3. On [GifWorkerFinish], finalises the GIF and sends [GifWorkerDone].
+/// 4. On [GifWorkerCancel], shuts down immediately.
+void gifEncoderWorker(SendPort mainSendPort) {
+  final workerPort = ReceivePort();
+
+  // Single handshake: send our port inside GifWorkerReady.
+  mainSendPort.send(GifWorkerReady(workerPort.sendPort));
+
+  final gif = img.GifEncoder(delay: 80);
+
+  workerPort.listen((message) {
+    if (message is GifWorkerFrameData) {
+      try {
+        final rgba = message.rgba.materialize().asUint8List();
+        final image = img.Image.fromBytes(
+          width: message.width,
+          height: message.height,
+          bytes: rgba.buffer,
+          numChannels: 4,
+          order: img.ChannelOrder.rgba,
+        );
+
+        gif.addFrame(image, duration: message.durationCs);
+        mainSendPort.send(GifWorkerFrameAccepted(message.frameIndex));
+      } catch (e) {
+        mainSendPort.send(
+          GifWorkerError('Frame ${message.frameIndex}: $e'),
+        );
+      }
+    } else if (message is GifWorkerFinish) {
+      try {
+        final result = gif.finish();
+        if (result == null || result.isEmpty) {
+          mainSendPort.send(
+            GifWorkerError('GifEncoder.finish() returned null/empty'),
+          );
+        } else {
+          mainSendPort.send(GifWorkerDone(result));
+        }
+      } catch (e) {
+        mainSendPort.send(GifWorkerError('Finish error: $e'));
+      }
+      workerPort.close();
+    } else if (message is GifWorkerCancel) {
+      workerPort.close();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous fallback encoder
+// ---------------------------------------------------------------------------
+
+/// Encodes a GIF synchronously on the calling isolate.
+///
+/// Used when [Isolate.spawn] fails (common on some iOS devices).
+/// Uses [img.Image.fromBytes] for bulk pixel copy instead of per-pixel loops.
+Uint8List? encodeGifFallback({
+  required List<Uint8List> rgbaFrames,
+  required List<int> widths,
+  required List<int> heights,
+  required List<int> durationsCs,
+}) {
+  if (rgbaFrames.isEmpty) return null;
+
+  final gif = img.GifEncoder(delay: 80);
+
+  for (int i = 0; i < rgbaFrames.length; i++) {
+    final width = widths[i];
+    final height = heights[i];
+    final rgba = rgbaFrames[i];
+
+    final expectedSize = width * height * 4;
+    if (rgba.length != expectedSize) continue;
+
+    final image = img.Image.fromBytes(
+      width: width,
+      height: height,
+      bytes: rgba.buffer,
+      numChannels: 4,
+      order: img.ChannelOrder.rgba,
+    );
+
+    gif.addFrame(image, duration: durationsCs[i]);
+  }
+
+  return gif.finish();
+}

--- a/lib/screens/chessboard/widgets/gif_export_worker.dart
+++ b/lib/screens/chessboard/widgets/gif_export_worker.dart
@@ -98,10 +98,10 @@ GifExportProfile planGifExport({
   late final List<int> frameIndices;
 
   if (moveCount <= 60) {
-    pixelRatio = 1.5;
+    pixelRatio = 1.25;
     frameIndices = List.generate(moveCount, (i) => i);
   } else if (moveCount <= 100) {
-    pixelRatio = 1.25;
+    pixelRatio = 1.0;
     frameIndices = List.generate(moveCount, (i) => i);
   } else {
     pixelRatio = 1.0;

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -272,33 +272,37 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       );
     }
 
-    // currentMoveIndex == -1 (initial position): export last 5 plies
+    // currentMoveIndex == -1 (initial position): try to export last 5 plies
     final offset = math.max(0, widget.moveSans.length - 5);
-    final movesToAnimate = widget.moveSans.sublist(offset);
 
-    // Pre-play prefix moves to compute the starting FEN for the window
-    String? captureStartFen = widget.startingFen;
     if (offset > 0) {
+      // Pre-play prefix moves to compute the starting FEN for the window
       try {
-        Position pos = captureStartFen != null
-            ? Chess.fromSetup(Setup.parseFen(captureStartFen))
+        Position pos = widget.startingFen != null
+            ? Chess.fromSetup(Setup.parseFen(widget.startingFen!))
             : Chess.initial;
         for (int i = 0; i < offset; i++) {
           final move = pos.parseSan(widget.moveSans[i]);
-          if (move == null) break;
+          if (move == null) throw StateError('Prefix move $i unparseable');
           pos = pos.play(move);
         }
-        captureStartFen = pos.fen;
+        return (
+          movesToAnimate: widget.moveSans.sublist(offset),
+          globalMoveOffset: offset,
+          captureStartFen: pos.fen,
+        );
       } catch (_) {
-        // If prefix play fails, fall back to standard initial
-        captureStartFen = null;
+        // Prefix replay failed — fall back to exporting the full line
+        // rather than silently using Chess.initial for a clipped window
+        debugPrint('GIF: prefix replay failed, falling back to full line');
       }
     }
 
+    // Either offset == 0 (fewer than 5 moves) or prefix replay failed
     return (
-      movesToAnimate: movesToAnimate,
-      globalMoveOffset: offset,
-      captureStartFen: captureStartFen,
+      movesToAnimate: widget.moveSans.toList(),
+      globalMoveOffset: 0,
+      captureStartFen: widget.startingFen,
     );
   }
 
@@ -482,11 +486,14 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
       // Capture initial position (output frame 0)
       Position position;
-      try {
-        position = captureStartFen != null
-            ? Chess.fromSetup(Setup.parseFen(captureStartFen))
-            : Chess.initial;
-      } catch (_) {
+      if (captureStartFen != null) {
+        try {
+          position = Chess.fromSetup(Setup.parseFen(captureStartFen));
+        } catch (e) {
+          _showMessage('Invalid starting position for GIF', isError: true);
+          return;
+        }
+      } else {
         position = Chess.initial;
       }
       setState(() {
@@ -605,11 +612,14 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
     // Capture initial position
     Position position;
-    try {
-      position = captureStartFen != null
-          ? Chess.fromSetup(Setup.parseFen(captureStartFen))
-          : Chess.initial;
-    } catch (_) {
+    if (captureStartFen != null) {
+      try {
+        position = Chess.fromSetup(Setup.parseFen(captureStartFen));
+      } catch (e) {
+        _showMessage('Invalid starting position for GIF', isError: true);
+        return;
+      }
+    } else {
       position = Chess.initial;
     }
     setState(() {

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -369,7 +369,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         }
       } else if (message is GifWorkerDone) {
         if (!doneCompleter.isCompleted) {
-          doneCompleter.complete(message.gifBytes);
+          doneCompleter.complete(message.gifBytes.materialize().asUint8List());
         }
       } else if (message is GifWorkerError) {
         debugPrint('GIF worker error: ${message.message}');

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -119,6 +119,12 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
   bool _gifFrameIsFinal = false; // Only show game ending effects on final frame
   bool _cancelled = false; // Set on dispose to abort in-flight GIF generation
 
+  @override
+  void dispose() {
+    _cancelled = true;
+    super.dispose();
+  }
+
   // Board settings with animations disabled for instant frame capture
   ChessboardSettings get _gifBoardSettings => ChessboardSettings(
     enableCoordinates: widget.boardSettings.enableCoordinates,
@@ -250,7 +256,10 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
   void _updateGifProgress(int captured, int accepted, int total) {
     final progress =
         (captured / total * 0.6 + accepted / total * 0.4).clamp(0.0, 0.95);
-    if (mounted) setState(() => _gifProgress = progress);
+    // Only rebuild if progress moved by ≥2% to avoid rebuild storms
+    if (mounted && (progress - _gifProgress).abs() >= 0.02) {
+      setState(() => _gifProgress = progress);
+    }
   }
 
   /// Computes the export window for GIF generation.
@@ -309,13 +318,12 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
   Future<void> _shareGif() async {
     if (_isGeneratingGif) return;
+    _cancelled = false;
 
     final exportWindow = _computeExportWindow();
     if (exportWindow == null) {
-      _showMessage(
-        'GIF unavailable: no move history',
-        isError: true,
-      );
+      // No moves to animate — fall back to static image export
+      await _shareImage();
       return;
     }
 
@@ -430,7 +438,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     int framesCaptured = 0;
     int framesAccepted = 0;
     int inFlight = 0;
-    const maxInFlight = 2;
+    const maxInFlight = 4;
     bool workerFailed = false;
     Completer<void>? backpressureCompleter;
     final doneCompleter = Completer<Uint8List>();
@@ -506,6 +514,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       } else {
         position = Chess.initial;
       }
+      if (!mounted) return;
       setState(() {
         _gifFrameFen = position.fen;
         _gifFrameLastMove = null;
@@ -534,7 +543,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       int outputIndex = 1; // next output frame index after initial
 
       for (int i = 0; i < movesToAnimate.length; i++) {
-        if (workerFailed) return;
+        if (workerFailed || _cancelled) return;
 
         final move = position.parseSan(movesToAnimate[i]);
         if (move == null) {
@@ -557,6 +566,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         final isGameEnd = widget.isAtGameEnd &&
             i + globalMoveOffset == widget.moveSans.length - 1;
 
+        if (!mounted) return;
         setState(() {
           _gifFrameFen = position.fen;
           _gifFrameLastMove = lastMoveForDisplay;
@@ -632,6 +642,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     } else {
       position = Chess.initial;
     }
+    if (!mounted) return;
     setState(() {
       _gifFrameFen = position.fen;
       _gifFrameLastMove = null;
@@ -652,6 +663,8 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     int durationIndex = 1;
 
     for (int i = 0; i < movesToAnimate.length; i++) {
+      if (_cancelled) return;
+
       final move = position.parseSan(movesToAnimate[i]);
       if (move == null) {
         _showMessage('Failed to parse move ${i + 1}', isError: true);
@@ -671,6 +684,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       final isGameEnd = widget.isAtGameEnd &&
           i + globalMoveOffset == widget.moveSans.length - 1;
 
+      if (!mounted) return;
       setState(() {
         _gifFrameFen = position.fen;
         _gifFrameLastMove = lastMoveForDisplay;
@@ -896,9 +910,6 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
             icon: Icons.gif_box_outlined,
             label: 'Share GIF',
             onTap: _shareGif,
-            enabled: widget.moveSans.isNotEmpty,
-            disabledMessage:
-                'GIF unavailable: move history could not be loaded for this game.',
           ),
           SizedBox(width: 4.w),
           _buildActionButton(

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -64,6 +64,7 @@ class ShareGameCardOverlay extends StatefulWidget {
   isAtGameEnd; // Whether viewing the actual final position of the game
   final VoidCallback onClose;
   final String gameId; // CRITICAL: Include game ID for correct eval caching
+  final String? startingFen; // null = standard initial position
 
   const ShareGameCardOverlay({
     super.key,
@@ -93,6 +94,7 @@ class ShareGameCardOverlay extends StatefulWidget {
     this.isAtGameEnd = false,
     required this.onClose,
     required this.gameId, // REQUIRED for correct eval caching
+    this.startingFen, // null = standard initial position
   });
 
   @override
@@ -250,15 +252,71 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     if (mounted) setState(() => _gifProgress = progress);
   }
 
+  /// Computes the export window for GIF generation.
+  ///
+  /// Returns `null` if no moves are available to animate.
+  ({
+    List<String> movesToAnimate,
+    int globalMoveOffset,
+    String? captureStartFen,
+  })? _computeExportWindow() {
+    if (widget.moveSans.isEmpty) return null;
+
+    if (widget.currentMoveIndex >= 0) {
+      // Normal case: export from start through the selected move
+      return (
+        movesToAnimate:
+            widget.moveSans.take(widget.currentMoveIndex + 1).toList(),
+        globalMoveOffset: 0,
+        captureStartFen: widget.startingFen,
+      );
+    }
+
+    // currentMoveIndex == -1 (initial position): export last 5 plies
+    final offset = math.max(0, widget.moveSans.length - 5);
+    final movesToAnimate = widget.moveSans.sublist(offset);
+
+    // Pre-play prefix moves to compute the starting FEN for the window
+    String? captureStartFen = widget.startingFen;
+    if (offset > 0) {
+      try {
+        Position pos = captureStartFen != null
+            ? Chess.fromSetup(Setup.parseFen(captureStartFen))
+            : Chess.initial;
+        for (int i = 0; i < offset; i++) {
+          final move = pos.parseSan(widget.moveSans[i]);
+          if (move == null) break;
+          pos = pos.play(move);
+        }
+        captureStartFen = pos.fen;
+      } catch (_) {
+        // If prefix play fails, fall back to standard initial
+        captureStartFen = null;
+      }
+    }
+
+    return (
+      movesToAnimate: movesToAnimate,
+      globalMoveOffset: offset,
+      captureStartFen: captureStartFen,
+    );
+  }
+
   Future<void> _shareGif() async {
     if (_isGeneratingGif) return;
 
-    final movesToAnimate =
-        widget.moveSans.take(widget.currentMoveIndex + 1).toList();
-    if (movesToAnimate.isEmpty) {
-      _showMessage('No moves to animate', isError: true);
+    final exportWindow = _computeExportWindow();
+    if (exportWindow == null) {
+      _showMessage(
+        'GIF unavailable: no move history',
+        isError: true,
+      );
       return;
     }
+
+    final movesToAnimate = exportWindow.movesToAnimate;
+    final globalMoveOffset = exportWindow.globalMoveOffset;
+    final captureStartFen = exportWindow.captureStartFen;
 
     setState(() {
       _isGeneratingGif = true;
@@ -314,12 +372,16 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
           workerSendPort: workerSendPort!,
           mainPort: mainPort!,
           workerIsolate: workerIsolate!,
+          captureStartFen: captureStartFen,
+          globalMoveOffset: globalMoveOffset,
         );
       } else {
         await _shareGifFallback(
           movesToAnimate: movesToAnimate,
           profile: profile,
           totalOutputFrames: totalOutputFrames,
+          captureStartFen: captureStartFen,
+          globalMoveOffset: globalMoveOffset,
         );
       }
     } catch (e, st) {
@@ -348,11 +410,14 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     required SendPort workerSendPort,
     required ReceivePort mainPort,
     required Isolate workerIsolate,
+    String? captureStartFen,
+    int globalMoveOffset = 0,
   }) async {
     int framesCaptured = 0;
     int framesAccepted = 0;
     int inFlight = 0;
     const maxInFlight = 2;
+    bool workerFailed = false;
     Completer<void>? backpressureCompleter;
     final doneCompleter = Completer<Uint8List>();
     final includedMoves = profile.frameIndices.toSet();
@@ -373,6 +438,13 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         }
       } else if (message is GifWorkerError) {
         debugPrint('GIF worker error: ${message.message}');
+        workerFailed = true;
+        inFlight--;
+        // Unblock any backpressure wait so the capture loop can exit
+        if (backpressureCompleter != null &&
+            !backpressureCompleter!.isCompleted) {
+          backpressureCompleter!.complete();
+        }
         if (!doneCompleter.isCompleted) {
           doneCompleter.completeError(Exception(message.message));
         }
@@ -380,18 +452,20 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     });
 
     try {
-      // Helper: send a frame to the worker with backpressure
-      Future<void> sendFrame(
+      // Helper: send a frame to the worker with backpressure.
+      // Returns false if the worker has failed and sending should stop.
+      Future<bool> sendFrame(
         Uint8List rgba,
         int width,
         int height,
         int durationCs,
         int outputIndex,
       ) async {
-        while (inFlight >= maxInFlight) {
+        while (inFlight >= maxInFlight && !workerFailed) {
           backpressureCompleter = Completer<void>();
           await backpressureCompleter!.future;
         }
+        if (workerFailed) return false;
         final transferable = TransferableTypedData.fromList([rgba]);
         workerSendPort.send(GifWorkerFrameData(
           rgba: transferable,
@@ -403,10 +477,18 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         inFlight++;
         framesCaptured++;
         _updateGifProgress(framesCaptured, framesAccepted, totalOutputFrames);
+        return true;
       }
 
       // Capture initial position (output frame 0)
-      Position position = Chess.initial;
+      Position position;
+      try {
+        position = captureStartFen != null
+            ? Chess.fromSetup(Setup.parseFen(captureStartFen))
+            : Chess.initial;
+      } catch (_) {
+        position = Chess.initial;
+      }
       setState(() {
         _gifFrameFen = position.fen;
         _gifFrameLastMove = null;
@@ -421,19 +503,22 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         _showMessage('Failed to capture initial frame', isError: true);
         return;
       }
-      await sendFrame(
+      final sent = await sendFrame(
         initial.rgba,
         initial.width,
         initial.height,
         profile.frameDurations[0],
         0,
       );
+      if (!sent) return; // Worker failed during initial frame
 
       // Iterate ALL moves sequentially (SAN parsing is stateful).
       // Capture only at indices in the export profile.
       int outputIndex = 1; // next output frame index after initial
 
       for (int i = 0; i < movesToAnimate.length; i++) {
+        if (workerFailed) return;
+
         final move = position.parseSan(movesToAnimate[i]);
         if (move == null) {
           // Abort: broken alignment would produce a corrupted GIF
@@ -450,9 +535,10 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
           lastMoveForDisplay = NormalMove(from: move.from, to: move.to);
         }
 
-        final (whiteClock, blackClock) = _getClocksAtMoveIndex(i);
-        final isGameEnd =
-            widget.isAtGameEnd && i == movesToAnimate.length - 1;
+        final (whiteClock, blackClock) =
+            _getClocksAtMoveIndex(i + globalMoveOffset);
+        final isGameEnd = widget.isAtGameEnd &&
+            i + globalMoveOffset == widget.moveSans.length - 1;
 
         setState(() {
           _gifFrameFen = position.fen;
@@ -470,13 +556,14 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
               isError: true);
           return;
         }
-        await sendFrame(
+        final frameSent = await sendFrame(
           frame.rgba,
           frame.width,
           frame.height,
           profile.frameDurations[outputIndex],
           outputIndex,
         );
+        if (!frameSent) return; // Worker failed
         outputIndex++;
       }
 
@@ -509,13 +596,22 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     required List<String> movesToAnimate,
     required GifExportProfile profile,
     required int totalOutputFrames,
+    String? captureStartFen,
+    int globalMoveOffset = 0,
   }) async {
     final rawFrames = <_RawFrame>[];
     final durations = <int>[];
     final includedMoves = profile.frameIndices.toSet();
 
     // Capture initial position
-    Position position = Chess.initial;
+    Position position;
+    try {
+      position = captureStartFen != null
+          ? Chess.fromSetup(Setup.parseFen(captureStartFen))
+          : Chess.initial;
+    } catch (_) {
+      position = Chess.initial;
+    }
     setState(() {
       _gifFrameFen = position.fen;
       _gifFrameLastMove = null;
@@ -550,9 +646,10 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         lastMoveForDisplay = NormalMove(from: move.from, to: move.to);
       }
 
-      final (whiteClock, blackClock) = _getClocksAtMoveIndex(i);
-      final isGameEnd =
-          widget.isAtGameEnd && i == movesToAnimate.length - 1;
+      final (whiteClock, blackClock) =
+          _getClocksAtMoveIndex(i + globalMoveOffset);
+      final isGameEnd = widget.isAtGameEnd &&
+          i + globalMoveOffset == widget.moveSans.length - 1;
 
       setState(() {
         _gifFrameFen = position.fen;
@@ -710,38 +807,49 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     required String label,
     required VoidCallback onTap,
     bool isPrimary = false,
+    bool enabled = true,
+    String? disabledMessage,
   }) {
+    final effectiveOnTap = enabled
+        ? onTap
+        : () => _showMessage(
+              disabledMessage ?? 'Not available',
+              isError: true,
+            );
+
+    final content = Container(
+      padding: EdgeInsets.symmetric(vertical: 12.h),
+      decoration: BoxDecoration(
+        color: isPrimary ? kPrimaryColor : kBlack3Color,
+        borderRadius: BorderRadius.circular(8.br),
+        border:
+            isPrimary ? null : Border.all(color: kDividerColor, width: 1),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            icon,
+            size: 18.sp,
+            color: isPrimary ? kWhiteColor : kWhiteColor,
+          ),
+          SizedBox(width: 8.w),
+          Text(
+            label,
+            style: TextStyle(
+              color: isPrimary ? kWhiteColor : kWhiteColor,
+              fontSize: 13.sp,
+              fontWeight: isPrimary ? FontWeight.w600 : FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+
     return Expanded(
       child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          padding: EdgeInsets.symmetric(vertical: 12.h),
-          decoration: BoxDecoration(
-            color: isPrimary ? kPrimaryColor : kBlack3Color,
-            borderRadius: BorderRadius.circular(8.br),
-            border:
-                isPrimary ? null : Border.all(color: kDividerColor, width: 1),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                icon,
-                size: 18.sp,
-                color: isPrimary ? kWhiteColor : kWhiteColor,
-              ),
-              SizedBox(width: 8.w),
-              Text(
-                label,
-                style: TextStyle(
-                  color: isPrimary ? kWhiteColor : kWhiteColor,
-                  fontSize: 13.sp,
-                  fontWeight: isPrimary ? FontWeight.w600 : FontWeight.w500,
-                ),
-              ),
-            ],
-          ),
-        ),
+        onTap: effectiveOnTap,
+        child: enabled ? content : Opacity(opacity: 0.4, child: content),
       ),
     );
   }
@@ -768,6 +876,9 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
             icon: Icons.gif_box_outlined,
             label: 'Share GIF',
             onTap: _shareGif,
+            enabled: widget.moveSans.isNotEmpty,
+            disabledMessage:
+                'GIF unavailable: move history could not be loaded for this game.',
           ),
           SizedBox(width: 4.w),
           _buildActionButton(

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:io' as io;
+import 'dart:isolate';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
@@ -7,10 +9,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
+
+import 'gif_export_worker.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -31,100 +34,6 @@ class _RawFrame {
   final int width;
   final int height;
   _RawFrame(this.rgba, this.width, this.height);
-}
-
-/// Result class to pass back both data and error info from isolate
-class _GifEncodeResult {
-  final Uint8List? data;
-  final String? error;
-  final int framesProcessed;
-  _GifEncodeResult({this.data, this.error, this.framesProcessed = 0});
-}
-
-/// Input data for isolate - contains raw RGBA frames
-class _GifEncodeInput {
-  final List<Uint8List> rgbaFrames;
-  final List<int> widths;
-  final List<int> heights;
-  _GifEncodeInput(this.rgbaFrames, this.widths, this.heights);
-}
-
-/// Top-level function for GIF encoding in isolate (MUST be top-level or static)
-/// Takes raw RGBA pixel data to avoid PNG decoding issues on iOS P3 displays
-/// Duration is in 1/100 second units (centiseconds): 100 = 1 second
-_GifEncodeResult _encodeGifFromRawFrames(_GifEncodeInput input) {
-  if (input.rgbaFrames.isEmpty) {
-    return _GifEncodeResult(error: 'No frames provided');
-  }
-
-  try {
-    // Create encoder with default delay of 80 centiseconds (0.8s per move)
-    final gif = img.GifEncoder(delay: 80);
-    int framesAdded = 0;
-    final errors = <String>[];
-
-    for (int i = 0; i < input.rgbaFrames.length; i++) {
-      try {
-        final width = input.widths[i];
-        final height = input.heights[i];
-        final rgba = input.rgbaFrames[i];
-
-        // Validate data
-        final expectedSize = width * height * 4;
-        if (rgba.length != expectedSize) {
-          errors.add(
-            'Frame $i: size mismatch (got ${rgba.length}, expected $expectedSize)',
-          );
-          continue;
-        }
-
-        // Create image from raw RGBA bytes
-        final image = img.Image(width: width, height: height);
-
-        // Copy RGBA data to image (more efficient bulk copy)
-        for (int y = 0; y < height; y++) {
-          for (int x = 0; x < width; x++) {
-            final idx = (y * width + x) * 4;
-            image.setPixelRgba(
-              x,
-              y,
-              rgba[idx],
-              rgba[idx + 1],
-              rgba[idx + 2],
-              rgba[idx + 3],
-            );
-          }
-        }
-
-        // 80 centiseconds = 800ms per frame, 300 centiseconds = 3s for last frame
-        final isLastFrame = i == input.rgbaFrames.length - 1;
-        gif.addFrame(image, duration: isLastFrame ? 300 : 80);
-        framesAdded++;
-      } catch (e) {
-        errors.add('Frame $i error: $e');
-        continue;
-      }
-    }
-
-    if (framesAdded == 0) {
-      return _GifEncodeResult(
-        error: 'No frames processed. Errors: ${errors.join("; ")}',
-        framesProcessed: 0,
-      );
-    }
-
-    final result = gif.finish();
-    if (result == null || result.isEmpty) {
-      return _GifEncodeResult(
-        error: 'GifEncoder.finish() returned null/empty',
-        framesProcessed: framesAdded,
-      );
-    }
-
-    return _GifEncodeResult(data: result, framesProcessed: framesAdded);
-  } catch (e, st) {
-    return _GifEncodeResult(error: 'Encoding exception: $e\nStack: $st');
-  }
 }
 
 class ShareGameCardOverlay extends StatefulWidget {
@@ -247,8 +156,8 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     return (whiteClock, blackClock);
   }
 
-  /// Capture raw RGBA pixel data from the RepaintBoundary
-  /// This avoids PNG encoding issues on iOS P3 displays
+  /// Capture raw RGBA pixel data from the RepaintBoundary.
+  /// Disposes the ui.Image immediately after extracting bytes.
   Future<_RawFrame?> _captureRawFrame(double pixelRatio) async {
     try {
       final boundary =
@@ -260,19 +169,23 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       }
 
       final image = await boundary.toImage(pixelRatio: pixelRatio);
-      final byteData = await image.toByteData(
-        format: ui.ImageByteFormat.rawRgba,
-      );
-      if (byteData == null) {
-        debugPrint('GIF: toByteData returned null');
-        return null;
-      }
+      try {
+        final byteData = await image.toByteData(
+          format: ui.ImageByteFormat.rawRgba,
+        );
+        if (byteData == null) {
+          debugPrint('GIF: toByteData returned null');
+          return null;
+        }
 
-      return _RawFrame(
-        byteData.buffer.asUint8List(),
-        image.width,
-        image.height,
-      );
+        return _RawFrame(
+          byteData.buffer.asUint8List(),
+          image.width,
+          image.height,
+        );
+      } finally {
+        image.dispose();
+      }
     } catch (e) {
       debugPrint('GIF: Raw capture error: $e');
       return null;
@@ -331,6 +244,12 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     }
   }
 
+  void _updateGifProgress(int captured, int accepted, int total) {
+    final progress =
+        (captured / total * 0.6 + accepted / total * 0.4).clamp(0.0, 0.95);
+    if (mounted) setState(() => _gifProgress = progress);
+  }
+
   Future<void> _shareGif() async {
     if (_isGeneratingGif) return;
 
@@ -347,161 +266,351 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     });
 
     try {
-      // Phase 1: Capture raw RGBA frames (avoids PNG encoding issues on iOS P3 displays)
-      Position position = Chess.initial;
-      final rawFrames = <_RawFrame>[];
-      const pixelRatio =
-          1.5; // Lower ratio for smaller file size and faster encoding
+      // Plan export profile using the truncated move list's coordinate space
+      final profile = planGifExport(
+        moveCount: movesToAnimate.length,
+        currentMoveIndex: movesToAnimate.length - 1,
+      );
+      final totalOutputFrames = 1 + profile.frameIndices.length;
 
-      // Initial position - set state and wait for widget to build
-      // At initial position (before any moves), no clocks to show yet
+      // Try to start a worker isolate for pipelined encoding
+      Isolate? workerIsolate;
+      SendPort? workerSendPort;
+      ReceivePort? mainPort;
+      bool useIsolate = true;
+
+      try {
+        mainPort = ReceivePort();
+        workerIsolate = await Isolate.spawn(
+          gifEncoderWorker,
+          mainPort.sendPort,
+        );
+
+        // Wait for GifWorkerReady (single handshake with SendPort)
+        final readyCompleter = Completer<SendPort>();
+        final readySub = mainPort.listen((message) {
+          if (message is GifWorkerReady && !readyCompleter.isCompleted) {
+            readyCompleter.complete(message.workerSendPort);
+          }
+        });
+
+        workerSendPort = await readyCompleter.future
+            .timeout(const Duration(seconds: 5));
+        await readySub.cancel();
+      } catch (e) {
+        debugPrint('GIF: Isolate startup failed: $e, using fallback');
+        useIsolate = false;
+        mainPort?.close();
+        workerIsolate?.kill();
+        mainPort = null;
+        workerIsolate = null;
+      }
+
+      if (useIsolate) {
+        await _shareGifPipelined(
+          movesToAnimate: movesToAnimate,
+          profile: profile,
+          totalOutputFrames: totalOutputFrames,
+          workerSendPort: workerSendPort!,
+          mainPort: mainPort!,
+          workerIsolate: workerIsolate!,
+        );
+      } else {
+        await _shareGifFallback(
+          movesToAnimate: movesToAnimate,
+          profile: profile,
+          totalOutputFrames: totalOutputFrames,
+        );
+      }
+    } catch (e, st) {
+      debugPrint('GIF error: $e');
+      debugPrint('GIF stack: $st');
+      _showMessage('Failed to generate GIF', isError: true);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGeneratingGif = false;
+          _gifProgress = 0.0;
+          _gifFrameFen = null;
+          _gifFrameLastMove = null;
+          _gifFrameWhiteClock = null;
+          _gifFrameBlackClock = null;
+          _gifFrameIsFinal = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _shareGifPipelined({
+    required List<String> movesToAnimate,
+    required GifExportProfile profile,
+    required int totalOutputFrames,
+    required SendPort workerSendPort,
+    required ReceivePort mainPort,
+    required Isolate workerIsolate,
+  }) async {
+    int framesCaptured = 0;
+    int framesAccepted = 0;
+    int inFlight = 0;
+    const maxInFlight = 2;
+    Completer<void>? backpressureCompleter;
+    final doneCompleter = Completer<Uint8List>();
+    final includedMoves = profile.frameIndices.toSet();
+
+    // Listen for worker responses
+    final subscription = mainPort.listen((message) {
+      if (message is GifWorkerFrameAccepted) {
+        framesAccepted++;
+        inFlight--;
+        _updateGifProgress(framesCaptured, framesAccepted, totalOutputFrames);
+        if (backpressureCompleter != null &&
+            !backpressureCompleter!.isCompleted) {
+          backpressureCompleter!.complete();
+        }
+      } else if (message is GifWorkerDone) {
+        if (!doneCompleter.isCompleted) {
+          doneCompleter.complete(message.gifBytes);
+        }
+      } else if (message is GifWorkerError) {
+        debugPrint('GIF worker error: ${message.message}');
+        if (!doneCompleter.isCompleted) {
+          doneCompleter.completeError(Exception(message.message));
+        }
+      }
+    });
+
+    try {
+      // Helper: send a frame to the worker with backpressure
+      Future<void> sendFrame(
+        Uint8List rgba,
+        int width,
+        int height,
+        int durationCs,
+        int outputIndex,
+      ) async {
+        while (inFlight >= maxInFlight) {
+          backpressureCompleter = Completer<void>();
+          await backpressureCompleter!.future;
+        }
+        final transferable = TransferableTypedData.fromList([rgba]);
+        workerSendPort.send(GifWorkerFrameData(
+          rgba: transferable,
+          width: width,
+          height: height,
+          durationCs: durationCs,
+          frameIndex: outputIndex,
+        ));
+        inFlight++;
+        framesCaptured++;
+        _updateGifProgress(framesCaptured, framesAccepted, totalOutputFrames);
+      }
+
+      // Capture initial position (output frame 0)
+      Position position = Chess.initial;
       setState(() {
         _gifFrameFen = position.fen;
         _gifFrameLastMove = null;
         _gifFrameWhiteClock = null;
         _gifFrameBlackClock = null;
-        _gifFrameIsFinal = false; // Not at final position yet
+        _gifFrameIsFinal = false;
       });
-      // Wait for widget to build and paint
       await WidgetsBinding.instance.endOfFrame;
-      await Future.delayed(const Duration(milliseconds: 50));
 
-      final initial = await _captureRawFrame(pixelRatio);
-      if (initial != null) {
-        debugPrint(
-          'GIF: Initial frame captured (${initial.width}x${initial.height}, ${initial.rgba.length} bytes)',
-        );
-        rawFrames.add(initial);
-      } else {
-        debugPrint('GIF WARNING: Initial frame capture returned null');
+      final initial = await _captureRawFrame(profile.pixelRatio);
+      if (initial == null) {
+        _showMessage('Failed to capture initial frame', isError: true);
+        return;
       }
+      await sendFrame(
+        initial.rgba,
+        initial.width,
+        initial.height,
+        profile.frameDurations[0],
+        0,
+      );
 
-      debugPrint('GIF: Processing ${movesToAnimate.length} moves...');
+      // Iterate ALL moves sequentially (SAN parsing is stateful).
+      // Capture only at indices in the export profile.
+      int outputIndex = 1; // next output frame index after initial
 
-      // Each move - capture only the final position (no animation frames)
       for (int i = 0; i < movesToAnimate.length; i++) {
         final move = position.parseSan(movesToAnimate[i]);
-        if (move == null) continue;
+        if (move == null) {
+          // Abort: broken alignment would produce a corrupted GIF
+          _showMessage('Failed to parse move ${i + 1}', isError: true);
+          return;
+        }
         position = position.play(move);
 
-        // Extract from/to squares safely for any move type
+        if (!includedMoves.contains(i)) continue;
+
+        // Extract from/to squares for last-move highlight
         NormalMove? lastMoveForDisplay;
         if (move is NormalMove) {
           lastMoveForDisplay = NormalMove(from: move.from, to: move.to);
-        } else {
-          // For castling and other special moves, skip highlighting
-          lastMoveForDisplay = null;
         }
 
-        // Get clock times at this move index
         final (whiteClock, blackClock) = _getClocksAtMoveIndex(i);
-
-        // Check if this is the final frame
-        final isLastFrame = i == movesToAnimate.length - 1;
+        final isGameEnd =
+            widget.isAtGameEnd && i == movesToAnimate.length - 1;
 
         setState(() {
           _gifFrameFen = position.fen;
           _gifFrameLastMove = lastMoveForDisplay;
           _gifFrameWhiteClock = whiteClock;
           _gifFrameBlackClock = blackClock;
-          _gifFrameIsFinal =
-              isLastFrame; // Only show game ending effects on final frame
-          _gifProgress =
-              (i + 1) / movesToAnimate.length * 0.7; // 70% for capture
+          _gifFrameIsFinal = isGameEnd;
         });
-
-        // Minimal wait - animations are disabled so position is instantly set
         await WidgetsBinding.instance.endOfFrame;
-        await Future.delayed(const Duration(milliseconds: 30));
 
-        final frame = await _captureRawFrame(pixelRatio);
-        if (frame != null) rawFrames.add(frame);
-      }
-
-      if (rawFrames.isEmpty) {
-        debugPrint('GIF ERROR: No frames were captured');
-        _showMessage(
-          'No frames captured - check board rendering',
-          isError: true,
+        final frame = await _captureRawFrame(profile.pixelRatio);
+        if (frame == null) {
+          // Abort: broken alignment would produce a corrupted GIF
+          _showMessage('Failed to capture frame at move ${i + 1}',
+              isError: true);
+          return;
+        }
+        await sendFrame(
+          frame.rgba,
+          frame.width,
+          frame.height,
+          profile.frameDurations[outputIndex],
+          outputIndex,
         );
-        return;
+        outputIndex++;
       }
 
-      debugPrint('GIF: Captured ${rawFrames.length} raw frames');
+      // All frames sent, tell worker to finish
+      workerSendPort.send(GifWorkerFinish());
 
-      // Prepare input for isolate
-      final input = _GifEncodeInput(
-        rawFrames.map((f) => f.rgba).toList(),
-        rawFrames.map((f) => f.width).toList(),
-        rawFrames.map((f) => f.height).toList(),
-      );
+      // Wait for the encoded result with timeout
+      final gifBytes = await doneCompleter.future
+          .timeout(const Duration(seconds: 30));
 
-      // Phase 2: Encode GIF in isolate (heavy work off main thread)
-      setState(() => _gifProgress = 0.8);
-
-      _GifEncodeResult result;
-      try {
-        result = await compute(_encodeGifFromRawFrames, input);
-        debugPrint('GIF: Isolate encoding completed');
-      } catch (e, st) {
-        // Isolate failed (common on some iOS devices), try synchronously
-        debugPrint('GIF: Isolate failed: $e');
-        debugPrint('GIF: Isolate stack: $st');
-        debugPrint('GIF: Trying synchronous encoding...');
-        result = _encodeGifFromRawFrames(input);
-      }
-
-      if (result.error != null) {
-        debugPrint('GIF ERROR: ${result.error}');
-        debugPrint('GIF: Frames processed: ${result.framesProcessed}');
-        // Show truncated error in UI for debugging on real devices
-        final shortError =
-            result.error!.length > 100
-                ? result.error!.substring(0, 100)
-                : result.error!;
-        _showMessage('GIF encode failed: $shortError', isError: true);
-        return;
-      }
-
-      final gifBytes = result.data;
-      if (gifBytes == null || gifBytes.isEmpty) {
-        debugPrint('GIF ERROR: Result data is null or empty');
-        _showMessage('GIF encode returned empty data', isError: true);
-        return;
-      }
-
-      debugPrint(
-        'GIF: Encoded ${gifBytes.length} bytes (${result.framesProcessed} frames)',
-      );
-
-      // Phase 3: Save and share
-      setState(() => _gifProgress = 0.95);
+      // Save and share
+      if (mounted) setState(() => _gifProgress = 0.95);
       final tempDir = await getTemporaryDirectory();
       final file = io.File('${tempDir.path}/chessever_game.gif');
       await file.writeAsBytes(gifBytes);
-
-      debugPrint('GIF: Saved to ${file.path}');
 
       await Share.shareXFiles(
         [XFile(file.path)],
         text: _gameUrl,
         sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
       );
-    } catch (e, st) {
-      debugPrint('GIF error: $e');
-      debugPrint('GIF stack: $st');
-      _showMessage('Failed to generate GIF', isError: true);
     } finally {
-      setState(() {
-        _isGeneratingGif = false;
-        _gifProgress = 0.0;
-        _gifFrameFen = null;
-        _gifFrameLastMove = null;
-        _gifFrameWhiteClock = null;
-        _gifFrameBlackClock = null;
-        _gifFrameIsFinal = false;
-      });
+      await subscription.cancel();
+      mainPort.close();
+      workerIsolate.kill(priority: Isolate.immediate);
     }
+  }
+
+  Future<void> _shareGifFallback({
+    required List<String> movesToAnimate,
+    required GifExportProfile profile,
+    required int totalOutputFrames,
+  }) async {
+    final rawFrames = <_RawFrame>[];
+    final durations = <int>[];
+    final includedMoves = profile.frameIndices.toSet();
+
+    // Capture initial position
+    Position position = Chess.initial;
+    setState(() {
+      _gifFrameFen = position.fen;
+      _gifFrameLastMove = null;
+      _gifFrameWhiteClock = null;
+      _gifFrameBlackClock = null;
+      _gifFrameIsFinal = false;
+    });
+    await WidgetsBinding.instance.endOfFrame;
+
+    final initial = await _captureRawFrame(profile.pixelRatio);
+    if (initial == null) {
+      _showMessage('Failed to capture initial frame', isError: true);
+      return;
+    }
+    rawFrames.add(initial);
+    durations.add(profile.frameDurations[0]);
+
+    int durationIndex = 1;
+
+    for (int i = 0; i < movesToAnimate.length; i++) {
+      final move = position.parseSan(movesToAnimate[i]);
+      if (move == null) {
+        _showMessage('Failed to parse move ${i + 1}', isError: true);
+        return;
+      }
+      position = position.play(move);
+
+      if (!includedMoves.contains(i)) continue;
+
+      NormalMove? lastMoveForDisplay;
+      if (move is NormalMove) {
+        lastMoveForDisplay = NormalMove(from: move.from, to: move.to);
+      }
+
+      final (whiteClock, blackClock) = _getClocksAtMoveIndex(i);
+      final isGameEnd =
+          widget.isAtGameEnd && i == movesToAnimate.length - 1;
+
+      setState(() {
+        _gifFrameFen = position.fen;
+        _gifFrameLastMove = lastMoveForDisplay;
+        _gifFrameWhiteClock = whiteClock;
+        _gifFrameBlackClock = blackClock;
+        _gifFrameIsFinal = isGameEnd;
+      });
+      await WidgetsBinding.instance.endOfFrame;
+
+      if (mounted) {
+        _updateGifProgress(
+          rawFrames.length,
+          rawFrames.length - 1,
+          totalOutputFrames,
+        );
+      }
+
+      final frame = await _captureRawFrame(profile.pixelRatio);
+      if (frame == null) {
+        _showMessage('Failed to capture frame at move ${i + 1}',
+            isError: true);
+        return;
+      }
+      rawFrames.add(frame);
+      durations.add(profile.frameDurations[durationIndex]);
+      durationIndex++;
+    }
+
+    if (rawFrames.isEmpty) {
+      _showMessage('No frames captured', isError: true);
+      return;
+    }
+
+    if (mounted) setState(() => _gifProgress = 0.8);
+
+    final gifBytes = encodeGifFallback(
+      rgbaFrames: rawFrames.map((f) => f.rgba).toList(),
+      widths: rawFrames.map((f) => f.width).toList(),
+      heights: rawFrames.map((f) => f.height).toList(),
+      durationsCs: durations,
+    );
+
+    if (gifBytes == null || gifBytes.isEmpty) {
+      _showMessage('GIF encode returned empty data', isError: true);
+      return;
+    }
+
+    if (mounted) setState(() => _gifProgress = 0.95);
+    final tempDir = await getTemporaryDirectory();
+    final file = io.File('${tempDir.path}/chessever_game.gif');
+    await file.writeAsBytes(gifBytes);
+
+    await Share.shareXFiles(
+      [XFile(file.path)],
+      text: _gameUrl,
+      sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
+    );
   }
 
   Future<void> _copyPgn() async {

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -117,6 +117,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
   String? _gifFrameWhiteClock;
   String? _gifFrameBlackClock;
   bool _gifFrameIsFinal = false; // Only show game ending effects on final frame
+  bool _cancelled = false; // Set on dispose to abort in-flight GIF generation
 
   // Board settings with animations disabled for instant frame capture
   ChessboardSettings get _gifBoardSettings => ChessboardSettings(
@@ -341,8 +342,14 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       ReceivePort? mainPort;
       bool useIsolate = true;
 
+      Stream<dynamic>? mainStream;
       try {
         mainPort = ReceivePort();
+        // Convert to broadcast stream so both the handshake and the pipeline
+        // can listen sequentially. ReceivePort is single-subscription — a
+        // second .listen() after cancel throws "Stream has already been
+        // listened to".
+        mainStream = mainPort.asBroadcastStream();
         workerIsolate = await Isolate.spawn(
           gifEncoderWorker,
           mainPort.sendPort,
@@ -350,7 +357,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
         // Wait for GifWorkerReady (single handshake with SendPort)
         final readyCompleter = Completer<SendPort>();
-        final readySub = mainPort.listen((message) {
+        final readySub = mainStream.listen((message) {
           if (message is GifWorkerReady && !readyCompleter.isCompleted) {
             readyCompleter.complete(message.workerSendPort);
           }
@@ -366,6 +373,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         workerIsolate?.kill();
         mainPort = null;
         workerIsolate = null;
+        mainStream = null;
       }
 
       if (useIsolate) {
@@ -374,6 +382,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
           profile: profile,
           totalOutputFrames: totalOutputFrames,
           workerSendPort: workerSendPort!,
+          mainStream: mainStream!,
           mainPort: mainPort!,
           workerIsolate: workerIsolate!,
           captureStartFen: captureStartFen,
@@ -412,6 +421,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     required GifExportProfile profile,
     required int totalOutputFrames,
     required SendPort workerSendPort,
+    required Stream<dynamic> mainStream,
     required ReceivePort mainPort,
     required Isolate workerIsolate,
     String? captureStartFen,
@@ -426,8 +436,8 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     final doneCompleter = Completer<Uint8List>();
     final includedMoves = profile.frameIndices.toSet();
 
-    // Listen for worker responses
-    final subscription = mainPort.listen((message) {
+    // Listen for worker responses on the broadcast stream
+    final subscription = mainStream.listen((message) {
       if (message is GifWorkerFrameAccepted) {
         framesAccepted++;
         inFlight--;

--- a/lib/screens/library/utils/gamebase_pgn_builder.dart
+++ b/lib/screens/library/utils/gamebase_pgn_builder.dart
@@ -256,21 +256,27 @@ String buildHeaderOnlyPgn({
 bool pgnHasMoves(String? pgn) {
   if (pgn == null || pgn.trim().isEmpty) return false;
 
-  // Find where the movetext section starts (after all headers)
-  // Headers are lines like [Key "Value"]
+  // Collect movetext lines: everything that isn't a PGN header ([Key "Value"])
+  // or a blank line. Handles three formats:
+  //   1. Standard PGN (headers + blank line + movetext)
+  //   2. No blank-line separator (headers immediately followed by movetext)
+  //   3. Movetext-only (no headers at all)
   final lines = pgn.split('\n');
   final movetextLines = <String>[];
 
-  bool pastHeaders = false;
+  bool inHeaders = true;
   for (final line in lines) {
     final trimmed = line.trim();
     if (trimmed.isEmpty) {
-      pastHeaders = true;
+      if (inHeaders) inHeaders = false; // blank line after headers
       continue;
     }
-    if (pastHeaders && !trimmed.startsWith('[')) {
-      movetextLines.add(trimmed);
+    if (inHeaders && trimmed.startsWith('[')) {
+      continue; // still in headers
     }
+    // Any non-header, non-empty line is movetext
+    inHeaders = false;
+    movetextLines.add(trimmed);
   }
 
   final movetext = movetextLines.join(' ').trim();

--- a/test/gif_export_worker_test.dart
+++ b/test/gif_export_worker_test.dart
@@ -176,7 +176,7 @@ void main() {
         } else if (message is GifWorkerFrameAccepted) {
           responses.add(message);
         } else if (message is GifWorkerDone) {
-          doneCompleter.complete(message.gifBytes);
+          doneCompleter.complete(message.gifBytes.materialize().asUint8List());
         } else if (message is GifWorkerError) {
           doneCompleter.completeError(Exception(message.message));
         }

--- a/test/gif_export_worker_test.dart
+++ b/test/gif_export_worker_test.dart
@@ -1,0 +1,283 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:chessever2/screens/chessboard/widgets/gif_export_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('planGifExport', () {
+    test('short game (20 moves) keeps all frames at pixelRatio 1.5', () {
+      final profile = planGifExport(moveCount: 20, currentMoveIndex: 19);
+
+      expect(profile.pixelRatio, 1.5);
+      expect(profile.frameIndices, List.generate(20, (i) => i));
+      // 21 durations: 1 initial + 20 moves
+      expect(profile.frameDurations.length, 21);
+      // All non-final durations should be 80cs (gap of 1)
+      for (int i = 0; i < 20; i++) {
+        expect(profile.frameDurations[i], 80);
+      }
+      // Last frame: 300cs (3s hold)
+      expect(profile.frameDurations[20], 300);
+    });
+
+    test('medium game (80 moves) keeps all frames at pixelRatio 1.25', () {
+      final profile = planGifExport(moveCount: 80, currentMoveIndex: 79);
+
+      expect(profile.pixelRatio, 1.25);
+      expect(profile.frameIndices.length, 80);
+      expect(profile.frameDurations.length, 81);
+      // Last duration is 300cs
+      expect(profile.frameDurations.last, 300);
+    });
+
+    test('boundary: 60 moves stays in short tier', () {
+      final profile = planGifExport(moveCount: 60, currentMoveIndex: 59);
+
+      expect(profile.pixelRatio, 1.5);
+      expect(profile.frameIndices.length, 60);
+    });
+
+    test('boundary: 61 moves moves to medium tier', () {
+      final profile = planGifExport(moveCount: 61, currentMoveIndex: 60);
+
+      expect(profile.pixelRatio, 1.25);
+      expect(profile.frameIndices.length, 61);
+    });
+
+    test('boundary: 100 moves stays in medium tier', () {
+      final profile = planGifExport(moveCount: 100, currentMoveIndex: 99);
+
+      expect(profile.pixelRatio, 1.25);
+      expect(profile.frameIndices.length, 100);
+    });
+
+    test('boundary: 101 moves moves to long tier', () {
+      final profile = planGifExport(moveCount: 101, currentMoveIndex: 100);
+
+      expect(profile.pixelRatio, 1.0);
+      expect(profile.frameIndices.length, 59);
+      // Total output frames = 1 initial + 59 = 60
+      expect(profile.frameDurations.length, 60);
+    });
+
+    test('long game (150 moves) caps to 59 sampled move frames', () {
+      final profile = planGifExport(moveCount: 150, currentMoveIndex: 149);
+
+      expect(profile.pixelRatio, 1.0);
+      expect(profile.frameIndices.length, 59);
+      // 60 total output frames: 1 initial + 59 sampled
+      expect(profile.frameDurations.length, 60);
+    });
+
+    test('long game includes required indices', () {
+      final profile = planGifExport(moveCount: 150, currentMoveIndex: 149);
+      final indices = profile.frameIndices;
+
+      // Must include move 0
+      expect(indices.contains(0), isTrue);
+      // Must include currentMoveIndex
+      expect(indices.contains(149), isTrue);
+      // Must include previous 8 moves (141-148)
+      for (int i = 141; i <= 148; i++) {
+        expect(indices.contains(i), isTrue, reason: 'Missing index $i');
+      }
+      // Sorted
+      for (int i = 1; i < indices.length; i++) {
+        expect(indices[i], greaterThan(indices[i - 1]));
+      }
+    });
+
+    test('long game durations accumulate correctly for gaps', () {
+      final profile = planGifExport(moveCount: 150, currentMoveIndex: 149);
+
+      // Non-last durations telescope: 80 * (lastIndex - (-1)) = 80 * 150 = 12000
+      // Last frame: 300cs
+      // Total = 12000 + 300 = 12300
+      final totalDuration =
+          profile.frameDurations.reduce((a, b) => a + b);
+      expect(totalDuration, 80 * 150 + 300);
+    });
+
+    test('edge case: currentMoveIndex < 9 includes available previous moves',
+        () {
+      final profile = planGifExport(moveCount: 120, currentMoveIndex: 5);
+      final indices = profile.frameIndices;
+
+      // Must include move 0 and move 5
+      expect(indices.contains(0), isTrue);
+      expect(indices.contains(5), isTrue);
+      // Includes moves 1-4 (all available before current)
+      for (int i = 1; i <= 4; i++) {
+        expect(indices.contains(i), isTrue, reason: 'Missing index $i');
+      }
+    });
+  });
+
+  group('sampleFrameIndices', () {
+    test('returns sorted, deduplicated list', () {
+      final indices = sampleFrameIndices(
+        totalMoves: 200,
+        targetMoveFrames: 59,
+        currentMoveIndex: 199,
+      );
+
+      // Sorted
+      for (int i = 1; i < indices.length; i++) {
+        expect(indices[i], greaterThan(indices[i - 1]));
+      }
+      // No duplicates
+      expect(indices.toSet().length, indices.length);
+    });
+
+    test('does not exceed target', () {
+      final indices = sampleFrameIndices(
+        totalMoves: 500,
+        targetMoveFrames: 59,
+        currentMoveIndex: 499,
+      );
+
+      expect(indices.length, lessThanOrEqualTo(59));
+    });
+
+    test('includes must-have indices', () {
+      final indices = sampleFrameIndices(
+        totalMoves: 300,
+        targetMoveFrames: 59,
+        currentMoveIndex: 299,
+      );
+
+      expect(indices.contains(0), isTrue);
+      expect(indices.contains(299), isTrue);
+      for (int i = 291; i <= 298; i++) {
+        expect(indices.contains(i), isTrue);
+      }
+    });
+  });
+
+  group('gifEncoderWorker', () {
+    test('produces a non-empty GIF from synthetic frames', () async {
+      final mainPort = ReceivePort();
+
+      final isolate = await Isolate.spawn(
+        gifEncoderWorker,
+        mainPort.sendPort,
+      );
+
+      final responses = <GifWorkerResponse>[];
+      final doneCompleter = Completer<Uint8List>();
+      SendPort? workerSendPort;
+      final readyCompleter = Completer<SendPort>();
+
+      final subscription = mainPort.listen((message) {
+        if (message is GifWorkerReady) {
+          readyCompleter.complete(message.workerSendPort);
+        } else if (message is GifWorkerFrameAccepted) {
+          responses.add(message);
+        } else if (message is GifWorkerDone) {
+          doneCompleter.complete(message.gifBytes);
+        } else if (message is GifWorkerError) {
+          doneCompleter.completeError(Exception(message.message));
+        }
+      });
+
+      workerSendPort =
+          await readyCompleter.future.timeout(const Duration(seconds: 5));
+
+      // Send 3 synthetic 2x2 RGBA frames
+      const w = 2;
+      const h = 2;
+      for (int i = 0; i < 3; i++) {
+        final rgba = Uint8List(w * h * 4);
+        // Fill with a distinct color per frame
+        for (int p = 0; p < w * h; p++) {
+          rgba[p * 4] = (i * 80) % 256; // R
+          rgba[p * 4 + 1] = 128; // G
+          rgba[p * 4 + 2] = 64; // B
+          rgba[p * 4 + 3] = 255; // A
+        }
+
+        workerSendPort.send(GifWorkerFrameData(
+          rgba: TransferableTypedData.fromList([rgba]),
+          width: w,
+          height: h,
+          durationCs: i == 2 ? 300 : 80,
+          frameIndex: i,
+        ));
+      }
+
+      workerSendPort.send(GifWorkerFinish());
+
+      final gifBytes =
+          await doneCompleter.future.timeout(const Duration(seconds: 10));
+
+      // Verify we got 3 frame-accepted responses
+      expect(responses.length, 3);
+      for (int i = 0; i < 3; i++) {
+        expect((responses[i] as GifWorkerFrameAccepted).frameIndex, i);
+      }
+
+      // Verify GIF output is non-empty and starts with GIF magic bytes
+      expect(gifBytes.length, greaterThan(0));
+      // GIF89a magic: 0x47 0x49 0x46 0x38 0x39 0x61
+      expect(gifBytes[0], 0x47); // G
+      expect(gifBytes[1], 0x49); // I
+      expect(gifBytes[2], 0x46); // F
+
+      await subscription.cancel();
+      mainPort.close();
+      isolate.kill(priority: Isolate.immediate);
+    });
+  });
+
+  group('encodeGifFallback', () {
+    test('produces a non-empty GIF from synthetic frames', () {
+      const w = 4;
+      const h = 4;
+      final frames = <Uint8List>[];
+      final widths = <int>[];
+      final heights = <int>[];
+      final durations = <int>[];
+
+      for (int i = 0; i < 3; i++) {
+        final rgba = Uint8List(w * h * 4);
+        for (int p = 0; p < w * h; p++) {
+          rgba[p * 4] = (i * 60) % 256;
+          rgba[p * 4 + 1] = 100;
+          rgba[p * 4 + 2] = 200;
+          rgba[p * 4 + 3] = 255;
+        }
+        frames.add(rgba);
+        widths.add(w);
+        heights.add(h);
+        durations.add(i == 2 ? 300 : 80);
+      }
+
+      final result = encodeGifFallback(
+        rgbaFrames: frames,
+        widths: widths,
+        heights: heights,
+        durationsCs: durations,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.length, greaterThan(0));
+      // GIF magic bytes
+      expect(result[0], 0x47);
+      expect(result[1], 0x49);
+      expect(result[2], 0x46);
+    });
+
+    test('returns null for empty input', () {
+      final result = encodeGifFallback(
+        rgbaFrames: [],
+        widths: [],
+        heights: [],
+        durationsCs: [],
+      );
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/gif_export_worker_test.dart
+++ b/test/gif_export_worker_test.dart
@@ -7,10 +7,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('planGifExport', () {
-    test('short game (20 moves) keeps all frames at pixelRatio 1.5', () {
+    test('short game (20 moves) keeps all frames at pixelRatio 1.25', () {
       final profile = planGifExport(moveCount: 20, currentMoveIndex: 19);
 
-      expect(profile.pixelRatio, 1.5);
+      expect(profile.pixelRatio, 1.25);
       expect(profile.frameIndices, List.generate(20, (i) => i));
       // 21 durations: 1 initial + 20 moves
       expect(profile.frameDurations.length, 21);
@@ -22,10 +22,10 @@ void main() {
       expect(profile.frameDurations[20], 300);
     });
 
-    test('medium game (80 moves) keeps all frames at pixelRatio 1.25', () {
+    test('medium game (80 moves) keeps all frames at pixelRatio 1.0', () {
       final profile = planGifExport(moveCount: 80, currentMoveIndex: 79);
 
-      expect(profile.pixelRatio, 1.25);
+      expect(profile.pixelRatio, 1.0);
       expect(profile.frameIndices.length, 80);
       expect(profile.frameDurations.length, 81);
       // Last duration is 300cs
@@ -35,21 +35,21 @@ void main() {
     test('boundary: 60 moves stays in short tier', () {
       final profile = planGifExport(moveCount: 60, currentMoveIndex: 59);
 
-      expect(profile.pixelRatio, 1.5);
+      expect(profile.pixelRatio, 1.25);
       expect(profile.frameIndices.length, 60);
     });
 
     test('boundary: 61 moves moves to medium tier', () {
       final profile = planGifExport(moveCount: 61, currentMoveIndex: 60);
 
-      expect(profile.pixelRatio, 1.25);
+      expect(profile.pixelRatio, 1.0);
       expect(profile.frameIndices.length, 61);
     });
 
     test('boundary: 100 moves stays in medium tier', () {
       final profile = planGifExport(moveCount: 100, currentMoveIndex: 99);
 
-      expect(profile.pixelRatio, 1.25);
+      expect(profile.pixelRatio, 1.0);
       expect(profile.frameIndices.length, 100);
     });
 


### PR DESCRIPTION
Replace the batch GIF export path with a pipelined worker-based flow.

- move GIF planning, worker protocol, and fallback encoding into a dedicated helper
- overlap frame capture and GIF encoding instead of waiting for all frames first
- cap memory by limiting in-flight frames instead of buffering the full export
- replace per-pixel setPixelRgba loops with Image.fromBytes
- remove fixed capture sleeps and rely on endOfFrame-driven capture
- add adaptive frame planning for long games while preserving short-game fidelity
- dispose captured ui.Image objects immediately after raw byte extraction
- add timeout and failure handling for worker startup/completion
- abort cleanly when SAN parsing or required frame capture fails
- add unit tests for export planning and worker encoding behavior