### PR TITLE
Add per-user event notification mute toggle

### DIFF
--- a/lib/providers/event_mute_provider.dart
+++ b/lib/providers/event_mute_provider.dart
@@ -9,11 +9,11 @@ import 'auth_state_provider.dart';
 /// Whether the current user has muted notifications for a given event
 /// (keyed by groupBroadcastId). Returns `true` if muted.
 final eventMuteProvider =
-    AsyncNotifierProvider.family<EventMuteNotifier, bool, String>(
+    AutoDisposeAsyncNotifierProvider.family<EventMuteNotifier, bool, String>(
   EventMuteNotifier.new,
 );
 
-class EventMuteNotifier extends FamilyAsyncNotifier<bool, String> {
+class EventMuteNotifier extends AutoDisposeFamilyAsyncNotifier<bool, String> {
   SupabaseClient get _supabase => Supabase.instance.client;
   bool _listening = false;
 

--- a/lib/providers/event_mute_provider.dart
+++ b/lib/providers/event_mute_provider.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'auth_state_provider.dart';
+
+/// Whether the current user has muted notifications for a given event
+/// (keyed by groupBroadcastId). Returns `true` if muted.
+final eventMuteProvider =
+    AsyncNotifierProvider.family<EventMuteNotifier, bool, String>(
+  EventMuteNotifier.new,
+);
+
+class EventMuteNotifier extends FamilyAsyncNotifier<bool, String> {
+  SupabaseClient get _supabase => Supabase.instance.client;
+  bool _listening = false;
+
+  String get _groupBroadcastId => arg;
+
+  @override
+  Future<bool> build(String arg) async {
+    if (!_listening) {
+      _listening = true;
+      ref.listen(currentUserProvider, (prev, next) {
+        if (prev?.id != next?.id) {
+          unawaited(_reload());
+        }
+      });
+    }
+    return _fetchMuted();
+  }
+
+  Future<void> _reload() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(_fetchMuted);
+  }
+
+  String? _currentUserId() => _supabase.auth.currentUser?.id;
+
+  Future<bool> _fetchMuted() async {
+    final userId = _currentUserId();
+    if (userId == null) return false;
+
+    try {
+      final response = await _supabase
+          .from('user_muted_events')
+          .select('id')
+          .eq('user_id', userId)
+          .eq('group_broadcast_id', _groupBroadcastId)
+          .maybeSingle();
+
+      return response != null;
+    } catch (e) {
+      debugPrint('[EventMute] Error fetching mute state: $e');
+      return false;
+    }
+  }
+
+  Future<void> toggleMute() async {
+    final userId = _currentUserId();
+    if (userId == null) return;
+
+    final currentlyMuted = state.valueOrNull ?? false;
+    // Optimistic update
+    state = AsyncValue.data(!currentlyMuted);
+
+    try {
+      if (currentlyMuted) {
+        // Unmute: delete the row
+        await _supabase
+            .from('user_muted_events')
+            .delete()
+            .eq('user_id', userId)
+            .eq('group_broadcast_id', _groupBroadcastId);
+      } else {
+        // Mute: insert a row
+        await _supabase.from('user_muted_events').upsert({
+          'user_id': userId,
+          'group_broadcast_id': _groupBroadcastId,
+        }, onConflict: 'user_id,group_broadcast_id');
+      }
+    } catch (e) {
+      debugPrint('[EventMute] Error toggling mute: $e');
+      // Revert on failure
+      state = AsyncValue.data(currentlyMuted);
+    }
+  }
+}

--- a/lib/screens/tour_detail/games_tour/widgets/games_app_bar_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/games_app_bar_widget.dart
@@ -25,6 +25,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:chessever2/providers/event_mute_provider.dart';
+import 'package:chessever2/providers/auth_state_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
 
 // Enum for menu items to improve maintainability
@@ -33,6 +35,7 @@ enum MenuAction {
   showHideFinishedGames,
   collapseAllRounds,
   expandAllRounds,
+  disableNotifications,
 }
 
 class GamesAppBarWidget extends ConsumerStatefulWidget {
@@ -654,6 +657,89 @@ class _GamesAppBarWidgetState extends ConsumerState<GamesAppBarWidget>
                                           ),
                                         ),
                                       ),
+                                      if (tourData
+                                              .aboutTourModel
+                                              .groupBroadcastId
+                                              ?.isNotEmpty ==
+                                          true) ...[
+                                        PopupMenuDivider(
+                                          height: 1.h,
+                                          thickness: 0.5.w,
+                                          color: kDividerColor,
+                                        ),
+                                        () {
+                                          final groupBroadcastId =
+                                              tourData
+                                                  .aboutTourModel
+                                                  .groupBroadcastId!;
+                                          final isMuted =
+                                              ref
+                                                  .read(
+                                                    eventMuteProvider(
+                                                      groupBroadcastId,
+                                                    ),
+                                                  )
+                                                  .valueOrNull ??
+                                              false;
+                                          return PopupMenuItem<MenuAction>(
+                                            value:
+                                                MenuAction.disableNotifications,
+                                            onTap: () {
+                                              final isAuthenticated = ref.read(
+                                                isAuthenticatedProvider,
+                                              );
+                                              if (!isAuthenticated) {
+                                                ScaffoldMessenger.of(
+                                                  context,
+                                                ).showSnackBar(
+                                                  const SnackBar(
+                                                    content: Text(
+                                                      'Please sign in to manage notifications',
+                                                    ),
+                                                  ),
+                                                );
+                                                return;
+                                              }
+                                              ref
+                                                  .read(
+                                                    eventMuteProvider(
+                                                      groupBroadcastId,
+                                                    ).notifier,
+                                                  )
+                                                  .toggleMute();
+                                            },
+                                            child: SizedBox(
+                                              width: 200,
+                                              child: Row(
+                                                mainAxisAlignment:
+                                                    MainAxisAlignment
+                                                        .spaceBetween,
+                                                children: [
+                                                  Text(
+                                                    isMuted
+                                                        ? "Enable notifications"
+                                                        : "Disable notifications",
+                                                    style: AppTypography
+                                                        .textXsMedium
+                                                        .copyWith(
+                                                          color: kWhiteColor,
+                                                        ),
+                                                  ),
+                                                  Icon(
+                                                    isMuted
+                                                        ? Icons
+                                                            .notifications_outlined
+                                                        : Icons
+                                                            .notifications_off_outlined,
+                                                    color: kWhiteColor,
+                                                    size: 16.sp,
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                          );
+                                        }(),
+                                      ],
                                     ],
                                   );
                                 }


### PR DESCRIPTION
Allow users to mute/unmute notifications for individual events via the 3-dot menu. Adds user_muted_events table, Riverpod provider for mute state, and edge function filtering to suppress notifications for muted events.