### PR TITLE
Add a safeguard

### DIFF
--- a/lib/screens/favorites/tabs/favorites_players_tab.dart
+++ b/lib/screens/favorites/tabs/favorites_players_tab.dart
@@ -610,7 +610,18 @@ class _FavoritesPlayersTabState extends ConsumerState<FavoritesPlayersTab>
 
       // Check favorite limit before adding
       if (!currentlyFavorite) {
-        final canAdd = await canAddMoreFavorites(context, ref);
+        final currentCount =
+            ref
+                .read(favoritePlayersNotifierProvider)
+                .valueOrNull
+                ?.players
+                .length ??
+            0;
+        final canAdd = await canAddMoreFavorites(
+          context,
+          ref,
+          currentSelectedCount: currentCount,
+        );
         if (!canAdd) return;
       }
 


### PR DESCRIPTION
When a free user click 4th favorite inside favorites (players), it adds a heart instead of pushing the paywall.