### PR TITLE
Fix castling annotation badge position

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -6448,6 +6448,17 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard> {
 
   Square? _lastMoveDestinationSquare(Move? lastMove) {
     if (lastMove == null) return null;
+    if (lastMove is NormalMove) {
+      // Castling is encoded as king-captures-rook in dartchess.
+      // Map to the king's actual destination square for annotation placement.
+      final from = lastMove.from;
+      final to = lastMove.to;
+      if (from == Square.e1 && to == Square.h1) return Square.g1;
+      if (from == Square.e1 && to == Square.a1) return Square.c1;
+      if (from == Square.e8 && to == Square.h8) return Square.g8;
+      if (from == Square.e8 && to == Square.a8) return Square.c8;
+      return to;
+    }
     final squares = lastMove.squares.toList();
     if (squares.isEmpty) return null;
     return squares.last;


### PR DESCRIPTION
Description:
When a castling move is marked as a blunder, mistake, or inaccuracy, the annotation badge is currently shown on the rook’s original square (h1, a1, h8, a8) instead of the king’s destination square (g1, c1, g8, c8).

This happens because dartchess encodes castling in king-captures-rook format, and the current destination-square logic uses the move’s raw to/last square value without accounting for castling.

This change updates the annotation-square resolution so castling moves map to the king’s actual destination:

White king-side castling: g1
White queen-side castling: c1
Black king-side castling: g8
Black queen-side castling: c8
Non-castling moves are unchanged.

Acceptance criteria:

Castling annotations appear on g1, c1, g8, or c8 as appropriate
Normal move annotations continue to appear on the correct destination square