### PR TITLE
Fix live game real-time updates for game cards and chessboard

### DIFF
--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -154,6 +154,7 @@ class ChessBoardScreenNotifierNew
   Timer? _autoSaveTimer;
   /// Snapshot of the game tree at last auto-save for diff detection
   String? _lastAutoSavedGameJson;
+  int _parseGeneration = 0;
 
   void _clearActiveEvalState() {
     _activeEvalKey = null;
@@ -685,6 +686,7 @@ class ChessBoardScreenNotifierNew
     // Don't reparse if already parsing or already parsed
     if (_hasParsedMoves) return;
     _hasParsedMoves = true;
+    final thisGeneration = ++_parseGeneration;
 
     // Get current state or null if in loading state (first initialization)
     final currentState = state.value;
@@ -769,7 +771,7 @@ class ChessBoardScreenNotifierNew
       // moves) to avoid falling back to placeholder/sample PGNs.
       if (pgn == null || pgn.trim().isEmpty) {
         final fetched = await fetchRemotePgn(requireMoves: false);
-        if (!mounted) return;
+        if (!mounted || thisGeneration != _parseGeneration) return;
         if (fetched != null) {
           pgn = fetched;
           game = game.copyWith(pgn: pgn);
@@ -838,7 +840,7 @@ class ChessBoardScreenNotifierNew
 
         hasAttemptedUpgrade = true;
         final upgraded = await fetchRemotePgn(requireMoves: true);
-        if (!mounted) return;
+        if (!mounted || thisGeneration != _parseGeneration) return;
         if (upgraded == null ||
             upgraded.trim().isEmpty ||
             upgraded == resolvedPgn) {
@@ -881,8 +883,8 @@ class ChessBoardScreenNotifierNew
         }
       }
 
-      // Only update state if still mounted
-      if (!mounted) return;
+      // Only update state if still mounted and not superseded by a newer parse
+      if (!mounted || thisGeneration != _parseGeneration) return;
 
       // Check if there are new unseen moves
       final lastSeenMoveCount =
@@ -1016,7 +1018,7 @@ class ChessBoardScreenNotifierNew
       state = AsyncValue.data(newState);
 
       // Update last seen move count when we auto-sync to the latest move
-      if (shouldForceLatestPosition) {
+      if (shouldForceLatestPosition || (wasViewingLastMove && hasNewMoves)) {
         _updateLastSeenMoveCount(currentMoveCount);
       }
       if (_isInitialLoad) {

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -1029,6 +1029,7 @@ class ChessBoardScreenNotifierNew
 
       if (_analysisGame == null) {
         await _initializeAnalysisBoard();
+        if (!mounted || thisGeneration != _parseGeneration) return;
       } else if (_analysisNavigator != null) {
         final liveAnalysisGame = _createChessGameFromPgn(resolvedPgn);
         _analysisNavigator!.updateWithLatestGame(liveAnalysisGame);

--- a/lib/screens/countryman_games_screen.dart
+++ b/lib/screens/countryman_games_screen.dart
@@ -73,9 +73,7 @@ class CountrymanGamesList extends ConsumerWidget {
 
               // Update game with unified live stream to keep FEN/PGN/clocks in sync
               if (game.gameStatus == GameStatus.ongoing) {
-                game = ref.watch(
-                  liveGameCardProvider((gameId: game.gameId, baseGame: game)),
-                );
+                game = watchLiveGame(ref, game);
               }
 
               return gamesListViewMode == GamesListViewMode.chessBoard

--- a/lib/screens/countrymen/tabs/countrymen_games_tab.dart
+++ b/lib/screens/countrymen/tabs/countrymen_games_tab.dart
@@ -1054,9 +1054,7 @@ class _CountrymenKeepAliveGameCardState
 
     // Watch live game updates for ongoing games
     // Use gameId as the stable key to prevent provider recreation
-    final liveGame = ref.watch(
-      liveGameCardProvider((gameId: widget.game.gameId, baseGame: widget.game)),
-    );
+    final liveGame = watchLiveGame(ref, widget.game);
     final gameId = liveGame.gameId;
 
     // Use ChessBoardFromFENNew directly with premium-guarded navigation

--- a/lib/screens/library/widgets/live_gamebase_search_game_card.dart
+++ b/lib/screens/library/widgets/live_gamebase_search_game_card.dart
@@ -41,9 +41,7 @@ class LiveGamebaseSearchGameCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Watch live game updates for ongoing games
     // Use gameId as the stable key to prevent provider recreation
-    final liveGame = ref.watch(
-      liveGameCardProvider((gameId: game.gameId, baseGame: game)),
-    );
+    final liveGame = watchLiveGame(ref, game);
 
     // Build updated games list with live data for navigation
     final updatedGames = List<GamesTourModel>.from(allGames);

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/board_game_card_wrapper_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/board_game_card_wrapper_widget.dart
@@ -31,9 +31,7 @@ class BoardGameCardWrapperWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Watch live game updates for ongoing games
     // Use gameId as the stable key to prevent provider recreation
-    final liveGame = ref.watch(
-      liveGameCardProvider((gameId: game.gameId, baseGame: game)),
-    );
+    final liveGame = watchLiveGame(ref, game);
 
     // Build updated games list with the live game data
     List<GamesTourModel> getUpdatedGamesList() {

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart
@@ -31,9 +31,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Watch live game updates for ongoing games
     // Use gameId as the stable key to prevent provider recreation
-    final liveGame = ref.watch(
-      liveGameCardProvider((gameId: game.gameId, baseGame: game)),
-    );
+    final liveGame = watchLiveGame(ref, game);
     final keyValue = 'game_${liveGame.gameId}';
 
     // Build updated games list with the live game data for navigation

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/grid_game_card_wrapper_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/grid_game_card_wrapper_widget.dart
@@ -31,9 +31,7 @@ class GridGameCardWrapperWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Watch live game updates for ongoing games
     // Use gameId as the stable key to prevent provider recreation
-    final liveGame = ref.watch(
-      liveGameCardProvider((gameId: game.gameId, baseGame: game)),
-    );
+    final liveGame = watchLiveGame(ref, game);
 
     // Build updated games list with the live game data
     List<GamesTourModel> getUpdatedGamesList() {

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/live_game_card_provider.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/live_game_card_provider.dart
@@ -2,19 +2,23 @@ import 'package:chessever2/screens/chessboard/provider/game_pgn_stream_provider.
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// Parameters for liveGameCardProvider.
-typedef LiveGameCardParams = ({String gameId, GamesTourModel baseGame});
+/// Stores the base game model for each game, keyed by gameId.
+/// Non-auto-dispose so it persists across provider rebuilds.
+final baseGameProvider =
+    StateProvider.family<GamesTourModel?, String>((ref, gameId) => null);
 
 /// Provider that combines the base game model with real-time updates from the stream.
 /// This is used by game cards to show live updates without entering the game screen.
 ///
+/// Keyed by gameId only (not baseGame) so that polling-triggered rebuilds of the
+/// parent widget don't recreate the provider and disrupt the Supabase stream.
+///
 /// Auto-disposes when the widget is scrolled out of view, which automatically
 /// cleans up the Supabase Realtime subscription for this game.
-final liveGameCardProvider = AutoDisposeProvider.family<
-  GamesTourModel,
-  LiveGameCardParams
->((ref, params) {
-  final (:gameId, :baseGame) = params;
+final liveGameCardProvider =
+    AutoDisposeProvider.family<GamesTourModel?, String>((ref, gameId) {
+  final baseGame = ref.read(baseGameProvider(gameId));
+  if (baseGame == null) return null;
 
   // For finished games, return the base game directly (no stream needed)
   if (baseGame.gameStatus.isFinished) {
@@ -79,3 +83,10 @@ final liveGameCardProvider = AutoDisposeProvider.family<
     error: (_, __) => baseGame,
   );
 });
+
+/// Helper that sets the base game and watches the live provider in one call.
+/// Returns the live game data, falling back to the base game if not yet available.
+GamesTourModel watchLiveGame(WidgetRef ref, GamesTourModel game) {
+  ref.read(baseGameProvider(game.gameId).notifier).state = game;
+  return ref.watch(liveGameCardProvider(game.gameId)) ?? game;
+}


### PR DESCRIPTION
- Decouple `liveGameCardProvider` family key from `baseGame` object so polling doesn't recreate the Supabase stream — game cards now update in real-time without manual refresh
- Update `lastSeenMoveCount` when auto-jumping via `wasViewingLastMove`, fixing stale new-move badges
- Add generation guard to `parseMoves()` to prevent concurrent calls from overwriting fresh state with stale data