### PR TITLE
fix: shared game links, PGN copy, and share across all game sources

### DIFF
--- a/lib/repository/supabase/game/game_repository.dart
+++ b/lib/repository/supabase/game/game_repository.dart
@@ -128,15 +128,48 @@ class GameRepository extends BaseRepository {
     });
   }
 
-  // Fetch game by ID
+  // Fetch game by its Supabase UUID (games.id column).
   Future<Games> getGameById(String id) async {
-    print('Fetching game by ID: $id');
+    debugPrint('Fetching game by ID: $id');
     return handleApiCall(() async {
-      final response =
-          await supabase.from('games').select().eq('id', id).single();
+      final response = await supabase
+          .from('games')
+          .select(_gameListSelectColumns)
+          .eq('id', id)
+          .single();
 
       return Games.fromJson(response);
     });
+  }
+
+  // Fetch game by Lichess short ID (games.lichess_id column).
+  Future<Games> getGameByLichessId(String lichessId) async {
+    debugPrint('Fetching game by Lichess ID: $lichessId');
+    return handleApiCall(() async {
+      final response = await supabase
+          .from('games')
+          .select(_gameListSelectColumns)
+          .eq('lichess_id', lichessId)
+          .single();
+
+      return Games.fromJson(response);
+    });
+  }
+
+  static final _uuidPattern = RegExp(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+    caseSensitive: false,
+  );
+
+  /// Resolves a game from either a Supabase UUID or a Lichess short ID.
+  /// UUID  → queries games.id
+  /// Other → queries games.lichess_id (e.g. "4uVwSr9q")
+  Future<Games> getGameByAnyId(String id) async {
+    final trimmed = id.trim();
+    if (_uuidPattern.hasMatch(trimmed)) {
+      return getGameById(trimmed);
+    }
+    return getGameByLichessId(trimmed);
   }
 
   // Get all games for a specific player by fideId

--- a/lib/repository/supabase/game/games.dart
+++ b/lib/repository/supabase/game/games.dart
@@ -138,7 +138,10 @@ class Games {
                 : null,
         status: json['status'] as String?,
         pgn: json['pgn'] as String?,
-        search: (json['search'] as List).map((e) => e as String).toList(),
+        search:
+            json['search'] != null
+                ? (json['search'] as List).map((e) => e as String).toList()
+                : null,
         boardNr:
             json['board_nr'] != null ? (json['board_nr'] as num).toInt() : null,
         lastMoveTime:

--- a/lib/screens/board_editor/board_editor_screen.dart
+++ b/lib/screens/board_editor/board_editor_screen.dart
@@ -131,6 +131,7 @@ class _BoardEditorScreenState extends ConsumerState<BoardEditorScreen> {
 
     final game = GamesTourModel(
       gameId: 'editor_$timestamp',
+      source: GameSource.boardEditor,
       whitePlayer: whitePlayer,
       blackPlayer: blackPlayer,
       whiteTimeDisplay: '--:--',

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -76,6 +76,7 @@ import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
 import 'package:chessever2/repository/gamebase/search/gamebase_search_models.dart';
 import 'package:chessever2/screens/gamebase/models/models.dart';
 import 'package:chessever2/screens/gamebase/providers/gamebase_providers.dart';
+import 'package:chessever2/screens/chessboard/utils/game_share_utils.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/library/utils/gamebase_game_to_games_tour_model.dart';
 import 'package:chessever2/screens/player_profile/player_profile_data_source.dart';
@@ -2497,6 +2498,26 @@ class _AppBar extends ConsumerStatefulWidget implements PreferredSizeWidget {
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 }
 
+class _ResolvedAppBarShareData {
+  final String pgn;
+  final String? shareUrl;
+  final GameShareSnapshot snapshot;
+  final double? evaluation;
+  final int mate;
+  final bool isFlipped;
+  final bool isAtGameEnd;
+
+  const _ResolvedAppBarShareData({
+    required this.pgn,
+    required this.shareUrl,
+    required this.snapshot,
+    required this.evaluation,
+    required this.mate,
+    required this.isFlipped,
+    required this.isAtGameEnd,
+  });
+}
+
 class _AppBarState extends ConsumerState<_AppBar> {
   Future<void> _showSaveAnalysisDialog() async {
     final allowed = await requireFullAuthGuard(context);
@@ -2668,102 +2689,130 @@ class _AppBarState extends ConsumerState<_AppBar> {
     );
   }
 
-  void copyPgnBtnClicked() async {
+  Future<String?> _fetchGamebaseSharePgn(String gameId) async {
     try {
-      String? pgn;
-      final params = ChessBoardProviderParams(
-        game: widget.game,
-        index: widget.currentGameIndex,
-      );
-      final boardState = ref.read(chessBoardScreenProviderNew(params));
-      final analysisGame = boardState.valueOrNull?.analysisState.game;
-      if (analysisGame != null) {
-        pgn = exportGameToPgn(analysisGame);
+      final gameWithPgn = await ref
+          .read(gamebaseRepositoryProvider)
+          .getGameWithPgn(gameId);
+      if (gameWithPgn == null) return null;
+
+      final built = buildPgnFromGamebaseData(gameWithPgn.data);
+      final raw = gameWithPgn.pgn;
+      for (final candidate in [built, raw]) {
+        final trimmed = candidate?.trim();
+        if (trimmed != null && trimmed.isNotEmpty) {
+          return trimmed;
+        }
       }
-      pgn ??=
-          (await ref
-              .read(gameRepositoryProvider)
-              .getGameById(widget.game.gameId)).pgn ??
-          '';
-      await Clipboard.setData(ClipboardData(text: pgn));
-      HapticFeedback.lightImpact();
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'PGN copied to clipboard',
-              style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
-            ),
-            backgroundColor: kBlack2Color.withValues(alpha: 0.95),
-            behavior: SnackBarBehavior.floating,
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Failed to copy PGN',
-              style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
-            ),
-            backgroundColor: kBlack2Color.withValues(alpha: 0.95),
-            behavior: SnackBarBehavior.floating,
-            duration: const Duration(seconds: 2),
-          ),
-        );
-      }
+    } catch (_) {
+      // Best-effort only. The caller falls back to a header-only PGN.
     }
+    return null;
   }
 
-  void shareGameBtnClicked() async {
-    // Get the board provider to access the current state
+  Future<_ResolvedAppBarShareData> _resolveAppBarShareData() async {
     final params = ChessBoardProviderParams(
       game: widget.game,
       index: widget.currentGameIndex,
     );
     final boardState = ref.read(chessBoardScreenProviderNew(params));
+    final state = boardState.valueOrNull;
 
-    // Only proceed if we have a valid state
-    if (!boardState.hasValue || boardState.value == null) {
+    final pgn = await resolveGameSharePgn(
+      game: widget.game,
+      analysisGame: state?.analysisState.game,
+      savedAnalysisData: widget.savedAnalysisData,
+      fetchSupabasePgn: (gameId) async {
+        try {
+          return await ref.read(gameRepositoryProvider).getGamePgn(gameId);
+        } catch (_) {
+          return null;
+        }
+      },
+      fetchGamebasePgn: _fetchGamebaseSharePgn,
+    );
+
+    final snapshot = buildGameShareSnapshot(
+      game: widget.game,
+      pgn: pgn,
+      state: state,
+    );
+
+    final boardReady = state != null && !state.isLoadingMoves;
+    final isAtGameEnd =
+        boardReady
+            ? state.analysisState.isAtEnd &&
+                state.analysisState.movePointer.length == 1
+            : widget.game.gameStatus.isFinished &&
+                snapshot.currentMoveIndex >= 0 &&
+                snapshot.currentMoveIndex == snapshot.moveSans.length - 1;
+
+    return _ResolvedAppBarShareData(
+      pgn: pgn,
+      shareUrl: buildGameShareUrl(
+        game: widget.game,
+        savedAnalysisData: widget.savedAnalysisData,
+      ),
+      snapshot: snapshot,
+      evaluation: boardReady ? state.evaluation : null,
+      mate: boardReady ? state.mate ?? 0 : 0,
+      isFlipped: boardReady ? state.isBoardFlipped : false,
+      isAtGameEnd: isAtGameEnd,
+    );
+  }
+
+  void copyPgnBtnClicked() async {
+    try {
+      final resolved = await _resolveAppBarShareData();
+      if (resolved.pgn.trim().isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'No PGN available for this game',
+              style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
+            ),
+            backgroundColor: kBlack2Color.withValues(alpha: 0.95),
+            behavior: SnackBarBehavior.floating,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+        return;
+      }
+      await Clipboard.setData(ClipboardData(text: resolved.pgn));
+      HapticFeedback.lightImpact();
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Please wait for the game to load',
+            'PGN copied to clipboard',
             style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
           ),
           backgroundColor: kBlack2Color.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 2),
         ),
       );
-      return;
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Failed to copy PGN',
+            style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
+          ),
+          backgroundColor: kBlack2Color.withValues(alpha: 0.95),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 2),
+        ),
+      );
     }
+  }
 
-    final state = boardState.value!;
-
-    // Prefer PGN from the already-loaded analysis state (works for all game
-    // sources: TWIC, opening explorer, player's database, analysis board).
-    // Fall back to a Supabase fetch only when the analysis game is unavailable.
-    String pgn = '';
-    final analysisGame = state.analysisState.game;
-    if (analysisGame != null) {
-      pgn = exportGameToPgn(analysisGame);
-    }
-    if (pgn.isEmpty) {
-      try {
-        final gameWithPgn = await ref
-            .read(gameRepositoryProvider)
-            .getGameById(widget.game.gameId);
-        pgn = gameWithPgn.pgn ?? '';
-      } catch (_) {
-        // Game may not exist in Supabase (e.g. gamebase / TWIC source) — proceed
-        // with whatever PGN we already have.
-      }
-    }
-
-    // Show share overlay - we'll navigate to a full screen overlay
-    if (context.mounted) {
+  void shareGameBtnClicked() async {
+    try {
+      final resolved = await _resolveAppBarShareData();
+      if (!mounted) return;
       Navigator.of(context).push(
         PageRouteBuilder(
           opaque: false,
@@ -2771,10 +2820,23 @@ class _AppBarState extends ConsumerState<_AppBar> {
           barrierColor: Colors.transparent,
           pageBuilder:
               (context, animation, secondaryAnimation) =>
-                  _ShareGameScreen(game: widget.game, state: state, pgn: pgn),
+                  _ShareGameScreen(game: widget.game, shareData: resolved),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             return FadeTransition(opacity: animation, child: child);
           },
+        ),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Failed to prepare game share',
+            style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
+          ),
+          backgroundColor: kBlack2Color.withValues(alpha: 0.95),
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 2),
         ),
       );
     }
@@ -5614,6 +5676,7 @@ class _AnalysisGameBody extends ConsumerWidget {
 
                   final resolvedGame = GamesTourModel(
                     gameId: resolvedId.isNotEmpty ? resolvedId : gameId,
+                    source: GameSource.gamebase,
                     whitePlayer: PlayerCard(
                       name: whiteName,
                       federation: '',
@@ -5767,6 +5830,7 @@ class _AnalysisGameBody extends ConsumerWidget {
                               : (op.trim().isNotEmpty ? op : null);
                       return GamesTourModel(
                         gameId: safeId,
+                        source: GameSource.gamebase,
                         whitePlayer: PlayerCard(
                           name: wn.isNotEmpty ? wn : 'White',
                           federation: '',
@@ -10424,14 +10488,9 @@ class _BlinkingRedDotState extends State<_BlinkingRedDot>
 
 class _ShareGameScreen extends ConsumerWidget {
   final GamesTourModel game;
-  final ChessBoardStateNew state;
-  final String pgn;
+  final _ResolvedAppBarShareData shareData;
 
-  const _ShareGameScreen({
-    required this.game,
-    required this.state,
-    required this.pgn,
-  });
+  const _ShareGameScreen({required this.game, required this.shareData});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -10470,17 +10529,17 @@ class _ShareGameScreen extends ConsumerWidget {
     );
 
     // Calculate clock times at current position (same logic as PlayerFirstRowDetailWidget)
-    final effectiveMoveIndex = state.analysisState.currentMoveIndex;
+    final effectiveMoveIndex = shareData.snapshot.currentMoveIndex;
 
     String? whiteTime;
     String? blackTime;
 
-    if (state.moveTimes.isNotEmpty) {
+    if (shareData.snapshot.moveTimes.isNotEmpty) {
       // Find white player's most recent move up to current position
       for (int i = effectiveMoveIndex; i >= 0; i--) {
         final isWhiteMove = i % 2 == 0;
-        if (isWhiteMove && i < state.moveTimes.length) {
-          whiteTime = state.moveTimes[i];
+        if (isWhiteMove && i < shareData.snapshot.moveTimes.length) {
+          whiteTime = shareData.snapshot.moveTimes[i];
           break;
         }
       }
@@ -10488,8 +10547,8 @@ class _ShareGameScreen extends ConsumerWidget {
       // Find black player's most recent move up to current position
       for (int i = effectiveMoveIndex; i >= 0; i--) {
         final isBlackMove = i % 2 == 1;
-        if (isBlackMove && i < state.moveTimes.length) {
-          blackTime = state.moveTimes[i];
+        if (isBlackMove && i < shareData.snapshot.moveTimes.length) {
+          blackTime = shareData.snapshot.moveTimes[i];
           break;
         }
       }
@@ -10509,14 +10568,11 @@ class _ShareGameScreen extends ConsumerWidget {
 
     return ShareGameCardOverlay(
       boardSettings: chessboardSettings,
-      positionFen: state.analysisState.position.fen,
-      lastMove: state.analysisState.lastMove,
-      pgn: pgn,
-      moveSans:
-          state
-              .analysisState
-              .moveSans, // Pass the actual move list from analysis state
-      moveTimes: state.moveTimes, // Pass clock times for GIF animation
+      positionFen: shareData.snapshot.positionFen,
+      lastMove: shareData.snapshot.lastMove,
+      pgn: shareData.pgn,
+      moveSans: shareData.snapshot.moveSans,
+      moveTimes: shareData.snapshot.moveTimes,
       whitePlayerName: game.whitePlayer.name,
       blackPlayerName: game.blackPlayer.name,
       // Use countryCode first (inactive profile games often only populate this),
@@ -10543,17 +10599,16 @@ class _ShareGameScreen extends ConsumerWidget {
       blackPlayerClock: blackTime,
       tournamentName: tournamentName,
       roundInfo: roundInfo,
-      currentMoveIndex: state.analysisState.currentMoveIndex,
-      evaluation: state.evaluation,
-      mate: state.mate ?? 0,
-      isFlipped: state.isBoardFlipped,
+      currentMoveIndex: shareData.snapshot.currentMoveIndex,
+      evaluation: shareData.evaluation,
+      mate: shareData.mate,
+      isFlipped: shareData.isFlipped,
       gameStatus: game.gameStatus,
-      isAtGameEnd:
-          state.analysisState.isAtEnd &&
-          state.analysisState.movePointer.length == 1,
+      isAtGameEnd: shareData.isAtGameEnd,
+      shareUrl: shareData.shareUrl,
       gameId: game.gameId, // Pass game ID for correct eval display
+      startingFen: shareData.snapshot.startingFen,
       onClose: () => Navigator.of(context).pop(),
-      startingFen: state.analysisState.startingPosition?.fen,
     );
   }
 }

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -2669,22 +2669,52 @@ class _AppBarState extends ConsumerState<_AppBar> {
   }
 
   void copyPgnBtnClicked() async {
-    String? pgn;
-    final params = ChessBoardProviderParams(
-      game: widget.game,
-      index: widget.currentGameIndex,
-    );
-    final boardState = ref.read(chessBoardScreenProviderNew(params));
-    final analysisGame = boardState.valueOrNull?.analysisState.game;
-    if (analysisGame != null) {
-      pgn = exportGameToPgn(analysisGame);
+    try {
+      String? pgn;
+      final params = ChessBoardProviderParams(
+        game: widget.game,
+        index: widget.currentGameIndex,
+      );
+      final boardState = ref.read(chessBoardScreenProviderNew(params));
+      final analysisGame = boardState.valueOrNull?.analysisState.game;
+      if (analysisGame != null) {
+        pgn = exportGameToPgn(analysisGame);
+      }
+      pgn ??=
+          (await ref
+              .read(gameRepositoryProvider)
+              .getGameById(widget.game.gameId)).pgn ??
+          '';
+      await Clipboard.setData(ClipboardData(text: pgn));
+      HapticFeedback.lightImpact();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'PGN copied to clipboard',
+              style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
+            ),
+            backgroundColor: kBlack2Color.withValues(alpha: 0.95),
+            behavior: SnackBarBehavior.floating,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Failed to copy PGN',
+              style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
+            ),
+            backgroundColor: kBlack2Color.withValues(alpha: 0.95),
+            behavior: SnackBarBehavior.floating,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
     }
-    pgn ??=
-        (await ref
-            .read(gameRepositoryProvider)
-            .getGameById(widget.game.gameId)).pgn ??
-        '';
-    Clipboard.setData(ClipboardData(text: pgn));
   }
 
   void shareGameBtnClicked() async {
@@ -2698,19 +2728,39 @@ class _AppBarState extends ConsumerState<_AppBar> {
     // Only proceed if we have a valid state
     if (!boardState.hasValue || boardState.value == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Please wait for the game to load'),
-          backgroundColor: Colors.orange,
+        SnackBar(
+          content: Text(
+            'Please wait for the game to load',
+            style: AppTypography.textSmMedium.copyWith(color: kWhiteColor),
+          ),
+          backgroundColor: kBlack2Color.withValues(alpha: 0.95),
+          behavior: SnackBarBehavior.floating,
         ),
       );
       return;
     }
 
     final state = boardState.value!;
-    final gameWithPgn = await ref
-        .read(gameRepositoryProvider)
-        .getGameById(widget.game.gameId);
-    final pgn = gameWithPgn.pgn ?? "";
+
+    // Prefer PGN from the already-loaded analysis state (works for all game
+    // sources: TWIC, opening explorer, player's database, analysis board).
+    // Fall back to a Supabase fetch only when the analysis game is unavailable.
+    String pgn = '';
+    final analysisGame = state.analysisState.game;
+    if (analysisGame != null) {
+      pgn = exportGameToPgn(analysisGame);
+    }
+    if (pgn.isEmpty) {
+      try {
+        final gameWithPgn = await ref
+            .read(gameRepositoryProvider)
+            .getGameById(widget.game.gameId);
+        pgn = gameWithPgn.pgn ?? '';
+      } catch (_) {
+        // Game may not exist in Supabase (e.g. gamebase / TWIC source) — proceed
+        // with whatever PGN we already have.
+      }
+    }
 
     // Show share overlay - we'll navigate to a full screen overlay
     if (context.mounted) {
@@ -7662,8 +7712,7 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
       }
 
       moveSpans = [
-        if (prefix.isNotEmpty)
-          TextSpan(text: prefix, style: numberStyle),
+        if (prefix.isNotEmpty) TextSpan(text: prefix, style: numberStyle),
         TextSpan(text: body, style: textStyle),
       ];
     }

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -150,6 +150,7 @@ class ChessBoardScreenNotifierNew
   ChessGameNavigatorStateManager? _analysisStateManager;
   ProviderSubscription<ChessGameNavigatorState>? _navigatorSubscription;
   bool _isInitialLoad = true;
+
   /// Tracks whether the user is auto-following the latest live move.
   /// Set to false when the user manually navigates backwards, true when they
   /// return to the last move. Prevents race conditions between parseMoves()
@@ -158,6 +159,7 @@ class ChessBoardScreenNotifierNew
   bool _isFollowingLive = true;
   ChessBoardStateNew? _pvPreviewSnapshot;
   Timer? _autoSaveTimer;
+
   /// Snapshot of the game tree at last auto-save for diff detection
   String? _lastAutoSavedGameJson;
   int _parseGeneration = 0;
@@ -214,9 +216,10 @@ class ChessBoardScreenNotifierNew
           variationComments,
         ), // Restore comments
         position: liveFenPosition,
-        analysisState: liveFenPosition != null
-            ? AnalysisBoardState(position: liveFenPosition)
-            : const AnalysisBoardState(),
+        analysisState:
+            liveFenPosition != null
+                ? AnalysisBoardState(position: liveFenPosition)
+                : const AnalysisBoardState(),
       ),
     );
     parseMoves();
@@ -234,46 +237,52 @@ class ChessBoardScreenNotifierNew
       final nextValue = next.value;
 
       if (prevValue != nextValue && nextValue != null) {
-    // GUARD: Skip re-eval if ONLY showEngineAnalysis changed.
-    // toggleEngineVisibility() already handles its own eval trigger,
-    // so firing again here causes duplicate 5000ms Stockfish jobs.
-    if (prevValue != null) {
-      final nothingChanged =
-        prevValue.searchTimeIndex == nextValue.searchTimeIndex &&
-        prevValue.principalVariationIndex == nextValue.principalVariationIndex &&
-        prevValue.showEngineGauge == nextValue.showEngineGauge &&
-        prevValue.showPvArrows == nextValue.showPvArrows &&
-        prevValue.showDepthOverlay == nextValue.showDepthOverlay &&
-        prevValue.maxArrowsOnBoard == nextValue.maxArrowsOnBoard &&
-        prevValue.showEngineAnalysis == nextValue.showEngineAnalysis; // ← same value
+        // GUARD: Skip re-eval if ONLY showEngineAnalysis changed.
+        // toggleEngineVisibility() already handles its own eval trigger,
+        // so firing again here causes duplicate 5000ms Stockfish jobs.
+        if (prevValue != null) {
+          final nothingChanged =
+              prevValue.searchTimeIndex == nextValue.searchTimeIndex &&
+              prevValue.principalVariationIndex ==
+                  nextValue.principalVariationIndex &&
+              prevValue.showEngineGauge == nextValue.showEngineGauge &&
+              prevValue.showPvArrows == nextValue.showPvArrows &&
+              prevValue.showDepthOverlay == nextValue.showDepthOverlay &&
+              prevValue.maxArrowsOnBoard == nextValue.maxArrowsOnBoard &&
+              prevValue.showEngineAnalysis ==
+                  nextValue.showEngineAnalysis; // ← same value
 
-    // Skip if only visibility changed (toggle handles its own eval)
-      final onlyVisibilityChanged =
-          prevValue.searchTimeIndex == nextValue.searchTimeIndex &&
-          prevValue.principalVariationIndex == nextValue.principalVariationIndex &&
-          prevValue.showEngineGauge == nextValue.showEngineGauge &&
-          prevValue.showPvArrows == nextValue.showPvArrows &&
-          prevValue.showDepthOverlay == nextValue.showDepthOverlay &&
-          prevValue.maxArrowsOnBoard == nextValue.maxArrowsOnBoard &&
-          prevValue.showEngineAnalysis != nextValue.showEngineAnalysis;
+          // Skip if only visibility changed (toggle handles its own eval)
+          final onlyVisibilityChanged =
+              prevValue.searchTimeIndex == nextValue.searchTimeIndex &&
+              prevValue.principalVariationIndex ==
+                  nextValue.principalVariationIndex &&
+              prevValue.showEngineGauge == nextValue.showEngineGauge &&
+              prevValue.showPvArrows == nextValue.showPvArrows &&
+              prevValue.showDepthOverlay == nextValue.showDepthOverlay &&
+              prevValue.maxArrowsOnBoard == nextValue.maxArrowsOnBoard &&
+              prevValue.showEngineAnalysis != nextValue.showEngineAnalysis;
 
-      if (nothingChanged || onlyVisibilityChanged) {
-        debugPrint('⏭️ [SETTINGS] skipped re-eval '
-            '(${nothingChanged ? "no change" : "visibility-only change"})');
-        // Still sync visibility state if needed
-        final currentState = state.valueOrNull;
-        if (currentState != null &&
-            currentState.showEngineAnalysis != nextValue.showEngineAnalysis) {
-          state = AsyncValue.data(
-            currentState.copyWith(
-              showEngineAnalysis: nextValue.showEngineAnalysis,
-              showPrincipalVariations: nextValue.showEngineAnalysis,
-            ),
-          );
+          if (nothingChanged || onlyVisibilityChanged) {
+            debugPrint(
+              '⏭️ [SETTINGS] skipped re-eval '
+              '(${nothingChanged ? "no change" : "visibility-only change"})',
+            );
+            // Still sync visibility state if needed
+            final currentState = state.valueOrNull;
+            if (currentState != null &&
+                currentState.showEngineAnalysis !=
+                    nextValue.showEngineAnalysis) {
+              state = AsyncValue.data(
+                currentState.copyWith(
+                  showEngineAnalysis: nextValue.showEngineAnalysis,
+                  showPrincipalVariations: nextValue.showEngineAnalysis,
+                ),
+              );
+            }
+            return;
+          }
         }
-        return;
-      }
-    }
         _releaseLog('');
         _releaseLog('🔄 ═══ ENGINE SETTINGS CHANGED ═══');
         _releaseLog('   Previous:');
@@ -1237,8 +1246,7 @@ class ChessBoardScreenNotifierNew
 
       // Update live-follow flag based on whether user navigated to the last move
       if (game.gameStatus.isOngoing) {
-        final allMoveCount =
-            updatedState.currentLine?.length ?? 0;
+        final allMoveCount = updatedState.currentLine?.length ?? 0;
         _isFollowingLive = moveIndex >= 0 && moveIndex == allMoveCount - 1;
       }
       return;
@@ -3062,7 +3070,13 @@ class ChessBoardScreenNotifierNew
     final currentState = state.valueOrNull;
     savedAnalysisData = SavedAnalysisData(
       analysisId: analysisId,
-      chessGame: currentState?.analysisState.game ?? savedAnalysisData!.chessGame,
+      sourceGameId:
+          savedAnalysisData?.sourceGameId ??
+          (currentState?.game.source == GameSource.savedAnalysis
+              ? null
+              : currentState?.game.gameId),
+      chessGame:
+          currentState?.analysisState.game ?? savedAnalysisData!.chessGame,
       variationComments: currentState?.variationComments ?? const {},
       isBoardFlipped: currentState?.isBoardFlipped ?? false,
       lastViewedPosition: currentState?.analysisState.currentMoveIndex ?? 0,
@@ -3119,8 +3133,11 @@ class ChessBoardScreenNotifierNew
         id: analysisId,
         userId: userId,
         folderId: savedAnalysisData?.folderId,
-        title: savedAnalysisData?.title ?? currentState.game.whitePlayer.name +
-            ' vs ' + currentState.game.blackPlayer.name,
+        title:
+            savedAnalysisData?.title ??
+            currentState.game.whitePlayer.name +
+                ' vs ' +
+                currentState.game.blackPlayer.name,
         chessGame: analysisGame,
         analysisState: analysisStateJson,
         variationComments: currentState.variationComments,
@@ -3203,8 +3220,11 @@ class ChessBoardScreenNotifierNew
         id: analysisId,
         userId: userId,
         folderId: savedAnalysisData?.folderId,
-        title: savedAnalysisData?.title ?? currentState.game.whitePlayer.name +
-            ' vs ' + currentState.game.blackPlayer.name,
+        title:
+            savedAnalysisData?.title ??
+            currentState.game.whitePlayer.name +
+                ' vs ' +
+                currentState.game.blackPlayer.name,
         chessGame: analysisGame,
         analysisState: analysisStateJson,
         variationComments: currentState.variationComments,
@@ -3866,34 +3886,38 @@ class ChessBoardScreenNotifierNew
             );
     state = AsyncValue.data(currentState.copyWith(game: updatedGame));
   }
+
   bool _isFirstEvalAfterToggle = false;
- void toggleEngineVisibility() {
-  
-  final currentState = state.value;
-  if (currentState == null) return;
+  void toggleEngineVisibility() {
+    final currentState = state.value;
+    if (currentState == null) return;
 
-  final newValue = !currentState.showEngineAnalysis;
-  debugPrint('⏱️ [TOGGLE] engine ON=$newValue at ${DateTime.now().millisecondsSinceEpoch}');
+    final newValue = !currentState.showEngineAnalysis;
+    debugPrint(
+      '⏱️ [TOGGLE] engine ON=$newValue at ${DateTime.now().millisecondsSinceEpoch}',
+    );
 
-  state = AsyncValue.data(
-    currentState.copyWith(
-      showEngineAnalysis: newValue,
-      showPrincipalVariations: newValue,
-    ),
-  );
+    state = AsyncValue.data(
+      currentState.copyWith(
+        showEngineAnalysis: newValue,
+        showPrincipalVariations: newValue,
+      ),
+    );
 
-  unawaited(
-    ref.read(engineSettingsProviderNew.notifier)
-        .toggleEngineAnalysis(newValue),
-  );
+    unawaited(
+      ref
+          .read(engineSettingsProviderNew.notifier)
+          .toggleEngineAnalysis(newValue),
+    );
 
-  // When turning ON, cancel stale jobs and trigger fresh eval
-  if (newValue) {
-    _isFirstEvalAfterToggle = true;
-    StockfishSingleton().cancelEvaluationsForOwner(_stockfishOwnerId);
-    _updateEvaluation(force: true);
+    // When turning ON, cancel stale jobs and trigger fresh eval
+    if (newValue) {
+      _isFirstEvalAfterToggle = true;
+      StockfishSingleton().cancelEvaluationsForOwner(_stockfishOwnerId);
+      _updateEvaluation(force: true);
+    }
   }
-}
+
   void togglePlayPause() {
     final currentState = state.value;
     if (currentState == null) return;
@@ -5197,12 +5221,15 @@ class ChessBoardScreenNotifierNew
       final multiPV = configuredMultiPV;
       final isCurrentlyVisible = currentVisiblePage == index;
       EngineSearchProgress? pendingProgress;
-      final effectiveSearchDuration = _isFirstEvalAfterToggle
-    ? const Duration(milliseconds: 800)
-    : combinedSearchDuration;
-_isFirstEvalAfterToggle = false;
-debugPrint('⏱️ [EVAL] searchDuration=${effectiveSearchDuration?.inMilliseconds}ms '
-    'at ${DateTime.now().millisecondsSinceEpoch}');
+      final effectiveSearchDuration =
+          _isFirstEvalAfterToggle
+              ? const Duration(milliseconds: 800)
+              : combinedSearchDuration;
+      _isFirstEvalAfterToggle = false;
+      debugPrint(
+        '⏱️ [EVAL] searchDuration=${effectiveSearchDuration?.inMilliseconds}ms '
+        'at ${DateTime.now().millisecondsSinceEpoch}',
+      );
       final stockfishFuture = StockfishSingleton().evaluatePosition(
         fenToAnalyze,
         depth: combinedMaxDepth,
@@ -6531,6 +6558,9 @@ class SavedAnalysisData {
   /// Null when opening a shared/read-only game (no save-back).
   final String? analysisId;
 
+  /// Original source game ID, if this analysis came from another game.
+  final String? sourceGameId;
+
   /// Pre-built ChessGame with all variations
   final ChessGame chessGame;
 
@@ -6554,6 +6584,7 @@ class SavedAnalysisData {
 
   const SavedAnalysisData({
     this.analysisId,
+    this.sourceGameId,
     required this.chessGame,
     required this.variationComments,
     this.movePointer,

--- a/lib/screens/chessboard/utils/game_share_utils.dart
+++ b/lib/screens/chessboard/utils/game_share_utils.dart
@@ -1,0 +1,217 @@
+import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
+import 'package:chessever2/screens/chessboard/notation/notation_tree.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new_worker.dart';
+import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
+import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:dartchess/dartchess.dart';
+
+typedef SharePgnFetcher = Future<String?> Function(String gameId);
+typedef SharePgnExporter = String Function(ChessGame game);
+typedef SharePgnParser = PgnParseResult Function(String pgn);
+
+const _defaultStartingFen =
+    'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+final _uuidPattern = RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+  caseSensitive: false,
+);
+final _lichessShortIdPattern = RegExp(r'^[A-Za-z0-9]{8}$');
+
+class GameShareSnapshot {
+  final String positionFen;
+  final Move? lastMove;
+  final List<String> moveSans;
+  final List<String> moveTimes;
+  final int currentMoveIndex;
+  final String? startingFen;
+
+  const GameShareSnapshot({
+    required this.positionFen,
+    required this.lastMove,
+    required this.moveSans,
+    required this.moveTimes,
+    required this.currentMoveIndex,
+    this.startingFen,
+  });
+}
+
+bool _hasText(String? value) => value != null && value.trim().isNotEmpty;
+
+String? _trimmedOrNull(String? value) {
+  if (!_hasText(value)) return null;
+  return value!.trim();
+}
+
+String? _normalizedStartingFen(String? fen) {
+  final trimmed = _trimmedValidFen(fen);
+  if (trimmed == null || trimmed == _defaultStartingFen) {
+    return null;
+  }
+  return trimmed;
+}
+
+String? _trimmedValidFen(String? fen) {
+  final trimmed = _trimmedOrNull(fen);
+  if (trimmed == null) return null;
+  try {
+    Setup.parseFen(trimmed);
+    return trimmed;
+  } catch (_) {
+    return null;
+  }
+}
+
+bool _isResolvableSharedGameId(String id) {
+  final trimmed = id.trim();
+  return _uuidPattern.hasMatch(trimmed) ||
+      _lichessShortIdPattern.hasMatch(trimmed);
+}
+
+bool isGamebaseBackedSource(GameSource source) {
+  return source == GameSource.gamebase || source == GameSource.twic;
+}
+
+String? buildGameShareUrl({
+  required GamesTourModel game,
+  SavedAnalysisData? savedAnalysisData,
+}) {
+  String? linkableId;
+  switch (game.source) {
+    case GameSource.supabase:
+      linkableId = _trimmedOrNull(game.gameId);
+      break;
+    case GameSource.savedAnalysis:
+      linkableId = _trimmedOrNull(savedAnalysisData?.sourceGameId);
+      break;
+    case GameSource.gamebase:
+    case GameSource.twic:
+    case GameSource.openingExplorer:
+    case GameSource.boardEditor:
+    case GameSource.localAnalysis:
+      linkableId = null;
+      break;
+  }
+
+  if (linkableId == null || !_isResolvableSharedGameId(linkableId)) {
+    return null;
+  }
+  return 'https://chessever.com/games/$linkableId';
+}
+
+String buildShareFallbackPgn(GamesTourModel game) {
+  final event =
+      _trimmedOrNull(game.tourSlug) ??
+      _trimmedOrNull(game.tourId) ??
+      'ChessEver';
+
+  return buildHeaderOnlyPgn(
+    whiteName: game.whitePlayer.name,
+    blackName: game.blackPlayer.name,
+    result: game.gameStatus.displayText,
+    event: event,
+    eco: _trimmedOrNull(game.roundSlug),
+    opening: _trimmedOrNull(game.openingName),
+    date: game.lastMoveTime,
+  );
+}
+
+Future<String> resolveGameSharePgn({
+  required GamesTourModel game,
+  required ChessGame? analysisGame,
+  required SavedAnalysisData? savedAnalysisData,
+  SharePgnFetcher? fetchSupabasePgn,
+  SharePgnFetcher? fetchGamebasePgn,
+  SharePgnExporter exportPgn = exportGameToPgn,
+}) async {
+  String? fallback;
+
+  String? firstUsable(String? candidate) {
+    final trimmed = _trimmedOrNull(candidate);
+    if (trimmed == null) return null;
+    fallback ??= trimmed;
+    return pgnHasMoves(trimmed) ? trimmed : null;
+  }
+
+  final analysisPgn =
+      analysisGame == null ? null : firstUsable(exportPgn(analysisGame));
+  if (analysisPgn != null) return analysisPgn;
+
+  final modelPgn = firstUsable(game.pgn);
+  if (modelPgn != null) return modelPgn;
+
+  final savedAnalysisPgn =
+      savedAnalysisData == null
+          ? null
+          : firstUsable(exportPgn(savedAnalysisData.chessGame));
+  if (savedAnalysisPgn != null) return savedAnalysisPgn;
+
+  if (game.source == GameSource.supabase && fetchSupabasePgn != null) {
+    final supabasePgn = firstUsable(await fetchSupabasePgn(game.gameId));
+    if (supabasePgn != null) return supabasePgn;
+  }
+
+  if (isGamebaseBackedSource(game.source) && fetchGamebasePgn != null) {
+    final gamebasePgn = firstUsable(await fetchGamebasePgn(game.gameId));
+    if (gamebasePgn != null) return gamebasePgn;
+  }
+
+  return fallback ?? buildShareFallbackPgn(game).trim();
+}
+
+GameShareSnapshot buildGameShareSnapshot({
+  required GamesTourModel game,
+  required String pgn,
+  ChessBoardStateNew? state,
+  SharePgnParser parsePgn = parsePgnWorker,
+}) {
+  final stateAnalysis = state?.analysisState;
+  final canUseBoardState =
+      state != null &&
+      !state.isLoadingMoves &&
+      stateAnalysis != null &&
+      (stateAnalysis.game != null ||
+          stateAnalysis.moveSans.isNotEmpty ||
+          state.moveSans.isNotEmpty);
+
+  if (canUseBoardState) {
+    return GameShareSnapshot(
+      positionFen: stateAnalysis.position.fen,
+      lastMove: stateAnalysis.lastMove,
+      moveSans: List<String>.from(stateAnalysis.moveSans),
+      moveTimes: List<String>.from(state.moveTimes),
+      currentMoveIndex: stateAnalysis.currentMoveIndex,
+      startingFen: _normalizedStartingFen(stateAnalysis.startingPosition?.fen),
+    );
+  }
+
+  final gameFen = _trimmedValidFen(game.fen);
+  final gameLastMove = _trimmedOrNull(game.lastMove);
+
+  try {
+    final parsed = parsePgn(pgn);
+    return GameShareSnapshot(
+      positionFen: gameFen ?? parsed.finalPos.fen,
+      lastMove:
+          gameLastMove == null
+              ? parsed.lastMove
+              : (Move.parse(gameLastMove) ?? parsed.lastMove),
+      moveSans: List<String>.from(parsed.moveSans),
+      moveTimes: List<String>.from(parsed.moveTimes),
+      currentMoveIndex:
+          parsed.moveSans.isEmpty ? -1 : parsed.moveSans.length - 1,
+      startingFen: _normalizedStartingFen(parsed.startingPos.fen),
+    );
+  } catch (_) {
+    return GameShareSnapshot(
+      positionFen: gameFen ?? _defaultStartingFen,
+      lastMove: gameLastMove == null ? null : Move.parse(gameLastMove),
+      moveSans: const <String>[],
+      moveTimes: const <String>[],
+      currentMoveIndex: -1,
+      startingFen: null,
+    );
+  }
+}

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -4,6 +4,7 @@ import 'package:chessever2/providers/engine_settings_provider.dart';
 import 'package:chessever2/providers/live_game_subscription_provider.dart';
 import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
 import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/screens/chessboard/utils/game_share_utils.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new_worker.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/chessboard/widgets/evaluation_bar_widget.dart';
@@ -110,9 +111,11 @@ Future<void> _showShareOverlay(
   final candidates = <(String source, String pgn)>[];
 
   // Tier 1: game.pgn (already available on the model)
-  debugPrint('GIF share [${game.gameId}]: Tier 1 game.pgn '
-      '${game.pgn == null ? "null" : "(${game.pgn!.length} chars)"} '
-      'hasMoves=${pgnHasMoves(game.pgn)}');
+  debugPrint(
+    'GIF share [${game.gameId}]: Tier 1 game.pgn '
+    '${game.pgn == null ? "null" : "(${game.pgn!.length} chars)"} '
+    'hasMoves=${pgnHasMoves(game.pgn)}',
+  );
   try {
     if (pgnHasMoves(game.pgn)) {
       candidates.add(('game.pgn', game.pgn!.trim()));
@@ -123,11 +126,14 @@ Future<void> _showShareOverlay(
 
   // Tier 2: Supabase getGamePgn
   try {
-    final fetched =
-        await ref.read(gameRepositoryProvider).getGamePgn(game.gameId);
-    debugPrint('GIF share [${game.gameId}]: Tier 2 Supabase '
-        '${fetched == null ? "null" : "(${fetched.length} chars)"} '
-        'hasMoves=${pgnHasMoves(fetched)}');
+    final fetched = await ref
+        .read(gameRepositoryProvider)
+        .getGamePgn(game.gameId);
+    debugPrint(
+      'GIF share [${game.gameId}]: Tier 2 Supabase '
+      '${fetched == null ? "null" : "(${fetched.length} chars)"} '
+      'hasMoves=${pgnHasMoves(fetched)}',
+    );
     if (pgnHasMoves(fetched)) {
       candidates.add(('Supabase', fetched!.trim()));
     }
@@ -140,8 +146,9 @@ Future<void> _showShareOverlay(
   if (_isGamebasePreviewGame(game)) {
     debugPrint('GIF share [${game.gameId}]: Tier 3 Gamebase attempted');
     try {
-      final gameWithPgn =
-          await ref.read(gamebaseRepositoryProvider).getGameWithPgn(game.gameId);
+      final gameWithPgn = await ref
+          .read(gamebaseRepositoryProvider)
+          .getGameWithPgn(game.gameId);
       if (gameWithPgn != null) {
         if (pgnHasMoves(gameWithPgn.pgn)) {
           candidates.add(('Gamebase.pgn', gameWithPgn.pgn!.trim()));
@@ -168,8 +175,10 @@ Future<void> _showShareOverlay(
     }
   }
 
-  debugPrint('GIF share [${game.gameId}]: ${uniqueCandidates.length} '
-      'candidate(s) after dedup');
+  debugPrint(
+    'GIF share [${game.gameId}]: ${uniqueCandidates.length} '
+    'candidate(s) after dedup',
+  );
 
   // Parse-and-accept: accept the first candidate that yields non-empty moveSans
   for (final (source, pgn) in uniqueCandidates) {
@@ -186,20 +195,26 @@ Future<void> _showShareOverlay(
             'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1') {
           startingFen = startFen;
         }
-        debugPrint('GIF share [${game.gameId}]: accepted PGN from $source '
-            '(${moveSans.length} moves)');
+        debugPrint(
+          'GIF share [${game.gameId}]: accepted PGN from $source '
+          '(${moveSans.length} moves)',
+        );
         break;
       } else {
-        debugPrint('GIF share [${game.gameId}]: $source PGN parsed '
-            'but yielded 0 moves');
+        debugPrint(
+          'GIF share [${game.gameId}]: $source PGN parsed '
+          'but yielded 0 moves',
+        );
       }
     } catch (e) {
       debugPrint('GIF share [${game.gameId}]: $source PGN parse failed: $e');
     }
   }
 
-  debugPrint('GIF share [${game.gameId}]: '
-      '${moveSans.isNotEmpty ? "resolved ${moveSans.length} moves" : "NO MOVES RESOLVED"}');
+  debugPrint(
+    'GIF share [${game.gameId}]: '
+    '${moveSans.isNotEmpty ? "resolved ${moveSans.length} moves" : "NO MOVES RESOLVED"}',
+  );
   // On total failure: all remain empty/default — overlay opens but GIF
   // is unavailable. resolvedPgn stays '' (non-null String).
 
@@ -249,6 +264,7 @@ Future<void> _showShareOverlay(
       game.roundSlug != null
           ? StringUtils.formatRoundLabel(game.roundSlug)
           : null;
+  final shareUrl = buildGameShareUrl(game: game);
 
   final positionFen = _resolveFen(game.fen);
   final lastMove = _uciToMove(game.lastMove ?? '');
@@ -287,6 +303,7 @@ Future<void> _showShareOverlay(
                 game.gameStatus != GameStatus.ongoing &&
                 game.gameStatus != GameStatus.unknown,
             onClose: () => Navigator.of(context).pop(),
+            shareUrl: shareUrl,
             gameId: game.gameId,
             startingFen: startingFen,
           ),

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -63,6 +63,7 @@ class ShareGameCardOverlay extends StatefulWidget {
   final bool
   isAtGameEnd; // Whether viewing the actual final position of the game
   final VoidCallback onClose;
+  final String? shareUrl;
   final String gameId; // CRITICAL: Include game ID for correct eval caching
   final String? startingFen; // null = standard initial position
 
@@ -93,6 +94,7 @@ class ShareGameCardOverlay extends StatefulWidget {
     required this.gameStatus,
     this.isAtGameEnd = false,
     required this.onClose,
+    this.shareUrl,
     required this.gameId, // REQUIRED for correct eval caching
     this.startingFen, // null = standard initial position
   });
@@ -226,7 +228,19 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     }
   }
 
-  String get _gameUrl => 'https://chessever.com/games/${widget.gameId}';
+  Future<void> _shareFiles(List<XFile> files) {
+    if (widget.shareUrl != null) {
+      return Share.shareXFiles(
+        files,
+        text: widget.shareUrl,
+        sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
+      );
+    }
+    return Share.shareXFiles(
+      files,
+      sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
+    );
+  }
 
   Future<void> _shareImage() async {
     final imageBytes = await _captureCard();
@@ -240,13 +254,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       final file = io.File('${tempDir.path}/chessever_share.png');
       await file.writeAsBytes(imageBytes);
 
-      // Fix for iOS 16+ share dialog bug
-      // Use minimal rect instead of calculating from context
-      await Share.shareXFiles(
-        [XFile(file.path)],
-        text: _gameUrl,
-        sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
-      );
+      await _shareFiles([XFile(file.path)]);
     } catch (e) {
       debugPrint('Error sharing: $e');
       _showMessage('Failed to share image', isError: true);
@@ -254,8 +262,10 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
   }
 
   void _updateGifProgress(int captured, int accepted, int total) {
-    final progress =
-        (captured / total * 0.6 + accepted / total * 0.4).clamp(0.0, 0.95);
+    final progress = (captured / total * 0.6 + accepted / total * 0.4).clamp(
+      0.0,
+      0.95,
+    );
     // Only rebuild if progress moved by ≥2% to avoid rebuild storms
     if (mounted && (progress - _gifProgress).abs() >= 0.02) {
       setState(() => _gifProgress = progress);
@@ -269,7 +279,8 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     List<String> movesToAnimate,
     int globalMoveOffset,
     String? captureStartFen,
-  })? _computeExportWindow() {
+  })?
+  _computeExportWindow() {
     if (widget.moveSans.isEmpty) return null;
 
     if (widget.currentMoveIndex >= 0) {
@@ -288,9 +299,10 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     if (offset > 0) {
       // Pre-play prefix moves to compute the starting FEN for the window
       try {
-        Position pos = widget.startingFen != null
-            ? Chess.fromSetup(Setup.parseFen(widget.startingFen!))
-            : Chess.initial;
+        Position pos =
+            widget.startingFen != null
+                ? Chess.fromSetup(Setup.parseFen(widget.startingFen!))
+                : Chess.initial;
         for (int i = 0; i < offset; i++) {
           final move = pos.parseSan(widget.moveSans[i]);
           if (move == null) throw StateError('Prefix move $i unparseable');
@@ -371,8 +383,9 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
           }
         });
 
-        workerSendPort = await readyCompleter.future
-            .timeout(const Duration(seconds: 5));
+        workerSendPort = await readyCompleter.future.timeout(
+          const Duration(seconds: 5),
+        );
         await readySub.cancel();
       } catch (e) {
         debugPrint('GIF: Isolate startup failed: $e, using fallback');
@@ -489,13 +502,15 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         }
         if (workerFailed) return false;
         final transferable = TransferableTypedData.fromList([rgba]);
-        workerSendPort.send(GifWorkerFrameData(
-          rgba: transferable,
-          width: width,
-          height: height,
-          durationCs: durationCs,
-          frameIndex: outputIndex,
-        ));
+        workerSendPort.send(
+          GifWorkerFrameData(
+            rgba: transferable,
+            width: width,
+            height: height,
+            durationCs: durationCs,
+            frameIndex: outputIndex,
+          ),
+        );
         inFlight++;
         framesCaptured++;
         _updateGifProgress(framesCaptured, framesAccepted, totalOutputFrames);
@@ -561,9 +576,11 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
           lastMoveForDisplay = NormalMove(from: move.from, to: move.to);
         }
 
-        final (whiteClock, blackClock) =
-            _getClocksAtMoveIndex(i + globalMoveOffset);
-        final isGameEnd = widget.isAtGameEnd &&
+        final (whiteClock, blackClock) = _getClocksAtMoveIndex(
+          i + globalMoveOffset,
+        );
+        final isGameEnd =
+            widget.isAtGameEnd &&
             i + globalMoveOffset == widget.moveSans.length - 1;
 
         if (!mounted) return;
@@ -579,8 +596,10 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         final frame = await _captureRawFrame(profile.pixelRatio);
         if (frame == null) {
           // Abort: broken alignment would produce a corrupted GIF
-          _showMessage('Failed to capture frame at move ${i + 1}',
-              isError: true);
+          _showMessage(
+            'Failed to capture frame at move ${i + 1}',
+            isError: true,
+          );
           return;
         }
         final frameSent = await sendFrame(
@@ -598,8 +617,9 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       workerSendPort.send(GifWorkerFinish());
 
       // Wait for the encoded result with timeout
-      final gifBytes = await doneCompleter.future
-          .timeout(const Duration(seconds: 30));
+      final gifBytes = await doneCompleter.future.timeout(
+        const Duration(seconds: 30),
+      );
 
       // Save and share
       if (mounted) setState(() => _gifProgress = 0.95);
@@ -607,11 +627,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
       final file = io.File('${tempDir.path}/chessever_game.gif');
       await file.writeAsBytes(gifBytes);
 
-      await Share.shareXFiles(
-        [XFile(file.path)],
-        text: _gameUrl,
-        sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
-      );
+      await _shareFiles([XFile(file.path)]);
     } finally {
       await subscription.cancel();
       mainPort.close();
@@ -679,9 +695,11 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         lastMoveForDisplay = NormalMove(from: move.from, to: move.to);
       }
 
-      final (whiteClock, blackClock) =
-          _getClocksAtMoveIndex(i + globalMoveOffset);
-      final isGameEnd = widget.isAtGameEnd &&
+      final (whiteClock, blackClock) = _getClocksAtMoveIndex(
+        i + globalMoveOffset,
+      );
+      final isGameEnd =
+          widget.isAtGameEnd &&
           i + globalMoveOffset == widget.moveSans.length - 1;
 
       if (!mounted) return;
@@ -704,8 +722,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
       final frame = await _captureRawFrame(profile.pixelRatio);
       if (frame == null) {
-        _showMessage('Failed to capture frame at move ${i + 1}',
-            isError: true);
+        _showMessage('Failed to capture frame at move ${i + 1}', isError: true);
         return;
       }
       rawFrames.add(frame);
@@ -737,11 +754,7 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     final file = io.File('${tempDir.path}/chessever_game.gif');
     await file.writeAsBytes(gifBytes);
 
-    await Share.shareXFiles(
-      [XFile(file.path)],
-      text: _gameUrl,
-      sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
-    );
+    await _shareFiles([XFile(file.path)]);
   }
 
   Future<void> _copyPgn() async {
@@ -844,29 +857,23 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
     bool enabled = true,
     String? disabledMessage,
   }) {
-    final effectiveOnTap = enabled
-        ? onTap
-        : () => _showMessage(
-              disabledMessage ?? 'Not available',
-              isError: true,
-            );
+    final effectiveOnTap =
+        enabled
+            ? onTap
+            : () =>
+                _showMessage(disabledMessage ?? 'Not available', isError: true);
 
     final content = Container(
       padding: EdgeInsets.symmetric(vertical: 12.h),
       decoration: BoxDecoration(
         color: isPrimary ? kPrimaryColor : kBlack3Color,
         borderRadius: BorderRadius.circular(8.br),
-        border:
-            isPrimary ? null : Border.all(color: kDividerColor, width: 1),
+        border: isPrimary ? null : Border.all(color: kDividerColor, width: 1),
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(
-            icon,
-            size: 18.sp,
-            color: isPrimary ? kWhiteColor : kWhiteColor,
-          ),
+          Icon(icon, size: 18.sp, color: isPrimary ? kWhiteColor : kWhiteColor),
           SizedBox(width: 8.w),
           Text(
             label,

--- a/lib/screens/gamebase/gamebase_explorer_screen.dart
+++ b/lib/screens/gamebase/gamebase_explorer_screen.dart
@@ -678,6 +678,7 @@ class _GamebaseExplorerScreenState extends ConsumerState<GamebaseExplorerScreen>
 
     final game = GamesTourModel(
       gameId: 'explorer_$timestamp',
+      source: GameSource.openingExplorer,
       whitePlayer: whitePlayer,
       blackPlayer: blackPlayer,
       whiteTimeDisplay: '--:--',

--- a/lib/screens/gamebase/widgets/position_games_sheet.dart
+++ b/lib/screens/gamebase/widgets/position_games_sheet.dart
@@ -252,10 +252,9 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
   }
 
   Future<void> _addSelectedToLibrary() async {
-    final selectedGames =
-        _games
-            .where((g) => _selectedGameIds.contains(g.gameId))
-            .toList(growable: false);
+    final selectedGames = _games
+        .where((g) => _selectedGameIds.contains(g.gameId))
+        .toList(growable: false);
     if (selectedGames.isEmpty) return;
 
     await showBulkAddToFolderSheet(
@@ -274,8 +273,7 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
           (ctx) => Container(
             decoration: BoxDecoration(
               color: kBlack3Color,
-              borderRadius:
-                  BorderRadius.vertical(top: Radius.circular(16.br)),
+              borderRadius: BorderRadius.vertical(top: Radius.circular(16.br)),
             ),
             padding: EdgeInsets.fromLTRB(
               16.w,
@@ -346,8 +344,7 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
             child: Padding(
               padding: EdgeInsets.fromLTRB(12.w, 8.h, 12.w, 8.h),
               child: Container(
-                padding:
-                    EdgeInsets.symmetric(horizontal: 14.w, vertical: 12.h),
+                padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 12.h),
                 decoration: BoxDecoration(
                   color: kBlack2Color,
                   borderRadius: BorderRadius.circular(16.br),
@@ -446,10 +443,7 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
     );
   }
 
-  Widget _buildSelectableCardWrapper(
-    Widget child, {
-    required bool isSelected,
-  }) {
+  Widget _buildSelectableCardWrapper(Widget child, {required bool isSelected}) {
     return Stack(
       clipBehavior: Clip.none,
       children: [
@@ -538,7 +532,9 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
             _Header(
               title: widget.title,
               onSaveToLibrary:
-                  _games.isNotEmpty && !_isSelectionMode && !_isLoadingAllForSave
+                  _games.isNotEmpty &&
+                          !_isSelectionMode &&
+                          !_isLoadingAllForSave
                       ? _showSaveToLibraryOptions
                       : null,
             ),
@@ -594,8 +590,7 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
                             showRound: true,
                             onTap:
                                 _isSelectionMode
-                                    ? () =>
-                                        _toggleGameSelection(game.gameId)
+                                    ? () => _toggleGameSelection(game.gameId)
                                     : () => _openGame(
                                       context,
                                       ref,
@@ -660,6 +655,7 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
 
     return GamesTourModel(
       gameId: safeId,
+      source: GameSource.gamebase,
       whitePlayer: PlayerCard(
         name: whiteName.isNotEmpty ? whiteName : 'White',
         federation: '',

--- a/lib/screens/library/gamebase_database_search_screen.dart
+++ b/lib/screens/library/gamebase_database_search_screen.dart
@@ -452,6 +452,7 @@ class _GamesList extends ConsumerWidget {
 
           return GamesTourModel(
             gameId: safeId,
+            source: GameSource.gamebase,
             whitePlayer: whiteCard,
             blackPlayer: blackCard,
             whiteTimeDisplay: '--:--',

--- a/lib/screens/library/providers/gamebase_database_games_provider.dart
+++ b/lib/screens/library/providers/gamebase_database_games_provider.dart
@@ -343,6 +343,7 @@ class DatabaseGamesPaginationNotifier
 
           return GamesTourModel(
             gameId: safeId,
+            source: GameSource.gamebase,
             whitePlayer: whiteCard,
             blackPlayer: blackCard,
             whiteTimeDisplay: '--:--',
@@ -363,7 +364,11 @@ class DatabaseGamesPaginationNotifier
         .where(
           (game) =>
               !useClientSideAverageRating ||
-              _matchesAverageRatingRange(game, _filter.minRating, _filter.maxRating),
+              _matchesAverageRatingRange(
+                game,
+                _filter.minRating,
+                _filter.maxRating,
+              ),
         )
         .toList(growable: false);
 
@@ -674,6 +679,7 @@ final gamebaseDatabaseGamesProvider = FutureProvider.autoDispose<
 
           return GamesTourModel(
             gameId: safeId,
+            source: GameSource.gamebase,
             whitePlayer: whiteCard,
             blackPlayer: blackCard,
             whiteTimeDisplay: '--:--',
@@ -694,7 +700,11 @@ final gamebaseDatabaseGamesProvider = FutureProvider.autoDispose<
         .where(
           (game) =>
               !useClientSideAverageRating ||
-              _matchesAverageRatingRange(game, filter.minRating, filter.maxRating),
+              _matchesAverageRatingRange(
+                game,
+                filter.minRating,
+                filter.maxRating,
+              ),
         )
         .toList(growable: false);
   } catch (e, st) {
@@ -706,7 +716,11 @@ final gamebaseDatabaseGamesProvider = FutureProvider.autoDispose<
   }
 });
 
-bool _matchesAverageRatingRange(GamesTourModel game, int minRating, int maxRating) {
+bool _matchesAverageRatingRange(
+  GamesTourModel game,
+  int minRating,
+  int maxRating,
+) {
   final white = game.whitePlayer.rating;
   final black = game.blackPlayer.rating;
   if (white <= 0 || black <= 0) return false;

--- a/lib/screens/library/providers/gamebase_player_games_provider.dart
+++ b/lib/screens/library/providers/gamebase_player_games_provider.dart
@@ -272,6 +272,7 @@ class GamebasePlayerGamesNotifier
 
           return GamesTourModel(
             gameId: id,
+            source: GameSource.gamebase,
             whitePlayer: whiteCard,
             blackPlayer: blackCard,
             whiteTimeDisplay: '--:--',

--- a/lib/screens/library/utils/create_empty_game.dart
+++ b/lib/screens/library/utils/create_empty_game.dart
@@ -42,6 +42,7 @@ GamesTourModel createEmptyGame() {
 
   return GamesTourModel(
     gameId: 'empty_game_$timestamp',
+    source: GameSource.localAnalysis,
     whitePlayer: whitePlayer,
     blackPlayer: blackPlayer,
     whiteTimeDisplay: '--:--',

--- a/lib/screens/library/utils/gamebase_game_to_games_tour_model.dart
+++ b/lib/screens/library/utils/gamebase_game_to_games_tour_model.dart
@@ -98,6 +98,7 @@ GamesTourModel mapGamebaseGameToGamesTourModel(GamebaseGame game) {
 
   return GamesTourModel(
     gameId: game.id,
+    source: GameSource.gamebase,
     whitePlayer: whitePlayer,
     blackPlayer: blackPlayer,
     whiteTimeDisplay: '--:--',

--- a/lib/screens/library/utils/load_saved_analysis.dart
+++ b/lib/screens/library/utils/load_saved_analysis.dart
@@ -136,6 +136,7 @@ SavedAnalysisData createSavedAnalysisData(SavedAnalysis analysis) {
 
   return SavedAnalysisData(
     analysisId: analysis.id,
+    sourceGameId: analysis.sourceGameId,
     chessGame: analysis.chessGame,
     variationComments: analysis.variationComments,
     movePointer: movePointer,
@@ -151,6 +152,7 @@ SavedAnalysisData createSavedAnalysisData(SavedAnalysis analysis) {
 SavedAnalysisData createReadOnlySavedAnalysisData(SavedAnalysis analysis) {
   return SavedAnalysisData(
     analysisId: null,
+    sourceGameId: analysis.sourceGameId,
     chessGame: analysis.chessGame,
     variationComments: analysis.variationComments,
     movePointer: null,
@@ -204,6 +206,7 @@ GamesTourModel convertSavedAnalysisToGame(SavedAnalysis analysis) {
   // The original source game ID is preserved in analysis.sourceGameId
   return GamesTourModel(
     gameId: 'saved_analysis_${analysis.id}',
+    source: GameSource.savedAnalysis,
     whitePlayer: whitePlayer,
     blackPlayer: blackPlayer,
     whiteTimeDisplay: '--:--',

--- a/lib/screens/library/widgets/book_saved_game_card.dart
+++ b/lib/screens/library/widgets/book_saved_game_card.dart
@@ -46,6 +46,7 @@ class BookSavedGameCard extends StatelessWidget {
 
     return GamesTourModel(
       gameId: analysis.id,
+      source: GameSource.savedAnalysis,
       whitePlayer: PlayerCard(
         name: whiteName,
         federation: '',

--- a/lib/screens/library/widgets/library_search_results_view.dart
+++ b/lib/screens/library/widgets/library_search_results_view.dart
@@ -218,6 +218,7 @@ class _LibrarySearchResultsViewState
 
     return GamesTourModel(
       gameId: id,
+      source: GameSource.gamebase,
       whitePlayer: whitePlayer,
       blackPlayer: blackPlayer,
       whiteTimeDisplay: '--:--',

--- a/lib/screens/player_profile/provider/player_profile_provider.dart
+++ b/lib/screens/player_profile/provider/player_profile_provider.dart
@@ -583,6 +583,7 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
 
         return GamesTourModel(
           gameId: safeId,
+          source: GameSource.twic,
           whitePlayer: whiteCard,
           blackPlayer: blackCard,
           whiteTimeDisplay: '--:--',
@@ -768,6 +769,7 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
 
         return GamesTourModel(
           gameId: safeId,
+          source: GameSource.twic,
           whitePlayer: whiteCard,
           blackPlayer: blackCard,
           whiteTimeDisplay: '--:--',
@@ -2889,6 +2891,7 @@ class PlayerProfileGamesNotifier
 
     return GamesTourModel(
       gameId: safeId,
+      source: GameSource.twic,
       whitePlayer: whiteCard,
       blackPlayer: blackCard,
       whiteTimeDisplay: '--:--',

--- a/lib/screens/standings/providers/twic_scorecard_event_games_provider.dart
+++ b/lib/screens/standings/providers/twic_scorecard_event_games_provider.dart
@@ -212,6 +212,7 @@ GamesTourModel _mapPlayerGameRowToModel(
 
   return GamesTourModel(
     gameId: gameId,
+    source: GameSource.twic,
     whitePlayer: whiteCard,
     blackPlayer: blackCard,
     whiteTimeDisplay: '--:--',

--- a/lib/screens/tour_detail/games_tour/models/games_tour_model.dart
+++ b/lib/screens/tour_detail/games_tour/models/games_tour_model.dart
@@ -3,6 +3,16 @@ import 'package:dartchess/dartchess.dart';
 
 enum GameDisplayMode { all, hideFinishedGames, showfinishedGame }
 
+enum GameSource {
+  supabase,
+  gamebase,
+  twic,
+  openingExplorer,
+  boardEditor,
+  savedAnalysis,
+  localAnalysis,
+}
+
 class GamesScreenModel {
   GamesScreenModel({
     required this.gamesTourModels,
@@ -48,6 +58,7 @@ class GamesScreenModel {
 
 class GamesTourModel {
   final String gameId;
+  final GameSource source;
   final PlayerCard whitePlayer;
   final PlayerCard blackPlayer;
   final String whiteTimeDisplay;
@@ -73,6 +84,7 @@ class GamesTourModel {
 
   GamesTourModel({
     required this.gameId,
+    this.source = GameSource.supabase,
     required this.whitePlayer,
     required this.blackPlayer,
     required this.whiteTimeDisplay,
@@ -98,6 +110,7 @@ class GamesTourModel {
 
   GamesTourModel copyWith({
     String? gameId,
+    GameSource? source,
     PlayerCard? whitePlayer,
     PlayerCard? blackPlayer,
     String? whiteTimeDisplay,
@@ -122,6 +135,7 @@ class GamesTourModel {
   }) {
     return GamesTourModel(
       gameId: gameId ?? this.gameId,
+      source: source ?? this.source,
       whitePlayer: whitePlayer ?? this.whitePlayer,
       blackPlayer: blackPlayer ?? this.blackPlayer,
       whiteTimeDisplay: whiteTimeDisplay ?? this.whiteTimeDisplay,
@@ -252,6 +266,7 @@ class GamesTourModel {
 
       return GamesTourModel(
         gameId: game.id,
+        source: GameSource.supabase,
         whitePlayer: PlayerCard.fromPlayer(white),
         blackPlayer: PlayerCard.fromPlayer(black),
         whiteTimeDisplay: whiteTimeDisplay,
@@ -551,6 +566,7 @@ class GamesTourModel {
     if (identical(this, other)) return true;
     return other is GamesTourModel &&
         other.gameId == gameId &&
+        other.source == source &&
         other.whitePlayer == whitePlayer &&
         other.blackPlayer == blackPlayer &&
         other.whiteTimeDisplay == whiteTimeDisplay &&
@@ -573,6 +589,7 @@ class GamesTourModel {
   @override
   int get hashCode {
     return gameId.hashCode ^
+        source.hashCode ^
         whitePlayer.hashCode ^
         blackPlayer.hashCode ^
         whiteTimeDisplay.hashCode ^

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -250,9 +250,10 @@ class DeepLinkService {
 
       debugPrint('DeepLinkService: Fetching game: $gameId');
 
-      // Fetch the tapped game from Supabase
+      // Fetch the tapped game from Supabase.
+      // getGameByAnyId handles both Supabase UUIDs and Lichess short IDs.
       final gameRepo = ref.read(gameRepositoryProvider);
-      final game = await gameRepo.getGameById(gameId).timeout(_fetchTimeout);
+      final game = await gameRepo.getGameByAnyId(gameId).timeout(_fetchTimeout);
       final gameTourModel = GamesTourModel.fromGame(game);
       List<GamesTourModel> gameList = <GamesTourModel>[gameTourModel];
       var openIndex = 0;
@@ -580,71 +581,6 @@ class DeepLinkService {
       tourId: resolvedTourId,
       roundId: resolvedRoundId,
     );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Sort helpers — same logic as game_card_wrapper_provider.dart
-  // ---------------------------------------------------------------------------
-
-  /// Sorts games to match tour detail screen ordering.
-  /// Order: round descending -> game number descending -> board number ascending
-  List<Games> _sortGamesForNavigation(List<Games> games) {
-    if (games.isEmpty) return games;
-
-    final gameInfo = <String, (int, int)>{};
-    for (final game in games) {
-      gameInfo[game.id] = (
-        _extractRoundNumber(game.roundSlug),
-        _extractGameNumber(game.roundSlug),
-      );
-    }
-
-    final sortedGames = List<Games>.from(games);
-    sortedGames.sort((a, b) {
-      final (roundA, gameA) = gameInfo[a.id] ?? (0, 0);
-      final (roundB, gameB) = gameInfo[b.id] ?? (0, 0);
-
-      if (roundA != roundB) return roundB.compareTo(roundA);
-      if (gameA != gameB) return gameB.compareTo(gameA);
-
-      final aBoard = a.boardNr, bBoard = b.boardNr;
-      if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
-      if (aBoard != null) return -1;
-      if (bBoard != null) return 1;
-      return 0;
-    });
-
-    return sortedGames;
-  }
-
-  /// Extracts round number from round slug (e.g., "round-5" -> 5).
-  /// Named knockout stages get high numbers so they sort after numbered rounds.
-  int _extractRoundNumber(String roundSlug) {
-    final slug = roundSlug.toLowerCase();
-    if (slug.contains('final') &&
-        !slug.contains('quarter') &&
-        !slug.contains('semi')) {
-      return 10000;
-    }
-    if (slug.contains('semifinal') || slug.contains('semi-final')) {
-      return 9000;
-    }
-    if (slug.contains('quarterfinal') || slug.contains('quarter-final')) {
-      return 8000;
-    }
-    final match =
-        RegExp(r'round-?(\d+)', caseSensitive: false).firstMatch(roundSlug) ??
-        RegExp(r'(\d+)').firstMatch(roundSlug);
-    return int.tryParse(match?.group(1) ?? '0') ?? 0;
-  }
-
-  /// Extracts game number from round slug (e.g., "round-6--game-2" -> 2).
-  int _extractGameNumber(String roundSlug) {
-    final match = RegExp(
-      r'game-?(\d+)',
-      caseSensitive: false,
-    ).firstMatch(roundSlug);
-    return int.tryParse(match?.group(1) ?? '0') ?? 0;
   }
 
   /// Dispose of resources

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -254,6 +254,9 @@ class DeepLinkService {
       // getGameByAnyId handles both Supabase UUIDs and Lichess short IDs.
       final gameRepo = ref.read(gameRepositoryProvider);
       final game = await gameRepo.getGameByAnyId(gameId).timeout(_fetchTimeout);
+      // Normalize to Supabase UUID so round-game index lookup works regardless
+      // of whether the deep link contained a Lichess short ID or a UUID.
+      final resolvedGameId = game.id;
       final gameTourModel = GamesTourModel.fromGame(game);
       List<GamesTourModel> gameList = <GamesTourModel>[gameTourModel];
       var openIndex = 0;
@@ -272,7 +275,7 @@ class DeepLinkService {
             if (aBoard != bBoard) return aBoard.compareTo(bBoard);
             return a.gameId.compareTo(b.gameId);
           });
-          final idx = gameList.indexWhere((g) => g.gameId == gameId);
+          final idx = gameList.indexWhere((g) => g.gameId == resolvedGameId);
           openIndex = idx >= 0 ? idx : 0;
         }
       } catch (e) {

--- a/test/repository/supabase/game_repository_get_by_any_id_test.dart
+++ b/test/repository/supabase/game_repository_get_by_any_id_test.dart
@@ -1,0 +1,225 @@
+// Tests for GameRepository.getGameByAnyId
+//
+// Strategy: extend GameRepository (so the real routing logic runs untouched)
+// and override only getGameById / getGameByLichessId to record calls and
+// return stub data.  No actual Supabase queries are made.
+//
+// BaseRepository's field initialiser (Supabase.instance.client) requires the
+// Supabase singleton to exist, so we call Supabase.initialize() once in
+// setUpAll with placeholder credentials.  The overridden methods never touch
+// the client, so the fake URL/key have no effect on test behaviour.
+
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+// ---------------------------------------------------------------------------
+// Tracking fake
+// ---------------------------------------------------------------------------
+
+/// Subclass of the real [GameRepository] that intercepts the two leaf methods
+/// so we can assert which one [getGameByAnyId] chose to delegate to.
+class _TrackingGameRepository extends GameRepository {
+  String? calledGetByIdWith;
+  String? calledGetByLichessIdWith;
+
+  void reset() {
+    calledGetByIdWith = null;
+    calledGetByLichessIdWith = null;
+  }
+
+  @override
+  Future<Games> getGameById(String id) async {
+    calledGetByIdWith = id;
+    return _stubGame(id);
+  }
+
+  @override
+  Future<Games> getGameByLichessId(String lichessId) async {
+    calledGetByLichessIdWith = lichessId;
+    return _stubGame(lichessId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+Games _stubGame(String id) => Games(
+  id: id,
+  roundId: 'round-1',
+  roundSlug: 'round-1',
+  tourId: 'tour-1',
+  tourSlug: 'tour-slug',
+  players: [
+    Player(
+      name: 'White Player',
+      title: 'GM',
+      rating: 2700,
+      fideId: 1,
+      fed: 'USA',
+      clock: 0,
+      team: '',
+    ),
+    Player(
+      name: 'Black Player',
+      title: 'IM',
+      rating: 2650,
+      fideId: 2,
+      fed: 'RUS',
+      clock: 0,
+      team: '',
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUpAll(() async {
+    // Required for platform-channel calls made during Supabase.initialize().
+    TestWidgetsFlutterBinding.ensureInitialized();
+
+    // supabase_flutter calls SharedPreferences.getInstance() during init to
+    // restore a previous auth session.  Provide an empty in-memory store so
+    // the platform channel is satisfied without touching the device.
+    SharedPreferences.setMockInitialValues({});
+
+    // One-time setup: satisfy BaseRepository's `Supabase.instance.client`
+    // field initialiser.  Calling initialize() a second time is a no-op in
+    // supabase_flutter, so this is safe when the suite runs alongside others.
+    await Supabase.initialize(
+      url: 'https://placeholder.supabase.co',
+      anonKey: 'placeholder-anon-key',
+    );
+  });
+
+  late _TrackingGameRepository repo;
+  setUp(() => repo = _TrackingGameRepository());
+
+  // -------------------------------------------------------------------------
+  group('getGameByAnyId — UUID routing', () {
+    test('lowercase UUID routes to getGameById', () async {
+      const id = 'fe6351a5-6354-4c16-b7f6-9124e5d9a9ef';
+      await repo.getGameByAnyId(id);
+
+      expect(repo.calledGetByIdWith, equals(id));
+      expect(repo.calledGetByLichessIdWith, isNull);
+    });
+
+    test('uppercase UUID routes to getGameById (case-insensitive regex)', () async {
+      const id = 'FE6351A5-6354-4C16-B7F6-9124E5D9A9EF';
+      await repo.getGameByAnyId(id);
+
+      expect(repo.calledGetByIdWith, equals(id));
+      expect(repo.calledGetByLichessIdWith, isNull);
+    });
+
+    test('mixed-case UUID routes to getGameById', () async {
+      const id = 'Fe6351A5-6354-4C16-b7f6-9124e5d9a9ef';
+      await repo.getGameByAnyId(id);
+
+      expect(repo.calledGetByIdWith, equals(id));
+      expect(repo.calledGetByLichessIdWith, isNull);
+    });
+
+    test('UUID with leading/trailing whitespace is trimmed then routes to getGameById',
+        () async {
+      const bare = 'fe6351a5-6354-4c16-b7f6-9124e5d9a9ef';
+      await repo.getGameByAnyId('  $bare  ');
+
+      expect(repo.calledGetByIdWith, equals(bare), reason: 'trimmed value passed');
+      expect(repo.calledGetByLichessIdWith, isNull);
+    });
+
+    test('returns the Games object produced by getGameById', () async {
+      const id = 'fe6351a5-6354-4c16-b7f6-9124e5d9a9ef';
+      final result = await repo.getGameByAnyId(id);
+
+      expect(result.id, equals(id));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('getGameByAnyId — short-ID (Lichess) routing', () {
+    test('8-char alphanumeric Lichess ID routes to getGameByLichessId', () async {
+      const id = '4uVwSr9q';
+      await repo.getGameByAnyId(id);
+
+      expect(repo.calledGetByLichessIdWith, equals(id));
+      expect(repo.calledGetByIdWith, isNull);
+    });
+
+    test('short ID with leading/trailing whitespace is trimmed then routes to getGameByLichessId',
+        () async {
+      const bare = '4uVwSr9q';
+      await repo.getGameByAnyId('  $bare  ');
+
+      expect(repo.calledGetByLichessIdWith, equals(bare), reason: 'trimmed value passed');
+      expect(repo.calledGetByIdWith, isNull);
+    });
+
+    test('returns the Games object produced by getGameByLichessId', () async {
+      const id = '4uVwSr9q';
+      final result = await repo.getGameByAnyId(id);
+
+      expect(result.id, equals(id));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('getGameByAnyId — non-UUID formats always route to getGameByLichessId', () {
+    test('UUID without dashes is not a valid UUID', () async {
+      // 32 hex chars, no dashes — looks UUID-ish but fails the pattern
+      await repo.getGameByAnyId('fe6351a563544c16b7f69124e5d9a9ef');
+
+      expect(repo.calledGetByLichessIdWith, isNotNull);
+      expect(repo.calledGetByIdWith, isNull);
+    });
+
+    test('UUID with an extra trailing segment is not a valid UUID', () async {
+      await repo.getGameByAnyId('fe6351a5-6354-4c16-b7f6-9124e5d9a9ef-extra');
+
+      expect(repo.calledGetByLichessIdWith, isNotNull);
+      expect(repo.calledGetByIdWith, isNull);
+    });
+
+    test('numeric-only string routes to getGameByLichessId', () async {
+      await repo.getGameByAnyId('12345678');
+
+      expect(repo.calledGetByLichessIdWith, equals('12345678'));
+      expect(repo.calledGetByIdWith, isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('getGameByAnyId — no cross-contamination between sequential calls', () {
+    test('Lichess call followed by UUID call: each uses the correct method', () async {
+      await repo.getGameByAnyId('4uVwSr9q');
+      expect(repo.calledGetByLichessIdWith, equals('4uVwSr9q'));
+      expect(repo.calledGetByIdWith, isNull);
+
+      repo.reset();
+
+      await repo.getGameByAnyId('fe6351a5-6354-4c16-b7f6-9124e5d9a9ef');
+      expect(repo.calledGetByIdWith, equals('fe6351a5-6354-4c16-b7f6-9124e5d9a9ef'));
+      expect(repo.calledGetByLichessIdWith, isNull);
+    });
+
+    test('UUID call followed by Lichess call: each uses the correct method', () async {
+      await repo.getGameByAnyId('4f8a1b2c-3d4e-5f6a-7b8c-9d0e1f2a3b4c');
+      expect(repo.calledGetByIdWith, isNotNull);
+      expect(repo.calledGetByLichessIdWith, isNull);
+
+      repo.reset();
+
+      await repo.getGameByAnyId('AbCd1234');
+      expect(repo.calledGetByLichessIdWith, equals('AbCd1234'));
+      expect(repo.calledGetByIdWith, isNull);
+    });
+  });
+}

--- a/test/screens/chessboard/utils/game_share_utils_test.dart
+++ b/test/screens/chessboard/utils/game_share_utils_test.dart
@@ -1,0 +1,262 @@
+import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/screens/chessboard/utils/game_share_utils.dart';
+import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _canonicalGameId = 'fe6351a5-6354-4c16-b7f6-9124e5d9a9ef';
+const _fullPgn = '''
+[Event "Test Event"]
+[Site "ChessEver"]
+[Date "2026.03.25"]
+[White "White"]
+[Black "Black"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 *
+''';
+const _headerOnlyPgn = '''
+[Event "Test Event"]
+[Site "ChessEver"]
+[Date "2026.03.25"]
+[White "White"]
+[Black "Black"]
+[Result "*"]
+
+*
+''';
+
+GamesTourModel _game({
+  String gameId = _canonicalGameId,
+  GameSource source = GameSource.supabase,
+  String? pgn,
+}) {
+  return GamesTourModel(
+    gameId: gameId,
+    source: source,
+    whitePlayer: PlayerCard(
+      name: 'White',
+      federation: '',
+      title: '',
+      rating: 0,
+      countryCode: '',
+      team: null,
+      fideId: null,
+    ),
+    blackPlayer: PlayerCard(
+      name: 'Black',
+      federation: '',
+      title: '',
+      rating: 0,
+      countryCode: '',
+      team: null,
+      fideId: null,
+    ),
+    whiteTimeDisplay: '--:--',
+    blackTimeDisplay: '--:--',
+    whiteClockCentiseconds: 0,
+    blackClockCentiseconds: 0,
+    gameStatus: GameStatus.ongoing,
+    roundId: 'round',
+    roundSlug: 'A00',
+    tourId: 'tour',
+    tourSlug: 'tour-slug',
+    pgn: pgn,
+  );
+}
+
+SavedAnalysisData _savedAnalysisData({String? sourceGameId}) {
+  return SavedAnalysisData(
+    analysisId: 'analysis-1',
+    sourceGameId: sourceGameId,
+    chessGame: ChessGame.fromPgn('saved', _fullPgn),
+    variationComments: const <String, String>{},
+    isBoardFlipped: false,
+    lastViewedPosition: 0,
+  );
+}
+
+void main() {
+  group('buildGameShareUrl', () {
+    test('returns a deep link for canonical Supabase games', () {
+      final url = buildGameShareUrl(game: _game());
+
+      expect(url, 'https://chessever.com/games/$_canonicalGameId');
+    });
+
+    test(
+      'returns a deep link for saved analyses with canonical source IDs',
+      () {
+        final url = buildGameShareUrl(
+          game: _game(
+            gameId: 'saved_analysis_1',
+            source: GameSource.savedAnalysis,
+          ),
+          savedAnalysisData: _savedAnalysisData(sourceGameId: _canonicalGameId),
+        );
+
+        expect(url, 'https://chessever.com/games/$_canonicalGameId');
+      },
+    );
+
+    test(
+      'returns null for non-canonical sources and unresolved saved analyses',
+      () {
+        expect(
+          buildGameShareUrl(
+            game: _game(gameId: 'gamebase-1', source: GameSource.gamebase),
+          ),
+          isNull,
+        );
+        expect(
+          buildGameShareUrl(
+            game: _game(gameId: 'twic-1', source: GameSource.twic),
+          ),
+          isNull,
+        );
+        expect(
+          buildGameShareUrl(
+            game: _game(
+              gameId: 'explorer_123',
+              source: GameSource.openingExplorer,
+            ),
+          ),
+          isNull,
+        );
+        expect(
+          buildGameShareUrl(
+            game: _game(gameId: 'editor_123', source: GameSource.boardEditor),
+          ),
+          isNull,
+        );
+        expect(
+          buildGameShareUrl(
+            game: _game(gameId: 'local_123', source: GameSource.localAnalysis),
+          ),
+          isNull,
+        );
+        expect(
+          buildGameShareUrl(
+            game: _game(
+              gameId: 'saved_analysis_1',
+              source: GameSource.savedAnalysis,
+            ),
+            savedAnalysisData: _savedAnalysisData(sourceGameId: 'gamebase-1'),
+          ),
+          isNull,
+        );
+      },
+    );
+  });
+
+  group('resolveGameSharePgn', () {
+    test('prefers the parsed analysis game and skips remote fetches', () async {
+      var supabaseCalls = 0;
+      var gamebaseCalls = 0;
+
+      final resolved = await resolveGameSharePgn(
+        game: _game(pgn: _headerOnlyPgn),
+        analysisGame: ChessGame.fromPgn('analysis', _fullPgn),
+        savedAnalysisData: null,
+        fetchSupabasePgn: (_) async {
+          supabaseCalls++;
+          return _fullPgn;
+        },
+        fetchGamebasePgn: (_) async {
+          gamebaseCalls++;
+          return _fullPgn;
+        },
+      );
+
+      expect(resolved, contains('1. e4 e5'));
+      expect(supabaseCalls, 0);
+      expect(gamebaseCalls, 0);
+    });
+
+    test(
+      'keeps local widget PGN for early share when it already has moves',
+      () async {
+        final resolved = await resolveGameSharePgn(
+          game: _game(
+            gameId: 'explorer_1',
+            source: GameSource.openingExplorer,
+            pgn: _fullPgn,
+          ),
+          analysisGame: null,
+          savedAnalysisData: null,
+        );
+
+        expect(resolved, contains('1. e4 e5'));
+      },
+    );
+
+    test('upgrades a header-only canonical PGN via Supabase fetch', () async {
+      final resolved = await resolveGameSharePgn(
+        game: _game(pgn: _headerOnlyPgn),
+        analysisGame: null,
+        savedAnalysisData: null,
+        fetchSupabasePgn: (_) async => _fullPgn,
+      );
+
+      expect(resolved, contains('1. e4 e5'));
+    });
+
+    test(
+      'falls back to saved analysis PGN before header-only fallback',
+      () async {
+        final resolved = await resolveGameSharePgn(
+          game: _game(
+            gameId: 'saved_analysis_1',
+            source: GameSource.savedAnalysis,
+            pgn: _headerOnlyPgn,
+          ),
+          analysisGame: null,
+          savedAnalysisData: _savedAnalysisData(sourceGameId: _canonicalGameId),
+        );
+
+        expect(resolved, contains('1. e4 e5'));
+      },
+    );
+
+    test('upgrades a header-only Gamebase PGN via Gamebase fetch', () async {
+      final resolved = await resolveGameSharePgn(
+        game: _game(
+          gameId: 'gamebase-1',
+          source: GameSource.gamebase,
+          pgn: _headerOnlyPgn,
+        ),
+        analysisGame: null,
+        savedAnalysisData: null,
+        fetchGamebasePgn: (_) async => _fullPgn,
+      );
+
+      expect(resolved, contains('1. e4 e5'));
+    });
+  });
+
+  group('buildGameShareSnapshot', () {
+    test('parses the PGN when the board state is still loading', () {
+      final game = _game(
+        gameId: 'explorer_1',
+        source: GameSource.openingExplorer,
+        pgn: _fullPgn,
+      );
+      final state = ChessBoardStateNew(
+        game: game,
+        pgnData: null,
+        isLoadingMoves: true,
+      );
+
+      final snapshot = buildGameShareSnapshot(
+        game: game,
+        pgn: _fullPgn,
+        state: state,
+      );
+
+      expect(snapshot.moveSans, isNotEmpty);
+      expect(snapshot.currentMoveIndex, snapshot.moveSans.length - 1);
+      expect(snapshot.positionFen, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
- Games.fromJson crashed on null `search` column → silent home redirect
- getGameById used bare SELECT * instead of _gameListSelectColumns
- Added getGameByAnyId to resolve both Supabase UUIDs and Lichess short IDs
- shareGameBtnClicked fetched PGN from Supabase only, breaking TWIC/gamebase/analysis board games
- copyPgnBtnClicked had no error handling or user feedback
- Snackbars updated to match app theme
- Removed dead sort helpers from DeepLinkService
- 13-case unit test added for getGameByAnyId routing logic