### PR TITLE
Fix Notation and Duplicate Games

### DIFF
--- a/lib/repository/supabase/game/game_repository.dart
+++ b/lib/repository/supabase/game/game_repository.dart
@@ -85,7 +85,9 @@ class GameRepository extends BaseRepository {
           .eq('round_id', roundId)
           .order('id', ascending: true);
 
-      return (response as List).map((json) => Games.fromJson(json)).toList();
+      final games =
+          (response as List).map((json) => Games.fromJson(json)).toList();
+      return _deduplicateGames(games);
     });
   }
 
@@ -232,7 +234,9 @@ class GameRepository extends BaseRepository {
       debugPrint(
         '===== GameRepository: Received ${(response as List).length} games =====',
       );
-      return (response as List).map((json) => Games.fromJson(json)).toList();
+      final games =
+          (response as List).map((json) => Games.fromJson(json)).toList();
+      return _deduplicateGames(games);
     });
   }
 
@@ -1348,8 +1352,15 @@ class GameRepository extends BaseRepository {
 }
 
 List<Games> _decodeGamesInIsolate(List<String> gameJsonList) {
-  return gameJsonList.map((e) {
+  final games = gameJsonList.map((e) {
     final decoded = json.decode(e) as Map<String, dynamic>;
     return Games.fromJson(decoded);
   }).toList();
+  return _deduplicateGames(games);
+}
+
+/// Removes duplicate games by ID, keeping the first occurrence.
+List<Games> _deduplicateGames(List<Games> games) {
+  final seen = <String>{};
+  return games.where((game) => seen.add(game.id)).toList();
 }

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -7128,17 +7128,9 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
 
     final analysisGame = widget.state.analysisState.game;
     if (analysisGame == null) {
-      return Container(
-        alignment: Alignment.center,
-        padding: EdgeInsets.all(20.sp),
-        child: Text(
-          'No moves available for this game',
-          style: AppTypography.textXsMedium.copyWith(
-            color: kWhiteColor70,
-            fontWeight: FontWeight.normal,
-          ),
-        ),
-      );
+      // Game is still being initialized by the analysis navigator.
+      // Show loading skeleton instead of "No moves" to avoid flicker.
+      return _buildMovesLoadingSkeleton();
     }
 
     final params = ChessBoardProviderParams(
@@ -7638,6 +7630,25 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
       color: color,
       fontWeight: isCurrent ? FontWeight.bold : FontWeight.normal,
     );
+    final numberStyle = AppTypography.textXsMedium.copyWith(
+      color: kWhiteColor,
+      fontWeight: isCurrent ? FontWeight.bold : FontWeight.normal,
+    );
+
+    // Build move number prefix (e.g., "1. " or "12... ")
+    String moveNumberPrefix = '';
+    final node = token.node;
+    if (node != null && node.showMoveNumber) {
+      final bool isNullMove = node.move.san == '--';
+      final bool isFirstBlackInLine =
+          !node.isWhiteMove && node.showEllipsis;
+      if (isNullMove && !node.isWhiteMove) {
+        moveNumberPrefix = '${node.moveNumber}... ';
+      } else if (!isFirstBlackInLine) {
+        final separator = node.isWhiteMove ? '. ' : '... ';
+        moveNumberPrefix = '${node.moveNumber}$separator';
+      }
+    }
 
     // Build move text spans - either with figurine pieces or plain text
     final List<InlineSpan> moveSpans;
@@ -7647,9 +7658,17 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
         pieceAssets: pieceAssets,
         style: textStyle,
         pieceSize: 14.sp, // Slightly larger than text for clarity
+        numberStyle: numberStyle,
       );
     } else {
-      moveSpans = [TextSpan(text: token.text, style: textStyle)];
+      moveSpans = [
+        if (moveNumberPrefix.isNotEmpty)
+          TextSpan(text: moveNumberPrefix, style: numberStyle),
+        TextSpan(
+          text: node?.move.san ?? token.text,
+          style: textStyle,
+        ),
+      ];
     }
 
     // Determine annotation presentation: inline symbol or badge

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -7635,21 +7635,6 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
       fontWeight: isCurrent ? FontWeight.bold : FontWeight.normal,
     );
 
-    // Build move number prefix (e.g., "1. " or "12... ")
-    String moveNumberPrefix = '';
-    final node = token.node;
-    if (node != null && node.showMoveNumber) {
-      final bool isNullMove = node.move.san == '--';
-      final bool isFirstBlackInLine =
-          !node.isWhiteMove && node.showEllipsis;
-      if (isNullMove && !node.isWhiteMove) {
-        moveNumberPrefix = '${node.moveNumber}... ';
-      } else if (!isFirstBlackInLine) {
-        final separator = node.isWhiteMove ? '. ' : '... ';
-        moveNumberPrefix = '${node.moveNumber}$separator';
-      }
-    }
-
     // Build move text spans - either with figurine pieces or plain text
     final List<InlineSpan> moveSpans;
     if (useFigurine && pieceAssets != null) {
@@ -7661,13 +7646,24 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
         numberStyle: numberStyle,
       );
     } else {
+      // Derive move-number prefix directly from the formatted move text to
+      // avoid duplicating move-number rules defined in the notation builder.
+      final String fullText = token.text;
+      String prefix = '';
+      String body = fullText;
+
+      // Match patterns like "1. e4", "12... Nf6", etc.
+      final prefixRegex = RegExp(r'^(\d+\.{1,3}\s+)(.*)$');
+      final match = prefixRegex.firstMatch(fullText);
+      if (match != null) {
+        prefix = match.group(1)!;
+        body = match.group(2)!;
+      }
+
       moveSpans = [
-        if (moveNumberPrefix.isNotEmpty)
-          TextSpan(text: moveNumberPrefix, style: numberStyle),
-        TextSpan(
-          text: node?.move.san ?? token.text,
-          style: textStyle,
-        ),
+        if (prefix.isNotEmpty)
+          TextSpan(text: prefix, style: numberStyle),
+        TextSpan(text: body, style: textStyle),
       ];
     }
 

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -1344,13 +1344,16 @@ class ChessBoardScreenNotifierNew
     final updatedState = ref.read(chessGameNavigatorProvider(_analysisGame!));
     _syncAnalysisFromNavigator(updatedState);
 
-    // Update live-follow flag based on whether the user landed on the last move
+    // Update live-follow flag based on whether the user landed on the last mainline move.
+    // Only resume when on the mainline (movePointer.length == 1), not at the end of a variation,
+    // otherwise the next incoming live move would yank the user out of their variation.
     if (game.gameStatus.isOngoing) {
       final navState = ref.read(chessGameNavigatorProvider(_analysisGame!));
       final line = navState.currentLine;
       final isAtTail =
           line != null &&
           navState.movePointer.isNotEmpty &&
+          navState.movePointer.length == 1 &&
           navState.movePointer.last == line.length - 1;
       _isFollowingLive = isAtTail;
     }
@@ -3593,12 +3596,15 @@ class ChessBoardScreenNotifierNew
     final updatedState = ref.read(chessGameNavigatorProvider(_analysisGame!));
     _syncAnalysisFromNavigator(updatedState);
 
-    // If user stepped forward to the last move, resume auto-following live moves
+    // If user stepped forward to the last move of the mainline, resume auto-following live moves.
+    // Only resume when on the mainline (movePointer.length == 1), not at the end of a variation,
+    // otherwise the next incoming live move would yank the user out of their variation.
     if (game.gameStatus.isOngoing) {
       final line = updatedState.currentLine;
       final isAtTail =
           line != null &&
           updatedState.movePointer.isNotEmpty &&
+          updatedState.movePointer.length == 1 &&
           updatedState.movePointer.last == line.length - 1;
       if (isAtTail) {
         _isFollowingLive = true;
@@ -3715,14 +3721,15 @@ class ChessBoardScreenNotifierNew
 
   void jumpToEnd() {
     _releaseLog('🎯 JUMP TO END called');
-    // User explicitly jumped to end — resume auto-following live moves
-    _isFollowingLive = true;
     final currentState = state.value;
     if (currentState == null) return;
 
     if (currentState.isAnalysisMode) {
       // Check if variant is selected
       if (currentState.selectedVariantIndex != null) {
+        // Jumping within a variant — do NOT auto-follow live mainline moves,
+        // otherwise the next incoming move would yank the user out of the variant.
+        _isFollowingLive = false;
         _releaseLog(
           '🎯 JUMP TO END: Variant selected, playing all variant moves',
         );
@@ -3751,6 +3758,8 @@ class ChessBoardScreenNotifierNew
           ),
         );
       } else {
+        // Jumping to mainline tail — resume auto-following live moves
+        _isFollowingLive = true;
         _releaseLog('🎯 JUMP TO END: No variant, jumping to game end');
         _analysisNavigator?.goToTail();
       }
@@ -3763,6 +3772,8 @@ class ChessBoardScreenNotifierNew
         _syncAnalysisFromNavigator(updatedState);
       }
     } else {
+      // Non-analysis mode — resume auto-following live moves
+      _isFollowingLive = true;
       goToMove(currentState.allMoves.length - 1);
     }
   }

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -908,7 +908,8 @@ class ChessBoardScreenNotifierNew
 
       // Use instance-level initial load flag instead of global lastSeenMoveCount
       final isFirstLoad = _isInitialLoad;
-      final wasViewingLastMove =
+      // Raw navigator state: was the UI actually on the last move index?
+      final baseWasViewingLastMove =
           currentState != null &&
           currentState.analysisState.allMoves.isNotEmpty &&
           currentState.analysisState.currentMoveIndex ==
@@ -919,7 +920,10 @@ class ChessBoardScreenNotifierNew
       // conditions where _syncAnalysisFromNavigator temporarily corrupts
       // analysisState.currentMoveIndex between updateWithLatestGame and goToTail.
       final isFollowing =
-          game.gameStatus.isOngoing ? _isFollowingLive : wasViewingLastMove;
+          game.gameStatus.isOngoing ? _isFollowingLive : baseWasViewingLastMove;
+      // Downstream bookkeeping (e.g. lastSeenMoveCount) historically keyed off
+      // "wasViewingLastMove". Use isFollowing so auto-follow advances the count.
+      final wasViewingLastMove = isFollowing;
       final shouldMarkAsUnseen =
           hasNewMoves && !shouldForceLatestPosition && !isFollowing;
 

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -150,6 +150,12 @@ class ChessBoardScreenNotifierNew
   ChessGameNavigatorStateManager? _analysisStateManager;
   ProviderSubscription<ChessGameNavigatorState>? _navigatorSubscription;
   bool _isInitialLoad = true;
+  /// Tracks whether the user is auto-following the latest live move.
+  /// Set to false when the user manually navigates backwards, true when they
+  /// return to the last move. Prevents race conditions between parseMoves()
+  /// and _syncAnalysisFromNavigator() that caused the board to jump to an
+  /// early move during live games.
+  bool _isFollowingLive = true;
   ChessBoardStateNew? _pvPreviewSnapshot;
   Timer? _autoSaveTimer;
   /// Snapshot of the game tree at last auto-save for diff detection
@@ -623,6 +629,11 @@ class ChessBoardScreenNotifierNew
           // CRITICAL: Update state immediately with new game object to show clock changes
           state = AsyncValue.data(currentState.copyWith(game: game));
 
+          // Stop auto-following when game finishes
+          if (game.gameStatus.isFinished) {
+            _isFollowingLive = false;
+          }
+
           // Only reparse moves if PGN actually changed (new moves arrived)
           if (pgnChanged) {
             _releaseLog('🆕 NEW MOVES: Reparsing PGN for game ${game.gameId}');
@@ -902,8 +913,13 @@ class ChessBoardScreenNotifierNew
               currentState.analysisState.allMoves.length - 1;
       final shouldForceLatestPosition =
           isFirstLoad || (!hadMovesPreviously && hasMovesNow);
+      // For live games, use the explicit _isFollowingLive flag to avoid race
+      // conditions where _syncAnalysisFromNavigator temporarily corrupts
+      // analysisState.currentMoveIndex between updateWithLatestGame and goToTail.
+      final isFollowing =
+          game.gameStatus.isOngoing ? _isFollowingLive : wasViewingLastMove;
       final shouldMarkAsUnseen =
-          hasNewMoves && !shouldForceLatestPosition && !wasViewingLastMove;
+          hasNewMoves && !shouldForceLatestPosition && !isFollowing;
 
       // Determine which move index to display:
       // - On initial load of a finished game: start at beginning (-1)
@@ -924,7 +940,7 @@ class ChessBoardScreenNotifierNew
         newMoveIndex = -1;
       } else if (shouldForceLatestPosition) {
         newMoveIndex = lastMoveIndex;
-      } else if (wasViewingLastMove) {
+      } else if (isFollowing) {
         newMoveIndex = lastMoveIndex;
       } else {
         newMoveIndex =
@@ -955,7 +971,7 @@ class ChessBoardScreenNotifierNew
                 isLoadingMoves: false,
                 evaluation: null, // Reset evaluation to trigger new calculation
                 isEvaluating: true, // Show loading indicator while evaluating
-                analysisState: AnalysisBoardState(
+                analysisState: currentState.analysisState.copyWith(
                   startingPosition: startingPos,
                   currentMoveIndex: newMoveIndex,
                   position: displayPosition,
@@ -1031,11 +1047,12 @@ class ChessBoardScreenNotifierNew
         final liveAnalysisGame = _createChessGameFromPgn(resolvedPgn);
         _analysisNavigator!.updateWithLatestGame(liveAnalysisGame);
 
-        // CRITICAL: When user was viewing the last move and new moves arrived,
+        // CRITICAL: When user is following live moves and new moves arrived,
         // jump the navigator to the tail so the animation plays.
-        // Without this, the navigator stays at the old position and the
-        // listener sync would reset the state back to the old move.
-        if (wasViewingLastMove && hasNewMoves) {
+        // Uses _isFollowingLive for live games to avoid race conditions where
+        // _syncAnalysisFromNavigator (triggered by updateWithLatestGame above)
+        // temporarily sets currentMoveIndex to the old position.
+        if (isFollowing && hasNewMoves) {
           _analysisNavigator!.goToTail();
         }
 
@@ -1170,6 +1187,13 @@ class ChessBoardScreenNotifierNew
       // Sync state after navigation
       final updatedState = ref.read(chessGameNavigatorProvider(_analysisGame!));
       _syncAnalysisFromNavigator(updatedState);
+
+      // Update live-follow flag based on whether user navigated to the last move
+      if (game.gameStatus.isOngoing) {
+        final allMoveCount =
+            updatedState.currentLine?.length ?? 0;
+        _isFollowingLive = moveIndex >= 0 && moveIndex == allMoveCount - 1;
+      }
       return;
     }
 
@@ -1316,6 +1340,17 @@ class ChessBoardScreenNotifierNew
     // The ref.listen callback may not fire synchronously.
     final updatedState = ref.read(chessGameNavigatorProvider(_analysisGame!));
     _syncAnalysisFromNavigator(updatedState);
+
+    // Update live-follow flag based on whether the user landed on the last move
+    if (game.gameStatus.isOngoing) {
+      final navState = ref.read(chessGameNavigatorProvider(_analysisGame!));
+      final line = navState.currentLine;
+      final isAtTail =
+          line != null &&
+          navState.movePointer.isNotEmpty &&
+          navState.movePointer.last == line.length - 1;
+      _isFollowingLive = isAtTail;
+    }
   }
 
   ChessGameNavigatorState? navigatorStateSnapshot() {
@@ -3554,6 +3589,18 @@ class ChessBoardScreenNotifierNew
     // (it watches navigator directly) while the board state lags behind.
     final updatedState = ref.read(chessGameNavigatorProvider(_analysisGame!));
     _syncAnalysisFromNavigator(updatedState);
+
+    // If user stepped forward to the last move, resume auto-following live moves
+    if (game.gameStatus.isOngoing) {
+      final line = updatedState.currentLine;
+      final isAtTail =
+          line != null &&
+          updatedState.movePointer.isNotEmpty &&
+          updatedState.movePointer.last == line.length - 1;
+      if (isAtTail) {
+        _isFollowingLive = true;
+      }
+    }
   }
 
   /// Navigate backward in analysis mode (through main line when no variant selected)
@@ -3600,6 +3647,8 @@ class ChessBoardScreenNotifierNew
 
     // CRITICAL: Reset cancellation flag before navigation to ensure evaluation happens
     _cancelEvaluation = false;
+    // User manually navigated backwards — stop auto-following live moves
+    _isFollowingLive = false;
 
     final navigatorState = ref.read(chessGameNavigatorProvider(_analysisGame!));
     _releaseLog(
@@ -3623,6 +3672,8 @@ class ChessBoardScreenNotifierNew
   void jumpToStart() {
     _releaseLog('🎯 JUMP TO START called');
     _exitPvPreviewIfActive();
+    // User manually navigated to start — stop auto-following live moves
+    _isFollowingLive = false;
     final currentState = state.value;
     if (currentState == null) return;
 
@@ -3661,6 +3712,8 @@ class ChessBoardScreenNotifierNew
 
   void jumpToEnd() {
     _releaseLog('🎯 JUMP TO END called');
+    // User explicitly jumped to end — resume auto-following live moves
+    _isFollowingLive = true;
     final currentState = state.value;
     if (currentState == null) return;
 
@@ -3713,6 +3766,7 @@ class ChessBoardScreenNotifierNew
 
   void resetGame() {
     _exitPvPreviewIfActive();
+    _isFollowingLive = false;
     if (state.value?.isAnalysisMode == true) {
       _analysisNavigator?.goToHead();
 

--- a/lib/utils/figurine_notation.dart
+++ b/lib/utils/figurine_notation.dart
@@ -22,14 +22,17 @@ List<InlineSpan> buildFigurineSpans({
   required PieceAssets pieceAssets,
   required TextStyle style,
   required double pieceSize,
+  TextStyle? numberStyle,
 }) {
   final spans = <InlineSpan>[];
   final buffer = StringBuffer();
   var i = 0;
+  var pastMoveNumber = false;
 
   void flushBuffer() {
     if (buffer.isNotEmpty) {
-      spans.add(TextSpan(text: buffer.toString(), style: style));
+      final effectiveStyle = pastMoveNumber ? style : (numberStyle ?? style);
+      spans.add(TextSpan(text: buffer.toString(), style: effectiveStyle));
       buffer.clear();
     }
   }
@@ -38,16 +41,22 @@ List<InlineSpan> buildFigurineSpans({
     final char = text[i];
 
     // Track if we're past move number (e.g., "1. " or "12... ")
-    if (char.contains(RegExp(r'[0-9.]'))) {
+    if (!pastMoveNumber && char.contains(RegExp(r'[0-9.]'))) {
       buffer.write(char);
       i++;
       continue;
     }
 
-    if (char == ' ') {
+    if (!pastMoveNumber && char == ' ') {
       buffer.write(char);
       i++;
       continue;
+    }
+
+    // We've reached the actual move notation
+    if (!pastMoveNumber) {
+      flushBuffer();
+      pastMoveNumber = true;
     }
 
     // Check if this is a piece letter that should be converted

--- a/lib/utils/figurine_notation.dart
+++ b/lib/utils/figurine_notation.dart
@@ -41,7 +41,8 @@ List<InlineSpan> buildFigurineSpans({
     final char = text[i];
 
     // Track if we're past move number (e.g., "1. " or "12... ")
-    if (!pastMoveNumber && char.contains(RegExp(r'[0-9.]'))) {
+    final c = char.codeUnitAt(0);
+    if (!pastMoveNumber && (char == '.' || (c >= 48 && c <= 57))) {
       buffer.write(char);
       i++;
       continue;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 10.9.3+1093
+version: 10.9.4+1094
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
1. Add _deduplicateGames helper that filters by game ID, applied in _decodeGamesInIsolate (covers ~24 methods) and the two inline-decode methods (getGamesByRoundId, getGamesByPlayerName).
2. Move numbers (e.g., "1.", "12...") were being colored the same as the move text in variation and annotation contexts. Split the move number prefix from the SAN move so only the actual move notation receives the variation/annotation color while numbers stay white.
3. Add _isFollowingLive flag to explicitly track whether the user is auto-following live moves. Previously, this was inferred from analysisState.currentMoveIndex which could be temporarily corrupted by _syncAnalysisFromNavigator during the updateWithLatestGame → goToTail sequence, causing wasViewingLastMove to return false and permanently breaking auto-follow for subsequent moves.
4. parseMoves() was creating a new AnalysisBoardState without carrying forward the game field, resetting it to null on every live update. The widget would briefly render "No moves available" until the navigator listener restored it. Now uses copyWith to preserve existing state, and shows a loading skeleton instead of an error message during initial navigator initialization.