### PR TITLE
Fill For You events to 4 available boards

### DIFF
--- a/lib/providers/for_you_games_provider.dart
+++ b/lib/providers/for_you_games_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:chessever2/providers/event_favorite_players_provider.dart';
 import 'package:chessever2/providers/favorite_events_provider.dart';
 import 'package:chessever2/repository/local_storage/tournament/games/games_local_storage.dart';
+import 'package:chessever2/repository/local_storage/tournament/games/pin_games_local_storage.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
 import 'package:chessever2/repository/supabase/tour/tour.dart';
 import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.dart';
@@ -15,7 +16,6 @@ import 'package:chessever2/screens/group_event/providers/sorting_all_event_provi
 import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/screens/chessboard/provider/game_pgn_stream_provider.dart';
-import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/live_rounds_id_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/live_tour_id_provider.dart';
 import 'package:collection/collection.dart';
@@ -384,8 +384,7 @@ final eventGamesProvider = FutureProvider.autoDispose.family<
   // ── 2. Order tours deterministically ──
   // Live tours first, then by avgElo descending, then stable original order.
   if (eventTours.isNotEmpty) {
-    final liveTourIds =
-        ref.read(liveTourIdProvider).valueOrNull ?? <String>[];
+    final liveTourIds = ref.read(liveTourIdProvider).valueOrNull ?? <String>[];
 
     // Capture original indices for stable tie-breaking
     final originalOrder = {
@@ -429,19 +428,25 @@ final eventGamesProvider = FutureProvider.autoDispose.family<
   // ── 3. Fetch and filter started games from EVERY tour ──
   // Always use refresh() to get fresh data from network for For You tab.
   // This ensures we see new rounds immediately when they start.
-  final allStartedGames = <Games>[];
-  for (final tourId in tourIdsToFetch) {
-    try {
-      final games = await gamesStorage.refresh(tourId);
-      for (final game in games) {
-        if (_hasActuallyStarted(game) &&
-            game.players != null &&
-            game.players!.length >= 2) {
-          allStartedGames.add(game);
-        }
+  final fetchedGamesByTour = await Future.wait(
+    tourIdsToFetch.map((tourId) async {
+      try {
+        return await gamesStorage.refresh(tourId);
+      } catch (e) {
+        debugPrint('[ForYou] Error fetching games for tour $tourId: $e');
+        return <Games>[];
       }
-    } catch (e) {
-      debugPrint('[ForYou] Error fetching games for tour $tourId: $e');
+    }),
+  );
+
+  final allStartedGames = <Games>[];
+  for (final games in fetchedGamesByTour) {
+    for (final game in games) {
+      if (_hasActuallyStarted(game) &&
+          game.players != null &&
+          game.players!.length >= 2) {
+        allStartedGames.add(game);
+      }
     }
   }
 
@@ -455,19 +460,26 @@ final eventGamesProvider = FutureProvider.autoDispose.family<
     '${tourIdsToFetch.length} tours for event $eventId',
   );
 
-  // ── 4. Aggregate pin IDs from ALL tours ──
+  // ── 4. Aggregate manual pin IDs from ALL tours ──
+  final pinStorage = ref.read(pinGameLocalStorage);
+  final pinsByTour = await Future.wait(
+    tourIdsToFetch.map((tourId) async {
+      try {
+        return await pinStorage.getPinnedGameIds(tourId);
+      } catch (e) {
+        debugPrint('[ForYou] Error fetching pinned games for tour $tourId: $e');
+        return <String>[];
+      }
+    }),
+  );
+
   final pinnedIds = <String>[];
   final seenPins = <String>{};
-  for (final tourId in tourIdsToFetch) {
-    try {
-      final pinState = ref.read(gamesPinprovider(tourId));
-      for (final pinId in pinState.allPins) {
-        if (seenPins.add(pinId)) {
-          pinnedIds.add(pinId);
-        }
+  for (final pinIds in pinsByTour) {
+    for (final pinId in pinIds) {
+      if (seenPins.add(pinId)) {
+        pinnedIds.add(pinId);
       }
-    } catch (e) {
-      // Pin provider might not be initialized for some tours
     }
   }
 
@@ -646,11 +658,12 @@ List<Games> selectForYouEventGames({
   // --- Normal (non-match) path ---
 
   // 1. Compute per-round recency: max activity timestamp per roundId.
-  //    Fallback chain: lastMoveTime > gameDay > dateStart.
+  //    Fallback chain: lastMoveTime > gameDay > dateStart > Unix epoch.
+  final unknownRoundTime = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
   final roundRecency = <String, DateTime>{};
   for (final game in allStartedGames) {
-    final time = game.lastMoveTime ?? game.gameDay ?? game.dateStart;
-    if (time == null) continue;
+    final time =
+        game.lastMoveTime ?? game.gameDay ?? game.dateStart ?? unknownRoundTime;
     final existing = roundRecency[game.roundId];
     if (existing == null || time.isAfter(existing)) {
       roundRecency[game.roundId] = time;
@@ -658,14 +671,9 @@ List<Games> selectForYouEventGames({
   }
 
   // Sort round IDs by recency descending
-  final roundsByRecency = roundRecency.keys.toList()
-    ..sort((a, b) => roundRecency[b]!.compareTo(roundRecency[a]!));
-
-  if (roundsByRecency.isEmpty) {
-    // No timestamps at all — just sort everything and take 4
-    final sorted = _sortGamesLikeGamesTab(allStartedGames, pinnedIds);
-    return sorted.take(kGamesPerEvent).toList();
-  }
+  final roundsByRecency =
+      roundRecency.keys.toList()
+        ..sort((a, b) => roundRecency[b]!.compareTo(roundRecency[a]!));
 
   final primaryRoundId = roundsByRecency.first;
 
@@ -683,9 +691,10 @@ List<Games> selectForYouEventGames({
   for (final roundId in roundsByRecency.skip(1)) {
     if (result.length >= kGamesPerEvent) break;
 
-    final roundGames = allStartedGames
-        .where((g) => g.roundId == roundId && !selectedIds.contains(g.id))
-        .toList();
+    final roundGames =
+        allStartedGames
+            .where((g) => g.roundId == roundId && !selectedIds.contains(g.id))
+            .toList();
     final sortedRound = _sortGamesLikeGamesTab(roundGames, pinnedIds);
 
     for (final game in sortedRound) {

--- a/lib/providers/for_you_games_provider.dart
+++ b/lib/providers/for_you_games_provider.dart
@@ -373,172 +373,116 @@ final eventGamesProvider = FutureProvider.autoDispose.family<
   final tourRepository = ref.read(tourRepositoryProvider);
   final gamesStorage = ref.read(gamesLocalStorage);
 
-  // Get all tours for this event — prefer the live tour, then highest avgElo
-  String? selectedTourId;
-  String? tourFormatString;
+  // ── 1. Fetch all tours for this event ──
   List<Tour> eventTours = [];
   try {
     eventTours = await tourRepository.getTourByGroupId(eventId);
-    if (eventTours.isNotEmpty) {
-      // Prefer a live tour (ongoing games) over highest avgElo.
-      // This ensures knockout events (e.g. Speed Chess Championship) show
-      // the current stage (finals) instead of a completed stage that had
-      // more participants and therefore a higher average Elo.
-      final liveTourIds =
-          ref.read(liveTourIdProvider).valueOrNull ?? <String>[];
-      final liveTour = eventTours.firstWhereOrNull(
-        (t) => liveTourIds.contains(t.id),
-      );
-
-      if (liveTour != null) {
-        selectedTourId = liveTour.id;
-        tourFormatString = liveTour.info.format;
-        debugPrint(
-          '[ForYou] Selected LIVE tour "${liveTour.name}" from ${eventTours.length} tours',
-        );
-      } else {
-        // No live tour — fall back to highest avgElo
-        eventTours.sort((a, b) => (b.avgElo ?? 0).compareTo(a.avgElo ?? 0));
-        selectedTourId = eventTours.first.id;
-        tourFormatString = eventTours.first.info.format;
-        debugPrint(
-          '[ForYou] Selected tour "${eventTours.first.name}" (avgElo: ${eventTours.first.avgElo}) from ${eventTours.length} tours',
-        );
-      }
-    }
   } catch (e) {
     debugPrint('[ForYou] Error fetching tours: $e');
   }
 
-  // Fallback: try getting tour IDs directly
-  if (selectedTourId == null) {
+  // ── 2. Order tours deterministically ──
+  // Live tours first, then by avgElo descending, then stable original order.
+  if (eventTours.isNotEmpty) {
+    final liveTourIds =
+        ref.read(liveTourIdProvider).valueOrNull ?? <String>[];
+
+    // Capture original indices for stable tie-breaking
+    final originalOrder = {
+      for (int i = 0; i < eventTours.length; i++) eventTours[i].id: i,
+    };
+
+    eventTours.sort((a, b) {
+      final aLive = liveTourIds.contains(a.id) ? 0 : 1;
+      final bLive = liveTourIds.contains(b.id) ? 0 : 1;
+      if (aLive != bLive) return aLive.compareTo(bLive);
+
+      final aElo = a.avgElo ?? 0;
+      final bElo = b.avgElo ?? 0;
+      if (aElo != bElo) return bElo.compareTo(aElo);
+
+      return (originalOrder[a.id] ?? 0).compareTo(originalOrder[b.id] ?? 0);
+    });
+
+    debugPrint(
+      '[ForYou] Ordered ${eventTours.length} tours for event $eventId: '
+      '${eventTours.map((t) => '"${t.name}" (elo:${t.avgElo}, live:${liveTourIds.contains(t.id)})').join(', ')}',
+    );
+  }
+
+  // Build the list of tour IDs to fetch games from
+  List<String> tourIdsToFetch = eventTours.map((t) => t.id).toList();
+  if (tourIdsToFetch.isEmpty) {
     try {
-      final tourIds = await groupBroadcastRepo.getTourIdsForGroupBroadcast(
+      tourIdsToFetch = await groupBroadcastRepo.getTourIdsForGroupBroadcast(
         eventId,
       );
-      if (tourIds.isNotEmpty) {
-        selectedTourId = tourIds.first;
-      }
     } catch (e) {
       debugPrint('[ForYou] Error fetching tour IDs: $e');
     }
   }
-
-  // Final fallback: use eventId as tourId
-  selectedTourId ??= eventId;
-
-  // Collect games from the selected tour - only those that have actually started
-  // Always use refresh() to get fresh data from network for For You tab
-  // This ensures we see new rounds immediately when they start
-  final allGames = <Games>[];
-  try {
-    final games = await gamesStorage.refresh(selectedTourId);
-    for (final game in games) {
-      // Only include games that have ACTUALLY started (have moves or finished)
-      if (_hasActuallyStarted(game) &&
-          game.players != null &&
-          game.players!.length >= 2) {
-        allGames.add(game);
-      }
-    }
-  } catch (e) {
-    debugPrint('[ForYou] Error fetching games for tour $selectedTourId: $e');
+  // Final fallback: use eventId as a tour ID
+  if (tourIdsToFetch.isEmpty) {
+    tourIdsToFetch = [eventId];
   }
 
-  // If the first-choice tour had no started games, try other tours in the group.
-  // This handles events like "Classical + Rapid & Blitz" where one tour might
-  // not have started yet while another already has games.
-  if (allGames.isEmpty && eventTours.length > 1) {
-    for (final tour in eventTours) {
-      if (tour.id == selectedTourId) continue; // already tried
-      try {
-        final games = await gamesStorage.refresh(tour.id);
-        for (final game in games) {
-          if (_hasActuallyStarted(game) &&
-              game.players != null &&
-              game.players!.length >= 2) {
-            allGames.add(game);
-          }
+  // ── 3. Fetch and filter started games from EVERY tour ──
+  // Always use refresh() to get fresh data from network for For You tab.
+  // This ensures we see new rounds immediately when they start.
+  final allStartedGames = <Games>[];
+  for (final tourId in tourIdsToFetch) {
+    try {
+      final games = await gamesStorage.refresh(tourId);
+      for (final game in games) {
+        if (_hasActuallyStarted(game) &&
+            game.players != null &&
+            game.players!.length >= 2) {
+          allStartedGames.add(game);
         }
-        if (allGames.isNotEmpty) {
-          selectedTourId = tour.id;
-          tourFormatString = tour.info.format;
-          debugPrint(
-            '[ForYou] Fallback to tour "${tour.name}" which has ${allGames.length} started games',
-          );
-          break;
-        }
-      } catch (e) {
-        debugPrint('[ForYou] Error fetching fallback tour ${tour.id}: $e');
       }
+    } catch (e) {
+      debugPrint('[ForYou] Error fetching games for tour $tourId: $e');
     }
   }
 
-  if (allGames.isEmpty) {
+  if (allStartedGames.isEmpty) {
     debugPrint('[ForYou] No games found for event $eventId');
     return [];
   }
 
-  // Collect pinned game IDs
+  debugPrint(
+    '[ForYou] Collected ${allStartedGames.length} started games across '
+    '${tourIdsToFetch.length} tours for event $eventId',
+  );
+
+  // ── 4. Aggregate pin IDs from ALL tours ──
   final pinnedIds = <String>[];
-  try {
-    final pinState = ref.read(gamesPinprovider(selectedTourId!));
-    pinnedIds.addAll(pinState.allPins);
-  } catch (e) {
-    // Pin provider might not be initialized, continue without pins
-  }
-
-  // Detect 1v1 match format (e.g., "12-game Match", "6-game Match").
-  // In match events each game has its own round slug (game-1, game-2, …),
-  // so the "latest round" filter would return only 1 game. Instead, show
-  // the most recent N games across the entire match.
-  if (_isMatchFormatEvent(tourFormatString, allGames)) {
-    debugPrint(
-      '[ForYou] Match format detected for event $eventId — showing latest games across all rounds',
-    );
-    final sortedGames = _sortGamesLikeGamesTab(allGames, pinnedIds);
-    final result = sortedGames.take(kGamesPerEvent).toList();
-    debugPrint(
-      '[ForYou] Selected ${result.length} games for match event $eventId (from ${allGames.length} total)',
-    );
-    return result;
-  }
-
-  // Find the latest round by time (most recent activity) rather than round number.
-  // This correctly handles events where rounds are played out of order or have
-  // non-standard naming (e.g., tiebreaks, knockout stages).
-  // Priority: lastMoveTime (precise) > gameDay (date-only, near-universal)
-  String? latestRoundId;
-  DateTime? latestTime;
-  for (final game in allGames) {
-    final time = game.lastMoveTime ?? game.gameDay;
-    if (time != null && (latestTime == null || time.isAfter(latestTime))) {
-      latestTime = time;
-      latestRoundId = game.roundId;
+  final seenPins = <String>{};
+  for (final tourId in tourIdsToFetch) {
+    try {
+      final pinState = ref.read(gamesPinprovider(tourId));
+      for (final pinId in pinState.allPins) {
+        if (seenPins.add(pinId)) {
+          pinnedIds.add(pinId);
+        }
+      }
+    } catch (e) {
+      // Pin provider might not be initialized for some tours
     }
   }
 
-  // Filter to only games from the latest round
-  final latestRoundGames =
-      latestRoundId != null
-          ? allGames.where((game) => game.roundId == latestRoundId).toList()
-          : allGames;
+  // ── 5. Collect format strings and select games ──
+  final formatStrings = eventTours.map((t) => t.info.format).toList();
 
-  debugPrint(
-    '[ForYou] Latest round by time: $latestRoundId with ${latestRoundGames.length} games',
+  final result = selectForYouEventGames(
+    allStartedGames: allStartedGames,
+    pinnedIds: pinnedIds,
+    formatStrings: formatStrings,
   );
 
-  if (latestRoundGames.isEmpty) {
-    return [];
-  }
-
-  // Sort using the SAME logic as Games tab
-  final sortedGames = _sortGamesLikeGamesTab(latestRoundGames, pinnedIds);
-
-  // Return first 4 games
-  final result = sortedGames.take(kGamesPerEvent).toList();
   debugPrint(
-    '[ForYou] Selected ${result.length} games for event $eventId (from ${latestRoundGames.length} in round $latestRoundId)',
+    '[ForYou] Selected ${result.length} games for event $eventId '
+    '(from ${allStartedGames.length} started across ${tourIdsToFetch.length} tours)',
   );
   return result;
 });
@@ -660,6 +604,99 @@ int _extractGameNumber(String roundSlug) {
     caseSensitive: false,
   ).firstMatch(roundSlug);
   return int.tryParse(match?.group(1) ?? '0') ?? 0;
+}
+
+// ============================================================================
+// EVENT-LEVEL GAME SELECTOR — FILLS UP TO kGamesPerEvent FROM ALL TOURS
+// ============================================================================
+
+/// Pure selector: picks up to [kGamesPerEvent] started games from a combined
+/// pool of all tours in an event.
+///
+/// - [allStartedGames]: all started games from every tour, already filtered
+///   by [_hasActuallyStarted] and having >= 2 players.
+/// - [pinnedIds]: aggregated pin IDs from all tours (first-seen order, deduped).
+/// - [formatStrings]: format strings from all tours in the event (used to
+///   detect match format when ANY tour is a 1v1 match).
+///
+/// For match-format events: sort all games and take the first 4.
+/// For normal events: take from the primary round (most recent activity) first,
+/// then fill the deficit from remaining rounds ordered by recency.
+@visibleForTesting
+List<Games> selectForYouEventGames({
+  required List<Games> allStartedGames,
+  required List<String> pinnedIds,
+  required List<String?> formatStrings,
+}) {
+  if (allStartedGames.isEmpty) return [];
+
+  // Match format: check if ANY tour triggers match detection with the
+  // combined game pool. _isMatchFormatEvent already returns false when
+  // there are >2 unique players, so multi-tour events with different
+  // players correctly fall through to the normal path.
+  final isMatch = formatStrings.any(
+    (fmt) => _isMatchFormatEvent(fmt, allStartedGames),
+  );
+
+  if (isMatch) {
+    final sorted = _sortGamesLikeGamesTab(allStartedGames, pinnedIds);
+    return sorted.take(kGamesPerEvent).toList();
+  }
+
+  // --- Normal (non-match) path ---
+
+  // 1. Compute per-round recency: max activity timestamp per roundId.
+  //    Fallback chain: lastMoveTime > gameDay > dateStart.
+  final roundRecency = <String, DateTime>{};
+  for (final game in allStartedGames) {
+    final time = game.lastMoveTime ?? game.gameDay ?? game.dateStart;
+    if (time == null) continue;
+    final existing = roundRecency[game.roundId];
+    if (existing == null || time.isAfter(existing)) {
+      roundRecency[game.roundId] = time;
+    }
+  }
+
+  // Sort round IDs by recency descending
+  final roundsByRecency = roundRecency.keys.toList()
+    ..sort((a, b) => roundRecency[b]!.compareTo(roundRecency[a]!));
+
+  if (roundsByRecency.isEmpty) {
+    // No timestamps at all — just sort everything and take 4
+    final sorted = _sortGamesLikeGamesTab(allStartedGames, pinnedIds);
+    return sorted.take(kGamesPerEvent).toList();
+  }
+
+  final primaryRoundId = roundsByRecency.first;
+
+  // 2. Take games from the primary round first
+  final primaryRoundGames =
+      allStartedGames.where((g) => g.roundId == primaryRoundId).toList();
+  final sortedPrimary = _sortGamesLikeGamesTab(primaryRoundGames, pinnedIds);
+  final result = sortedPrimary.take(kGamesPerEvent).toList();
+
+  if (result.length >= kGamesPerEvent) return result;
+
+  // 3. Fill deficit from remaining rounds (by recency descending)
+  final selectedIds = result.map((g) => g.id).toSet();
+
+  for (final roundId in roundsByRecency.skip(1)) {
+    if (result.length >= kGamesPerEvent) break;
+
+    final roundGames = allStartedGames
+        .where((g) => g.roundId == roundId && !selectedIds.contains(g.id))
+        .toList();
+    final sortedRound = _sortGamesLikeGamesTab(roundGames, pinnedIds);
+
+    for (final game in sortedRound) {
+      if (result.length >= kGamesPerEvent) break;
+      if (selectedIds.add(game.id)) {
+        result.add(game);
+      }
+    }
+  }
+
+  return result;
 }
 
 // ============================================================================

--- a/lib/screens/group_event/widget/for_you_games_widget.dart
+++ b/lib/screens/group_event/widget/for_you_games_widget.dart
@@ -572,8 +572,8 @@ class _ForYouTabletColumnGames extends ConsumerWidget {
           return const SizedBox.shrink();
         }
 
-        // Take only first 4 games for tablet column view
-        final gameModels = allGameModels.take(4).toList();
+        // Take only first kGamesPerEvent games for tablet column view
+        final gameModels = allGameModels.take(kGamesPerEvent).toList();
 
         // Build 2-column grid of games (2 per row, max 2 rows = 4 games)
         // Wrap with animated slots for smooth transitions when games change

--- a/test/for_you_event_selection_test.dart
+++ b/test/for_you_event_selection_test.dart
@@ -29,7 +29,8 @@ Games _makeGame({
     dateStart: dateStart,
     status: status,
     boardNr: boardNr,
-    players: players ??
+    players:
+        players ??
         [
           Player(
             name: 'White $id',
@@ -191,6 +192,57 @@ void main() {
       expect(result.where((g) => g.tourId == 'tour-a').length, 2);
       // Filled from tour B
       expect(result.where((g) => g.tourId == 'tour-b').length, 2);
+    });
+
+    test('null-timestamp rounds remain eligible for backfill', () {
+      final now = DateTime(2025, 6, 1, 12, 0);
+
+      final games = [
+        _makeGame(
+          id: 'recent-1',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'recent-2',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 2,
+        ),
+        _makeGame(
+          id: 'unknown-1',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: null,
+          gameDay: null,
+          dateStart: null,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'unknown-2',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: null,
+          gameDay: null,
+          dateStart: null,
+          boardNr: 2,
+        ),
+      ];
+
+      final result = selectForYouEventGames(
+        allStartedGames: games,
+        pinnedIds: [],
+        formatStrings: ['9-round Swiss'],
+      );
+
+      expect(result.length, 4);
+      expect(result[0].roundId, 'r2');
+      expect(result[1].roundId, 'r2');
+      expect(result[2].roundId, 'r1');
+      expect(result[3].roundId, 'r1');
     });
 
     test('match format: returns latest 4 across entire match', () {

--- a/test/for_you_event_selection_test.dart
+++ b/test/for_you_event_selection_test.dart
@@ -1,0 +1,341 @@
+import 'package:chessever2/providers/for_you_games_provider.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Helper to create a minimal [Games] object for testing.
+Games _makeGame({
+  required String id,
+  required String roundId,
+  String roundSlug = 'round-1',
+  String tourId = 'tour-1',
+  String tourSlug = 'tour-slug',
+  String? lastMove = 'e2e4',
+  DateTime? lastMoveTime,
+  DateTime? gameDay,
+  DateTime? dateStart,
+  String status = '*',
+  int? boardNr,
+  List<Player>? players,
+}) {
+  return Games(
+    id: id,
+    roundId: roundId,
+    roundSlug: roundSlug,
+    tourId: tourId,
+    tourSlug: tourSlug,
+    lastMove: lastMove,
+    lastMoveTime: lastMoveTime,
+    gameDay: gameDay,
+    dateStart: dateStart,
+    status: status,
+    boardNr: boardNr,
+    players: players ??
+        [
+          Player(
+            name: 'White $id',
+            title: 'GM',
+            rating: 2700,
+            fideId: 1,
+            fed: 'USA',
+            clock: 0,
+            team: '',
+          ),
+          Player(
+            name: 'Black $id',
+            title: 'GM',
+            rating: 2700,
+            fideId: 2,
+            fed: 'USA',
+            clock: 0,
+            team: '',
+          ),
+        ],
+  );
+}
+
+void main() {
+  group('selectForYouEventGames', () {
+    test(
+      'latest round has 4+ started games — returns exactly 4 from that round',
+      () {
+        final now = DateTime(2025, 6, 1, 12, 0);
+        final games = List.generate(
+          6,
+          (i) => _makeGame(
+            id: 'game-$i',
+            roundId: 'round-5',
+            roundSlug: 'round-5',
+            lastMoveTime: now,
+            boardNr: i + 1,
+          ),
+        );
+
+        final result = selectForYouEventGames(
+          allStartedGames: games,
+          pinnedIds: [],
+          formatStrings: ['9-round Swiss'],
+        );
+
+        expect(result.length, 4);
+        expect(result.every((g) => g.roundId == 'round-5'), isTrue);
+      },
+    );
+
+    test('latest round has 2 games — fills from older rounds', () {
+      final now = DateTime(2025, 6, 1, 12, 0);
+      final older = now.subtract(const Duration(hours: 2));
+
+      final games = [
+        // 2 games in latest round
+        _makeGame(
+          id: 'g1',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'g2',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 2,
+        ),
+        // 3 games in older round
+        _makeGame(
+          id: 'g3',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: older,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'g4',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: older,
+          boardNr: 2,
+        ),
+        _makeGame(
+          id: 'g5',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: older,
+          boardNr: 3,
+        ),
+      ];
+
+      final result = selectForYouEventGames(
+        allStartedGames: games,
+        pinnedIds: [],
+        formatStrings: ['9-round Swiss'],
+      );
+
+      expect(result.length, 4);
+      // First 2 from latest round
+      expect(result[0].roundId, 'r2');
+      expect(result[1].roundId, 'r2');
+      // Next 2 filled from older round
+      expect(result[2].roundId, 'r1');
+      expect(result[3].roundId, 'r1');
+    });
+
+    test('multi-tour event: games from different tours fill to 4', () {
+      final now = DateTime(2025, 6, 1, 12, 0);
+
+      final games = [
+        // Tour A, round 3 (latest)
+        _makeGame(
+          id: 'a1',
+          roundId: 'r3a',
+          roundSlug: 'round-3',
+          tourId: 'tour-a',
+          lastMoveTime: now,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'a2',
+          roundId: 'r3a',
+          roundSlug: 'round-3',
+          tourId: 'tour-a',
+          lastMoveTime: now,
+          boardNr: 2,
+        ),
+        // Tour B, round 2 (slightly older)
+        _makeGame(
+          id: 'b1',
+          roundId: 'r2b',
+          roundSlug: 'round-2',
+          tourId: 'tour-b',
+          lastMoveTime: now.subtract(const Duration(minutes: 30)),
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'b2',
+          roundId: 'r2b',
+          roundSlug: 'round-2',
+          tourId: 'tour-b',
+          lastMoveTime: now.subtract(const Duration(minutes: 30)),
+          boardNr: 2,
+        ),
+      ];
+
+      final result = selectForYouEventGames(
+        allStartedGames: games,
+        pinnedIds: [],
+        formatStrings: ['9-round Swiss', '6-round Swiss'],
+      );
+
+      expect(result.length, 4);
+      // Primary round from tour A first
+      expect(result.where((g) => g.tourId == 'tour-a').length, 2);
+      // Filled from tour B
+      expect(result.where((g) => g.tourId == 'tour-b').length, 2);
+    });
+
+    test('match format: returns latest 4 across entire match', () {
+      final now = DateTime(2025, 6, 1, 12, 0);
+      final matchPlayers = [
+        Player(
+          name: 'Carlsen',
+          title: 'GM',
+          rating: 2830,
+          fideId: 1,
+          fed: 'NOR',
+          clock: 0,
+          team: '',
+        ),
+        Player(
+          name: 'Nepo',
+          title: 'GM',
+          rating: 2790,
+          fideId: 2,
+          fed: 'RUS',
+          clock: 0,
+          team: '',
+        ),
+      ];
+
+      // 6 games across 6 different rounds (game-1 through game-6)
+      final games = List.generate(
+        6,
+        (i) => _makeGame(
+          id: 'match-$i',
+          roundId: 'game-${i + 1}',
+          roundSlug: 'game-${i + 1}',
+          lastMoveTime: now.subtract(Duration(days: 5 - i)),
+          players: matchPlayers,
+          status: i < 5 ? '1/2-1/2' : '*',
+        ),
+      );
+
+      final result = selectForYouEventGames(
+        allStartedGames: games,
+        pinnedIds: [],
+        formatStrings: ['12-game Match'],
+      );
+
+      expect(result.length, 4);
+      // Should not be restricted to a single round
+      final roundIds = result.map((g) => g.roundId).toSet();
+      expect(roundIds.length, greaterThan(1));
+    });
+
+    test('event with fewer than 4 started games returns only available', () {
+      final now = DateTime(2025, 6, 1, 12, 0);
+
+      // 0 games
+      expect(
+        selectForYouEventGames(
+          allStartedGames: [],
+          pinnedIds: [],
+          formatStrings: [],
+        ),
+        isEmpty,
+      );
+
+      // 1 game
+      final result1 = selectForYouEventGames(
+        allStartedGames: [
+          _makeGame(id: 'g1', roundId: 'r1', lastMoveTime: now),
+        ],
+        pinnedIds: [],
+        formatStrings: ['Swiss'],
+      );
+      expect(result1.length, 1);
+
+      // 3 games
+      final result3 = selectForYouEventGames(
+        allStartedGames: List.generate(
+          3,
+          (i) => _makeGame(
+            id: 'g-$i',
+            roundId: 'r1',
+            roundSlug: 'round-1',
+            lastMoveTime: now,
+            boardNr: i,
+          ),
+        ),
+        pinnedIds: [],
+        formatStrings: ['Swiss'],
+      );
+      expect(result3.length, 3);
+    });
+
+    test('pinned game from non-primary round gets priority', () {
+      final now = DateTime(2025, 6, 1, 12, 0);
+      final older = now.subtract(const Duration(hours: 2));
+
+      final games = [
+        // 3 games in latest round
+        _makeGame(
+          id: 'new1',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'new2',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 2,
+        ),
+        _makeGame(
+          id: 'new3',
+          roundId: 'r2',
+          roundSlug: 'round-2',
+          lastMoveTime: now,
+          boardNr: 3,
+        ),
+        // 2 games in older round, one is pinned
+        _makeGame(
+          id: 'old-pinned',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: older,
+          boardNr: 1,
+        ),
+        _makeGame(
+          id: 'old2',
+          roundId: 'r1',
+          roundSlug: 'round-1',
+          lastMoveTime: older,
+          boardNr: 2,
+        ),
+      ];
+
+      final result = selectForYouEventGames(
+        allStartedGames: games,
+        pinnedIds: ['old-pinned'],
+        formatStrings: ['9-round Swiss'],
+      );
+
+      expect(result.length, 4);
+      // Primary round (r2) contributes 3 games; the pinned game from r1 fills
+      // the 4th slot. The pinned game should be present in the result.
+      expect(result.any((g) => g.id == 'old-pinned'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Update For You event selection to show up to four started boards per event instead of stopping at a single latest round or tour. When the primary round has fewer than four games, backfill from other started rounds or sibling tours in the same event while preserving pin priority, match-event behavior, and existing For You view modes. Also keep the 4-board cap consistent across phone and tablet rendering.