### PR TITLE
fix: prevent annotation badge from bleeding onto next move

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -240,6 +240,16 @@ extension LichessMoveAnnotationTypeX on LichessMoveAnnotationType {
   }
 }
 
+/// Look up the board annotation badge for the current move index.
+/// Returns null when the current move has no annotation.
+LichessMoveAnnotation? resolveBoardAnnotation(
+  Map<int, LichessMoveAnnotation> annotations,
+  int currentMoveIndex,
+) {
+  if (currentMoveIndex < 0) return null;
+  return annotations[currentMoveIndex];
+}
+
 String _moveSansSignature(List<String> moveSans) {
   // Normalize: strip check indicators (+, #) for consistent signature matching
   // Different PGN parsers may or may not include these symbols
@@ -6603,11 +6613,7 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard> {
           if (lichessAnnotations.isEmpty) return null;
           final currentMoveIndex =
               widget.chessBoardState.analysisState.currentMoveIndex;
-          if (currentMoveIndex < 0) return null;
-          final current = lichessAnnotations[currentMoveIndex];
-          if (current != null) return current;
-          final previous = lichessAnnotations[currentMoveIndex - 1];
-          return previous;
+          return resolveBoardAnnotation(lichessAnnotations, currentMoveIndex);
         })();
     final boardAnnotationSquare = _lastMoveDestinationSquare(
       widget.chessBoardState.analysisState.lastMove,

--- a/test/notation_token_builder_test.dart
+++ b/test/notation_token_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
+import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/chessboard/notation/notation_token_builder.dart';
 import 'package:chessever2/screens/chessboard/notation/notation_tree.dart';
 import 'package:chessever2/services/lichess_move_annotations_service.dart';
@@ -225,6 +226,43 @@ void main() {
       expect(moves[2].text, '2. Nf3');
       expect(moves[3].text, 'Nc6');
       expect(moves[4].text, '3. Bb5');
+    });
+  });
+
+  group('resolveBoardAnnotation', () {
+    const mistake = LichessMoveAnnotation(
+      type: LichessMoveAnnotationType.mistake,
+      comment: 'Mistake.',
+    );
+    const blunder = LichessMoveAnnotation(
+      type: LichessMoveAnnotationType.blunder,
+      comment: 'Blunder.',
+    );
+
+    test('returns null when currentMoveIndex is negative (start position)', () {
+      final annotations = <int, LichessMoveAnnotation>{0: mistake};
+      expect(resolveBoardAnnotation(annotations, -1), isNull);
+    });
+
+    test('returns annotation for the current move when it exists', () {
+      final annotations = <int, LichessMoveAnnotation>{
+        2: mistake,
+        5: blunder,
+      };
+      expect(resolveBoardAnnotation(annotations, 2), mistake);
+      expect(resolveBoardAnnotation(annotations, 5), blunder);
+    });
+
+    test('returns null when the current move has no annotation (no fallback to previous)', () {
+      // Move 2 has an annotation, but move 3 does not.
+      // The old code would fall back to move 2's annotation — this must NOT happen.
+      final annotations = <int, LichessMoveAnnotation>{2: mistake};
+      expect(resolveBoardAnnotation(annotations, 3), isNull);
+    });
+
+    test('returns null when annotations map is empty', () {
+      expect(resolveBoardAnnotation(const {}, 0), isNull);
+      expect(resolveBoardAnnotation(const {}, 5), isNull);
     });
   });
 }


### PR DESCRIPTION
Remove fallback logic that showed the previous move's annotation when the current move had none, causing question marks to appear on unannotated moves. Extract resolveBoardAnnotation into a testable function and add unit tests.