### PR TITLE
fix: favorites not pinning in events

### DIFF
--- a/lib/screens/favorites/favorite_players_provider.dart
+++ b/lib/screens/favorites/favorite_players_provider.dart
@@ -102,17 +102,19 @@ class FavoritePlayersNotifier
   Future<bool> toggleFavorite(PlayerStandingModel player) async {
     final currentState = state.valueOrNull;
     if (currentState == null) {
-      if (player.fideId != null) {
-        return (await _favoritesService.getFavoritePlayers()).any(
-          (p) => p.fideId == player.fideId,
-        );
-      }
-      return false;
+      final favorites = await _favoritesService.getFavoritePlayers();
+      return favorites.any(
+        (p) =>
+            p.name == player.name ||
+            (player.fideId != null && p.fideId == player.fideId),
+      );
     }
 
-    final isFav = player.fideId != null
-        ? currentState.players.any((p) => p.fideId == player.fideId)
-        : currentState.players.any((p) => p.name == player.name);
+    final isFav = currentState.players.any(
+      (p) =>
+          p.name == player.name ||
+          (player.fideId != null && p.fideId == player.fideId),
+    );
 
     if (isFav) {
       await removeFavorite(player);

--- a/lib/screens/favorites/favorite_players_provider.dart
+++ b/lib/screens/favorites/favorite_players_provider.dart
@@ -100,35 +100,33 @@ class FavoritePlayersNotifier
   }
 
   Future<bool> toggleFavorite(PlayerStandingModel player) async {
-    if (player.fideId != null) {
-      final currentState = state.valueOrNull;
-      if (currentState == null) {
+    final currentState = state.valueOrNull;
+    if (currentState == null) {
+      if (player.fideId != null) {
         return (await _favoritesService.getFavoritePlayers()).any(
           (p) => p.fideId == player.fideId,
         );
       }
-
-      final isFav = currentState.players.any((p) => p.fideId == player.fideId);
-
-      if (isFav) {
-        await removeFavorite(player);
-        // Increment favorites version to trigger immediate games re-sort
-        ref.read(favoritesVersionProvider.notifier).state++;
-        debugPrint(
-          '[FavoritePlayers] Incremented favorites version after removing favorite',
-        );
-        return false;
-      } else {
-        await addFavorite(player);
-        // Increment favorites version to trigger immediate games re-sort
-        ref.read(favoritesVersionProvider.notifier).state++;
-        debugPrint(
-          '[FavoritePlayers] Incremented favorites version after adding favorite',
-        );
-        return true;
-      }
+      return false;
     }
-    return false;
+
+    final isFav = player.fideId != null
+        ? currentState.players.any((p) => p.fideId == player.fideId)
+        : currentState.players.any((p) => p.name == player.name);
+
+    if (isFav) {
+      await removeFavorite(player);
+    } else {
+      await addFavorite(player);
+    }
+
+    // Always increment favorites version to trigger immediate games re-sort,
+    // regardless of whether the player has a fideId.
+    ref.read(favoritesVersionProvider.notifier).state++;
+    debugPrint(
+      '[FavoritePlayers] Incremented favorites version after ${isFav ? 'removing' : 'adding'} favorite',
+    );
+    return !isFav;
   }
 
   Future<void> addFavorite(PlayerStandingModel player) async {

--- a/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
@@ -57,12 +57,20 @@ class _AutoPinLogController {
                 return players.any(
                       (player) =>
                           player.name == games.whitePlayer.name &&
-                          games.whitePlayer.federation == player.countryCode,
+                          (player.countryCode.isEmpty ||
+                              CountryCodeMatcher.matches(
+                                games.whitePlayer.federation,
+                                player.countryCode,
+                              )),
                     ) ||
                     players.any(
                       (player) =>
                           player.name == games.blackPlayer.name &&
-                          games.blackPlayer.federation == player.countryCode,
+                          (player.countryCode.isEmpty ||
+                              CountryCodeMatcher.matches(
+                                games.blackPlayer.federation,
+                                player.countryCode,
+                              )),
                     );
               })
               .map((e) => e.gameId);

--- a/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart
@@ -59,7 +59,7 @@ class _AutoPinLogController {
                           player.name == games.whitePlayer.name &&
                           (player.countryCode.isEmpty ||
                               CountryCodeMatcher.matches(
-                                games.whitePlayer.federation,
+                                games.whitePlayer.countryCode,
                                 player.countryCode,
                               )),
                     ) ||
@@ -68,7 +68,7 @@ class _AutoPinLogController {
                           player.name == games.blackPlayer.name &&
                           (player.countryCode.isEmpty ||
                               CountryCodeMatcher.matches(
-                                games.blackPlayer.federation,
+                                games.blackPlayer.countryCode,
                                 player.countryCode,
                               )),
                     );


### PR DESCRIPTION
- Country code comparison used `==` instead of `CountryCodeMatcher.matches()`, causing ISO2/ISO3 mismatches (e.g. "GB" vs "ENG") to never pin
- Empty `countryCode` on a saved favorite now falls back to name-only match
- `toggleFavorite()` fideId guard was blocking `favoritesVersionProvider` bump for players without a fideId, leaving auto-pins stale