### PR TITLE
Align For You event games with Games tab logic

### DIFF
--- a/lib/providers/event_pin_refresh_provider.dart
+++ b/lib/providers/event_pin_refresh_provider.dart
@@ -1,0 +1,24 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Per-event signal used to force For You snapshots to recompute when pin state
+/// changes from outside the For You tab or other event-scoped refreshes happen.
+final eventPinRefreshProvider = StateProvider.family<int, String>(
+  (ref, eventId) => 0,
+);
+
+void bumpEventPinRefreshSignal(Ref ref, String? eventId) {
+  if (eventId == null || eventId.isEmpty) {
+    return;
+  }
+
+  final notifier = ref.read(eventPinRefreshProvider(eventId).notifier);
+  notifier.state++;
+}
+
+/// Global signal used to ask all active For You event snapshots to revalidate.
+final forYouEventsRefreshProvider = StateProvider<int>((ref) => 0);
+
+void bumpForYouEventsRefreshSignal(Ref ref) {
+  final notifier = ref.read(forYouEventsRefreshProvider.notifier);
+  notifier.state++;
+}

--- a/lib/providers/for_you_games_logic.dart
+++ b/lib/providers/for_you_games_logic.dart
@@ -1,0 +1,922 @@
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/repository/supabase/round/round.dart';
+import 'package:chessever2/repository/supabase/tour/tour.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/knockout_tournament_state_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/utils/knockout_match_detector.dart';
+import 'package:collection/collection.dart';
+
+class ForYouEventGamesSnapshot {
+  ForYouEventGamesSnapshot({
+    required this.eventId,
+    required this.tourId,
+    required List<GamesTourModel> visibleGames,
+    required List<String> pinnedIds,
+    List<String> manualPinnedIds = const [],
+    List<String> autoPinnedIds = const [],
+    List<String> unpinnedOverrideIds = const [],
+  }) : visibleGames = List<GamesTourModel>.unmodifiable(visibleGames),
+       pinnedIds = List<String>.unmodifiable(pinnedIds),
+       manualPinnedIds = List<String>.unmodifiable(manualPinnedIds),
+       autoPinnedIds = List<String>.unmodifiable(autoPinnedIds),
+       unpinnedOverrideIds = List<String>.unmodifiable(unpinnedOverrideIds);
+
+  final String eventId;
+  final String tourId;
+  final List<GamesTourModel> visibleGames;
+  final List<String> pinnedIds;
+  final List<String> manualPinnedIds;
+  final List<String> autoPinnedIds;
+  final List<String> unpinnedOverrideIds;
+
+  bool get hasGames => visibleGames.isNotEmpty;
+}
+
+bool areEquivalentForYouSnapshots(
+  ForYouEventGamesSnapshot a,
+  ForYouEventGamesSnapshot b,
+) {
+  return a.eventId == b.eventId &&
+      a.tourId == b.tourId &&
+      _stringListsEqual(a.pinnedIds, b.pinnedIds) &&
+      _stringListsEqual(a.manualPinnedIds, b.manualPinnedIds) &&
+      _stringListsEqual(a.autoPinnedIds, b.autoPinnedIds) &&
+      _stringListsEqual(a.unpinnedOverrideIds, b.unpinnedOverrideIds) &&
+      _gamesListsEqual(a.visibleGames, b.visibleGames);
+}
+
+bool _stringListsEqual(List<String> a, List<String> b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _gamesListsEqual(List<GamesTourModel> a, List<GamesTourModel> b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var i = 0; i < a.length; i++) {
+    if (!_gamesEqual(a[i], b[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _gamesEqual(GamesTourModel a, GamesTourModel b) {
+  return a.gameId == b.gameId &&
+      _playerCardsEqual(a.whitePlayer, b.whitePlayer) &&
+      _playerCardsEqual(a.blackPlayer, b.blackPlayer) &&
+      a.whiteTimeDisplay == b.whiteTimeDisplay &&
+      a.blackTimeDisplay == b.blackTimeDisplay &&
+      a.whiteClockCentiseconds == b.whiteClockCentiseconds &&
+      a.blackClockCentiseconds == b.blackClockCentiseconds &&
+      a.whiteClockSeconds == b.whiteClockSeconds &&
+      a.blackClockSeconds == b.blackClockSeconds &&
+      a.gameStatus == b.gameStatus &&
+      a.fen == b.fen &&
+      a.pgn == b.pgn &&
+      a.lastMove == b.lastMove &&
+      a.boardNr == b.boardNr &&
+      a.roundId == b.roundId &&
+      a.roundSlug == b.roundSlug &&
+      a.tourId == b.tourId &&
+      a.tourSlug == b.tourSlug &&
+      a.lastMoveTime == b.lastMoveTime &&
+      a.eco == b.eco &&
+      a.openingName == b.openingName &&
+      a.timeControl == b.timeControl;
+}
+
+bool _playerCardsEqual(PlayerCard a, PlayerCard b) {
+  return a.name == b.name &&
+      a.federation == b.federation &&
+      a.title == b.title &&
+      a.rating == b.rating &&
+      a.countryCode == b.countryCode &&
+      a.fideId == b.fideId &&
+      a.team == b.team &&
+      a.gamebasePlayerId == b.gamebasePlayerId;
+}
+
+ForYouEventGamesSnapshot buildForYouEventGamesSnapshot({
+  required String eventId,
+  required Tour selectedTour,
+  required List<Tour> eventTours,
+  required List<Round> selectedTourRounds,
+  required Map<String, List<Round>> roundsByTourId,
+  required List<Games> selectedTourGames,
+  required Map<String, List<Games>> gamesByTourId,
+  required List<String> liveRoundIds,
+  required List<String> pinnedIds,
+  List<String> manualPinnedIds = const [],
+  List<String> autoPinnedIds = const [],
+  List<String> unpinnedOverrideIds = const [],
+}) {
+  final primaryGames = _mapGames(selectedTourGames);
+  final isKnockoutTournament = isKnockoutTour(
+    tour: selectedTour,
+    games: selectedTourGames,
+  );
+  final isGroupEvent =
+      !isKnockoutTournament &&
+      selectedTour.players.isNotEmpty &&
+      selectedTour.players.every((player) => player.team != null);
+
+  final sortedPrimaryGames = sortGamesForGamesTab(
+    games: selectedTourGames,
+    pinnedIds: pinnedIds,
+  );
+
+  final roundSortMeta = <String, _RoundSortMeta>{
+    for (final round in selectedTourRounds)
+      round.id: _RoundSortMeta.fromRound(round),
+  };
+
+  final baseRounds =
+      selectedTourRounds
+          .map((round) => GamesAppBarModel.fromRound(round, liveRoundIds))
+          .toList();
+
+  final processedRounds = _buildProcessedRounds(
+    selectedTour: selectedTour,
+    eventTours: eventTours,
+    baseRounds: baseRounds,
+    roundsByTourId: roundsByTourId,
+    gamesByTourId: gamesByTourId,
+    liveRoundIds: liveRoundIds,
+    roundSortMeta: roundSortMeta,
+    primaryGames: primaryGames,
+    isKnockoutTournament: isKnockoutTournament,
+  );
+
+  _sortRounds(processedRounds, roundSortMeta);
+
+  final gamesByRound = _buildGamesByRound(
+    selectedTour: selectedTour,
+    processedRounds: processedRounds,
+    selectedTourGames: selectedTourGames,
+    selectedTourSortedGames: sortedPrimaryGames,
+    gamesByTourId: gamesByTourId,
+    isKnockoutTournament: isKnockoutTournament,
+    pinnedIds: pinnedIds,
+  );
+
+  final visibleRounds = _visibleRounds(
+    rounds: processedRounds,
+    gamesByRound: gamesByRound,
+    roundSortMeta: roundSortMeta,
+  );
+
+  final orderedVisibleGames =
+      isGroupEvent
+          ? _flattenGroupEventGames(
+            visibleRounds: visibleRounds,
+            orderedTourGames: sortedPrimaryGames,
+          )
+          : _flattenVisibleGames(
+            visibleRounds: visibleRounds,
+            gamesByRound: gamesByRound,
+            isKnockoutTournament: isKnockoutTournament,
+          );
+
+  return ForYouEventGamesSnapshot(
+    eventId: eventId,
+    tourId: selectedTour.id,
+    visibleGames: orderedVisibleGames,
+    pinnedIds: pinnedIds,
+    manualPinnedIds: manualPinnedIds,
+    autoPinnedIds: autoPinnedIds,
+    unpinnedOverrideIds: unpinnedOverrideIds,
+  );
+}
+
+bool isKnockoutTour({required Tour tour, required List<Games> games}) {
+  if (_formatSuggestsKnockout(tour.info.format)) {
+    return true;
+  }
+  return KnockoutMatchDetector.isKnockoutMatchFormat(_mapGames(games));
+}
+
+List<GamesTourModel> sortGamesForGamesTab({
+  required List<Games> games,
+  required List<String> pinnedIds,
+}) {
+  if (games.isEmpty) {
+    return const [];
+  }
+
+  final parsedGames = <GamesTourModel>[];
+  for (final game in games) {
+    try {
+      parsedGames.add(GamesTourModel.fromGame(game));
+    } catch (_) {
+      // Ignore malformed game rows to match tournament detail resiliency.
+    }
+  }
+
+  final sortedGames = List<GamesTourModel>.from(parsedGames);
+  sortedGames.sort((a, b) {
+    final aPinned = pinnedIds.contains(a.gameId);
+    final bPinned = pinnedIds.contains(b.gameId);
+    if (aPinned && !bPinned) return -1;
+    if (!aPinned && bPinned) return 1;
+
+    if (aPinned && bPinned) {
+      final aIndex = pinnedIds.indexOf(a.gameId);
+      final bIndex = pinnedIds.indexOf(b.gameId);
+      if (aIndex != bIndex) {
+        return aIndex.compareTo(bIndex);
+      }
+    }
+
+    final roundA = _extractRoundNumber(a.roundSlug);
+    final roundB = _extractRoundNumber(b.roundSlug);
+    if (roundA != roundB) {
+      return roundB.compareTo(roundA);
+    }
+
+    final gameA = _extractGameNumber(a.roundSlug);
+    final gameB = _extractGameNumber(b.roundSlug);
+    if (gameA != gameB) {
+      return gameB.compareTo(gameA);
+    }
+
+    final aBoard = a.boardNr;
+    final bBoard = b.boardNr;
+    if (aBoard != null && bBoard != null) {
+      return aBoard.compareTo(bBoard);
+    }
+    if (aBoard != null) return -1;
+    if (bBoard != null) return 1;
+    return 0;
+  });
+
+  return sortedGames;
+}
+
+List<String> mergePinnedIds({
+  required List<String> manualPins,
+  required List<String> autoPins,
+}) {
+  final seen = <String>{};
+  final merged = <String>[];
+
+  for (final pin in manualPins) {
+    if (seen.add(pin)) {
+      merged.add(pin);
+    }
+  }
+
+  for (final pin in autoPins) {
+    if (seen.add(pin)) {
+      merged.add(pin);
+    }
+  }
+
+  return merged;
+}
+
+List<GamesTourModel> _mapGames(List<Games> games) {
+  final models = <GamesTourModel>[];
+  for (final game in games) {
+    try {
+      models.add(GamesTourModel.fromGame(game));
+    } catch (_) {
+      // Ignore invalid display rows.
+    }
+  }
+  return models;
+}
+
+bool _formatSuggestsKnockout(String? format) {
+  if (format == null || format.isEmpty) return false;
+  final lower = format.toLowerCase();
+  return lower.contains('knockout') ||
+      lower.contains('single-elimination') ||
+      lower.contains('elimination');
+}
+
+List<GamesAppBarModel> _buildProcessedRounds({
+  required Tour selectedTour,
+  required List<Tour> eventTours,
+  required List<GamesAppBarModel> baseRounds,
+  required Map<String, List<Round>> roundsByTourId,
+  required Map<String, List<Games>> gamesByTourId,
+  required List<String> liveRoundIds,
+  required Map<String, _RoundSortMeta> roundSortMeta,
+  required List<GamesTourModel> primaryGames,
+  required bool isKnockoutTournament,
+}) {
+  if (!isKnockoutTournament) {
+    return baseRounds;
+  }
+
+  final relatedTours =
+      eventTours
+          .where(
+            (tour) => tour.groupBroadcastId == selectedTour.groupBroadcastId,
+          )
+          .toList()
+        ..sort((a, b) {
+          final aDate = a.dates.isNotEmpty ? a.dates.first : DateTime(1970);
+          final bDate = b.dates.isNotEmpty ? b.dates.first : DateTime(1970);
+          return bDate.compareTo(aDate);
+        });
+
+  if (relatedTours.length > 1) {
+    final stageModels = <GamesAppBarModel>[];
+
+    for (final tour in relatedTours) {
+      final tourRounds = roundsByTourId[tour.id] ?? const <Round>[];
+      if (tourRounds.isEmpty) {
+        continue;
+      }
+
+      final stageRoundModels =
+          tourRounds
+              .map((round) => GamesAppBarModel.fromRound(round, liveRoundIds))
+              .toList();
+      final tourGames = gamesByTourId[tour.id] ?? const <Games>[];
+      final tourModels = _mapGames(tourGames);
+      final stageIsKnockout =
+          _formatSuggestsKnockout(tour.info.format) ||
+          KnockoutMatchDetector.isKnockoutMatchFormat(tourModels);
+      if (!stageIsKnockout) {
+        continue;
+      }
+
+      final stageStartsAt = _resolveStageStartDate(
+        tour: tour,
+        stageRoundModels: stageRoundModels,
+      );
+      final stageName =
+          tour.name.contains('|')
+              ? tour.name.split('|').last.trim()
+              : tour.name;
+      final stageId = '$kKnockoutStagePrefix-${tour.id}';
+
+      roundSortMeta[stageId] = _RoundSortMeta(
+        slug: tour.slug,
+        createdAt: tour.createdAt,
+        startsAt: stageStartsAt,
+        roundNumber: _parseRoundNumber(stageName),
+        gameNumber: null,
+      );
+
+      stageModels.add(
+        GamesAppBarModel(
+          id: stageId,
+          name: stageName,
+          startsAt: stageStartsAt,
+          roundStatus: _aggregateStageStatus(stageRoundModels),
+        ),
+      );
+    }
+
+    if (stageModels.isNotEmpty) {
+      return stageModels;
+    }
+  }
+
+  final stageGamesMap = <String, List<GamesAppBarModel>>{};
+  for (final game in primaryGames) {
+    final slug = game.roundSlug?.trim();
+    if (slug == null || slug.isEmpty) {
+      continue;
+    }
+
+    final stagePart = slug.contains('--') ? slug.split('--').first : slug;
+    final stageName = _formatStageName(stagePart);
+    final matchingRound =
+        baseRounds.where((round) => round.id == game.roundId).firstOrNull;
+    if (matchingRound == null) {
+      continue;
+    }
+    stageGamesMap.putIfAbsent(stageName, () => []).add(matchingRound);
+  }
+
+  if (stageGamesMap.length > 1) {
+    final stageModels = <GamesAppBarModel>[];
+
+    for (final entry in stageGamesMap.entries) {
+      final stageRounds = entry.value.toSet().toList();
+      final stageStartsAt = stageRounds
+          .map((round) => round.startsAt)
+          .whereType<DateTime>()
+          .fold<DateTime?>(null, (latest, value) {
+            if (latest == null || value.isAfter(latest)) {
+              return value;
+            }
+            return latest;
+          });
+      final stageCreatedAt =
+          stageRounds
+              .map((round) => roundSortMeta[round.id]?.createdAt)
+              .whereType<DateTime>()
+              .fold<DateTime?>(null, (latest, value) {
+                if (latest == null || value.isAfter(latest)) {
+                  return value;
+                }
+                return latest;
+              }) ??
+          selectedTour.createdAt;
+      final stageId =
+          '$kKnockoutStagePrefix-${selectedTour.id}-${entry.key.toLowerCase().replaceAll(' ', '-')}';
+
+      roundSortMeta[stageId] = _RoundSortMeta(
+        slug: entry.key.toLowerCase().replaceAll(' ', '-'),
+        createdAt: stageCreatedAt,
+        startsAt: stageStartsAt,
+        roundNumber: _parseRoundNumber(entry.key),
+        gameNumber: null,
+      );
+
+      stageModels.add(
+        GamesAppBarModel(
+          id: stageId,
+          name: entry.key,
+          startsAt: stageStartsAt,
+          roundStatus: _aggregateStageStatus(stageRounds),
+        ),
+      );
+    }
+
+    return stageModels;
+  }
+
+  final logicalRoundId = '$kKnockoutStagePrefix-${selectedTour.id}';
+  final logicalRoundName =
+      selectedTour.name.contains('|')
+          ? selectedTour.name.split('|').last.trim()
+          : selectedTour.name;
+  final logicalStartsAt = _resolveStageStartDate(
+    tour: selectedTour,
+    stageRoundModels: baseRounds,
+  );
+
+  roundSortMeta[logicalRoundId] = _RoundSortMeta(
+    slug: baseRounds.firstOrNull?.name.toLowerCase().replaceAll(' ', '-') ?? '',
+    createdAt: selectedTour.createdAt,
+    startsAt: logicalStartsAt,
+    roundNumber: _parseRoundNumber(logicalRoundName),
+    gameNumber: null,
+  );
+
+  return [
+    GamesAppBarModel(
+      id: logicalRoundId,
+      name: logicalRoundName,
+      startsAt: logicalStartsAt,
+      roundStatus: _aggregateStageStatus(baseRounds),
+    ),
+  ];
+}
+
+Map<String, List<GamesTourModel>> _buildGamesByRound({
+  required Tour selectedTour,
+  required List<GamesAppBarModel> processedRounds,
+  required List<Games> selectedTourGames,
+  required List<GamesTourModel> selectedTourSortedGames,
+  required Map<String, List<Games>> gamesByTourId,
+  required bool isKnockoutTournament,
+  required List<String> pinnedIds,
+}) {
+  if (!isKnockoutTournament) {
+    final result = <String, List<GamesTourModel>>{};
+    for (final round in processedRounds) {
+      result[round.id] = selectedTourSortedGames
+          .where((game) => game.roundId == round.id)
+          .toList(growable: false);
+    }
+    return result;
+  }
+
+  final result = <String, List<GamesTourModel>>{
+    for (final round in processedRounds) round.id: <GamesTourModel>[],
+  };
+  final hasSyntheticStages = processedRounds.any(
+    (round) => round.id.startsWith('$kKnockoutStagePrefix-'),
+  );
+  final isRoundSlugDerivedStages =
+      hasSyntheticStages &&
+      processedRounds.any(
+        (round) =>
+            round.id.startsWith('$kKnockoutStagePrefix-${selectedTour.id}-'),
+      );
+
+  if (hasSyntheticStages && !isRoundSlugDerivedStages) {
+    for (final round in processedRounds) {
+      final stageTourId = round.id.replaceFirst('$kKnockoutStagePrefix-', '');
+      final stageGames = _mapGames(
+        gamesByTourId[stageTourId] ?? const <Games>[],
+      );
+      result[round.id] = _pinOnlySort(stageGames, pinnedIds);
+    }
+    return result;
+  }
+
+  if (isRoundSlugDerivedStages) {
+    for (final game in selectedTourSortedGames) {
+      final gameSlug = (game.roundSlug ?? '').trim().toLowerCase();
+      if (gameSlug.isEmpty) {
+        continue;
+      }
+
+      final stagePart = (gameSlug.contains('--')
+              ? gameSlug.split('--').first
+              : gameSlug)
+          .replaceAll(' ', '-');
+
+      for (final round in processedRounds) {
+        if (!round.id.startsWith('$kKnockoutStagePrefix-')) {
+          continue;
+        }
+
+        final roundStagePart = round.id.split('-').skip(3).join('-');
+        if (roundStagePart == stagePart) {
+          result[round.id]!.add(game);
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
+  final selectedStageId = '$kKnockoutStagePrefix-${selectedTour.id}';
+  result[selectedStageId] = _pinOnlySort(
+    _mapGames(selectedTourGames),
+    pinnedIds,
+  );
+  return result;
+}
+
+List<GamesAppBarModel> _visibleRounds({
+  required List<GamesAppBarModel> rounds,
+  required Map<String, List<GamesTourModel>> gamesByRound,
+  required Map<String, _RoundSortMeta> roundSortMeta,
+}) {
+  final isMultiStageKnockout = rounds.any(
+    (round) => round.id.startsWith('$kKnockoutStagePrefix-'),
+  );
+
+  final visibleRounds = <GamesAppBarModel>[];
+  for (final round in rounds) {
+    final roundGames = gamesByRound[round.id] ?? const <GamesTourModel>[];
+    if (roundGames.isEmpty) {
+      continue;
+    }
+
+    if (isMultiStageKnockout) {
+      visibleRounds.add(round);
+      continue;
+    }
+
+    final hasLiveOrOngoing = rounds.any(
+      (candidate) =>
+          candidate.roundStatus == RoundStatus.live ||
+          candidate.roundStatus == RoundStatus.ongoing,
+    );
+    final hasCompleted = rounds.any(
+      (candidate) => candidate.roundStatus == RoundStatus.completed,
+    );
+    final allAreUpcoming = rounds.every(
+      (candidate) =>
+          candidate.roundStatus == RoundStatus.upcoming ||
+          (gamesByRound[candidate.id]?.isEmpty ?? true),
+    );
+
+    if (allAreUpcoming) {
+      visibleRounds.add(round);
+      continue;
+    }
+
+    if (hasLiveOrOngoing) {
+      if (round.roundStatus != RoundStatus.upcoming) {
+        visibleRounds.add(round);
+      }
+      continue;
+    }
+
+    if (hasCompleted && round.roundStatus == RoundStatus.upcoming) {
+      final upcomingRounds =
+          rounds
+              .where(
+                (candidate) =>
+                    candidate.roundStatus == RoundStatus.upcoming &&
+                    (gamesByRound[candidate.id]?.isNotEmpty ?? false),
+              )
+              .toList()
+            ..sort((a, b) => _compareByStart(a, b, true, roundSortMeta));
+
+      if (upcomingRounds.isNotEmpty && upcomingRounds.first.id == round.id) {
+        visibleRounds.add(round);
+      }
+      continue;
+    }
+
+    if (round.roundStatus != RoundStatus.upcoming) {
+      visibleRounds.add(round);
+    }
+  }
+
+  return visibleRounds;
+}
+
+List<GamesTourModel> _flattenVisibleGames({
+  required List<GamesAppBarModel> visibleRounds,
+  required Map<String, List<GamesTourModel>> gamesByRound,
+  required bool isKnockoutTournament,
+}) {
+  final orderedGames = <GamesTourModel>[];
+
+  for (final round in visibleRounds) {
+    final roundGames = gamesByRound[round.id] ?? const <GamesTourModel>[];
+    if (roundGames.isEmpty) {
+      continue;
+    }
+
+    final isKnockoutRound =
+        isKnockoutTournament &&
+        (round.id.startsWith('$kKnockoutStagePrefix-') ||
+            round.id.toLowerCase().startsWith('knockout-round-'));
+
+    if (!isKnockoutRound) {
+      orderedGames.addAll(roundGames);
+      continue;
+    }
+
+    final matches = KnockoutMatchDetector.groupByMatches(roundGames);
+    for (final matchGames in matches.values) {
+      orderedGames.addAll(matchGames);
+    }
+  }
+
+  return orderedGames;
+}
+
+List<GamesTourModel> _flattenGroupEventGames({
+  required List<GamesAppBarModel> visibleRounds,
+  required List<GamesTourModel> orderedTourGames,
+}) {
+  final flattened = <GamesTourModel>[];
+
+  for (final round in visibleRounds) {
+    final grouped = _groupEventGames(round.id, orderedTourGames);
+    for (final games in grouped.values) {
+      flattened.addAll(games);
+    }
+  }
+
+  return flattened;
+}
+
+Map<String, List<GamesTourModel>> _groupEventGames(
+  String roundId,
+  List<GamesTourModel> games,
+) {
+  final grouped = <String, List<GamesTourModel>>{};
+  final roundGames = games
+      .where((game) => game.roundId == roundId)
+      .toList(growable: false);
+
+  for (final game in roundGames) {
+    final whiteTeam =
+        (game.whitePlayer.team?.isNotEmpty ?? false)
+            ? game.whitePlayer.team!
+            : game.whitePlayer.countryCode;
+    final blackTeam =
+        (game.blackPlayer.team?.isNotEmpty ?? false)
+            ? game.blackPlayer.team!
+            : game.blackPlayer.countryCode;
+    final matchupKey = _canonicalMatchupKey(whiteTeam, blackTeam);
+    grouped.putIfAbsent(matchupKey, () => <GamesTourModel>[]).add(game);
+  }
+
+  return grouped;
+}
+
+String _canonicalMatchupKey(String firstTeam, String secondTeam) {
+  final normalizedFirst = firstTeam.trim().toLowerCase();
+  final normalizedSecond = secondTeam.trim().toLowerCase();
+
+  if (normalizedFirst.compareTo(normalizedSecond) <= 0) {
+    return '$normalizedFirst\u0000$normalizedSecond';
+  }
+
+  return '$normalizedSecond\u0000$normalizedFirst';
+}
+
+List<GamesTourModel> _pinOnlySort(
+  List<GamesTourModel> games,
+  List<String> pinnedIds,
+) {
+  if (games.isEmpty || pinnedIds.isEmpty) {
+    return games;
+  }
+
+  final sorted = List<GamesTourModel>.from(games);
+  sorted.sort((a, b) {
+    final aPinned = pinnedIds.contains(a.gameId);
+    final bPinned = pinnedIds.contains(b.gameId);
+    if (aPinned == bPinned) {
+      return 0;
+    }
+    return aPinned ? -1 : 1;
+  });
+  return sorted;
+}
+
+RoundStatus _aggregateStageStatus(List<GamesAppBarModel> rounds) {
+  if (rounds.any((round) => round.roundStatus == RoundStatus.live)) {
+    return RoundStatus.live;
+  }
+  if (rounds.any((round) => round.roundStatus == RoundStatus.ongoing)) {
+    return RoundStatus.ongoing;
+  }
+  if (rounds.every((round) => round.roundStatus == RoundStatus.completed)) {
+    return RoundStatus.completed;
+  }
+  if (rounds.every((round) => round.roundStatus == RoundStatus.upcoming)) {
+    return RoundStatus.upcoming;
+  }
+  return RoundStatus.ongoing;
+}
+
+DateTime? _resolveStageStartDate({
+  required Tour tour,
+  required List<GamesAppBarModel> stageRoundModels,
+}) {
+  final candidates = <DateTime>[...tour.dates, tour.createdAt];
+  for (final round in stageRoundModels) {
+    if (round.startsAt != null) {
+      candidates.add(round.startsAt!);
+    }
+  }
+
+  if (candidates.isEmpty) {
+    return null;
+  }
+
+  return candidates.reduce(
+    (latest, date) => date.isAfter(latest) ? date : latest,
+  );
+}
+
+void _sortRounds(
+  List<GamesAppBarModel> rounds,
+  Map<String, _RoundSortMeta> roundSortMeta,
+) {
+  rounds.sort((a, b) {
+    final aStart = _roundEventDateTime(a, roundSortMeta);
+    final bStart = _roundEventDateTime(b, roundSortMeta);
+    if (aStart != null && bStart != null) {
+      final compare = bStart.compareTo(aStart);
+      if (compare != 0) {
+        return compare;
+      }
+    } else if (aStart != null) {
+      return -1;
+    } else if (bStart != null) {
+      return 1;
+    }
+
+    return a.name.compareTo(b.name);
+  });
+}
+
+int _compareByStart(
+  GamesAppBarModel a,
+  GamesAppBarModel b,
+  bool ascending,
+  Map<String, _RoundSortMeta> roundSortMeta,
+) {
+  final aStart = _roundEventDateTime(a, roundSortMeta);
+  final bStart = _roundEventDateTime(b, roundSortMeta);
+
+  int compare;
+  if (aStart == null && bStart == null) {
+    compare = a.name.compareTo(b.name);
+  } else if (aStart == null) {
+    compare = 1;
+  } else if (bStart == null) {
+    compare = -1;
+  } else {
+    compare = aStart.compareTo(bStart);
+    if (compare == 0) {
+      compare = a.name.compareTo(b.name);
+    }
+  }
+
+  return ascending ? compare : -compare;
+}
+
+DateTime? _roundEventDateTime(
+  GamesAppBarModel round,
+  Map<String, _RoundSortMeta> roundSortMeta,
+) {
+  final meta = roundSortMeta[round.id];
+  return meta?.startsAt ?? round.startsAt ?? meta?.createdAt;
+}
+
+String _formatStageName(String stagePart) {
+  final lower = stagePart.toLowerCase().trim();
+
+  if (lower.startsWith('round-')) {
+    return 'Round ${lower.replaceAll('round-', '')}';
+  }
+  if (lower == 'quarterfinals' || lower == 'quarterfinal') {
+    return 'Quarterfinals';
+  }
+  if (lower == 'semifinals' || lower == 'semifinal') {
+    return 'Semifinals';
+  }
+  if (lower == 'finals' || lower == 'final') {
+    return 'Finals';
+  }
+
+  return stagePart
+      .split(RegExp(r'[-_\s]'))
+      .where((value) => value.isNotEmpty)
+      .map((value) => value[0].toUpperCase() + value.substring(1))
+      .join(' ');
+}
+
+int _extractRoundNumber(String? roundSlug) {
+  return _parseRoundNumber(roundSlug) ?? 0;
+}
+
+int _extractGameNumber(String? roundSlug) {
+  return _parseGameNumber(roundSlug) ?? 0;
+}
+
+int? _parseRoundNumber(String? value) {
+  if (value == null || value.isEmpty) return null;
+
+  final lower = value.toLowerCase();
+  if (lower.contains('final') &&
+      !lower.contains('semifinal') &&
+      !lower.contains('quarterfinal')) {
+    return 300;
+  }
+  if (lower.contains('semifinal')) {
+    return 200;
+  }
+  if (lower.contains('quarterfinal')) {
+    return 100;
+  }
+
+  final match =
+      RegExp(r'round[\s_\-:]*?(\d+)', caseSensitive: false).firstMatch(value) ??
+      RegExp(r'\b(\d{1,3})\b').firstMatch(value);
+  return match == null ? null : int.tryParse(match.group(1)!);
+}
+
+int? _parseGameNumber(String? value) {
+  if (value == null || value.isEmpty) return null;
+  final match = RegExp(
+    r'(?:game|board|match)[\s_\-:]*?(\d+)',
+    caseSensitive: false,
+  ).firstMatch(value);
+  return match == null ? null : int.tryParse(match.group(1)!);
+}
+
+class _RoundSortMeta {
+  const _RoundSortMeta({
+    required this.slug,
+    required this.createdAt,
+    required this.startsAt,
+    required this.roundNumber,
+    required this.gameNumber,
+  });
+
+  final String slug;
+  final DateTime createdAt;
+  final DateTime? startsAt;
+  final int? roundNumber;
+  final int? gameNumber;
+
+  factory _RoundSortMeta.fromRound(Round round) {
+    return _RoundSortMeta(
+      slug: round.slug,
+      createdAt: round.createdAt,
+      startsAt: round.startsAt,
+      roundNumber:
+          _parseRoundNumber(round.name) ?? _parseRoundNumber(round.slug),
+      gameNumber: _parseGameNumber(round.name) ?? _parseGameNumber(round.slug),
+    );
+  }
+}

--- a/lib/providers/for_you_games_provider.dart
+++ b/lib/providers/for_you_games_provider.dart
@@ -2,23 +2,42 @@ import 'dart:async';
 
 import 'package:chessever2/providers/event_favorite_players_provider.dart';
 import 'package:chessever2/providers/favorite_events_provider.dart';
+import 'package:chessever2/providers/event_pin_refresh_provider.dart';
+import 'package:chessever2/providers/for_you_games_logic.dart';
 import 'package:chessever2/repository/local_storage/tournament/games/games_local_storage.dart';
 import 'package:chessever2/repository/local_storage/tournament/games/pin_games_local_storage.dart';
+import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
+import 'package:chessever2/repository/sqlite/app_database.dart';
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/repository/supabase/round/round.dart';
+import 'package:chessever2/repository/supabase/round/round_repository.dart';
 import 'package:chessever2/repository/supabase/tour/tour.dart';
 import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.dart';
 import 'package:chessever2/repository/supabase/group_broadcast/group_tour_repository.dart';
 import 'package:chessever2/repository/supabase/tour/tour_repository.dart';
+import 'package:chessever2/providers/auth_state_provider.dart';
+import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
+import 'package:chessever2/providers/country_dropdown_provider.dart';
 import 'package:chessever2/providers/favorite_players_provider.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/group_event/providers/live_group_broadcast_id_provider.dart';
 import 'package:chessever2/screens/group_event/providers/sorting_all_event_provider.dart';
 import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart';
 import 'package:chessever2/screens/chessboard/provider/game_pgn_stream_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/live_rounds_id_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/live_tour_id_provider.dart';
-import 'package:collection/collection.dart';
+import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_detail_repo_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_selection_logic.dart';
+import 'package:chessever2/screens/standings/player_standing_model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -93,8 +112,8 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
 
   Future<void> refresh() async {
     _offset = 0;
-    state = const ForYouState(isLoading: true);
-    ref.invalidate(eventGamesProvider);
+    state = state.copyWith(isLoading: true, error: null);
+    bumpForYouEventsRefreshSignal(ref);
     await _fetchPage(isInitial: true);
   }
 
@@ -112,17 +131,6 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
   Future<void> loadMore() async {
     if (_isFetching || !state.hasMore || state.isLoading) return;
     await _fetchPage(isInitial: false);
-  }
-
-  /// Removes an event from the rendered For You list.
-  /// Used by the UI when an event resolves to zero available games.
-  void removeEvent(String eventId) {
-    if (!mounted) return;
-    if (!state.events.any((event) => event.id == eventId)) return;
-
-    state = state.copyWith(
-      events: state.events.where((event) => event.id != eventId).toList(),
-    );
   }
 
   Future<void> _fetchPage({required bool isInitial}) async {
@@ -364,448 +372,1049 @@ final forYouEventsProvider =
       return ForYouNotifier(ref);
     });
 
+final forYouEventListProvider = Provider.autoDispose<List<GroupEventCardModel>>(
+  (ref) {
+    return ref.watch(forYouEventsProvider).events;
+  },
+);
+
+final forYouVisibleEventsProvider =
+    Provider.autoDispose<List<GroupEventCardModel>>((ref) {
+      final events = ref.watch(forYouEventListProvider);
+      final visibleEvents = <GroupEventCardModel>[];
+
+      for (final event in events) {
+        final hasGamesAsync = ref.watch(forYouEventHasGamesProvider(event.id));
+        final shouldHide = hasGamesAsync.maybeWhen(
+          data: (hasGames) => !hasGames,
+          orElse: () => false,
+        );
+        if (!shouldHide) {
+          visibleEvents.add(event);
+        }
+      }
+
+      return visibleEvents;
+    });
+
+final forYouEventHasGamesProvider = FutureProvider.autoDispose
+    .family<bool, String>((ref, eventId) async {
+      ref.watch(forYouEventsRefreshProvider);
+      ref.watch(liveTourIdProvider);
+      ref.watch(liveRoundsIdProvider);
+      ref.watch(currentSelectedTourIdForEventProvider(eventId));
+
+      return _computeForYouEventHasGames(
+        ref: ref,
+        eventId: eventId,
+        loadGames: _safeRefreshGames,
+      );
+    });
+
+abstract class ForYouPinStorage {
+  Future<List<String>> getPinnedGameIds(String tourId);
+
+  Future<void> addPinnedGameId(String tourId, String gameId);
+
+  Future<void> removePinnedGameId(String tourId, String gameId);
+
+  Future<List<String>> getUnpinnedGameIds(String tourId);
+
+  Future<void> addUnpinnedGameId(String tourId, String gameId);
+
+  Future<void> removeUnpinnedGameId(String tourId, String gameId);
+}
+
+class _RiverpodForYouPinStorage implements ForYouPinStorage {
+  const _RiverpodForYouPinStorage(this._ref);
+
+  final Ref _ref;
+
+  @override
+  Future<List<String>> getPinnedGameIds(String tourId) {
+    return _ref.read(pinGameLocalStorage).getPinnedGameIds(tourId);
+  }
+
+  @override
+  Future<void> addPinnedGameId(String tourId, String gameId) {
+    return _ref.read(pinGameLocalStorage).addPinnedGameId(tourId, gameId);
+  }
+
+  @override
+  Future<void> removePinnedGameId(String tourId, String gameId) {
+    return _ref.read(pinGameLocalStorage).removePinnedGameId(tourId, gameId);
+  }
+
+  @override
+  Future<List<String>> getUnpinnedGameIds(String tourId) {
+    return _ref.read(pinGameLocalStorage).getUnpinnedGameIds(tourId);
+  }
+
+  @override
+  Future<void> addUnpinnedGameId(String tourId, String gameId) {
+    return _ref.read(pinGameLocalStorage).addUnpinnedGameId(tourId, gameId);
+  }
+
+  @override
+  Future<void> removeUnpinnedGameId(String tourId, String gameId) {
+    return _ref.read(pinGameLocalStorage).removeUnpinnedGameId(tourId, gameId);
+  }
+}
+
+final forYouPinStorageProvider = Provider<ForYouPinStorage>((ref) {
+  return _RiverpodForYouPinStorage(ref);
+});
+
+abstract class ForYouPinAction {
+  Future<void> togglePin({
+    required String eventId,
+    required String gameId,
+    required String tourId,
+  });
+}
+
+final forYouPinActionProvider = Provider.autoDispose<ForYouPinAction>(
+  (ref) => _ForYouPinActionController(ref),
+);
+
+final currentTournamentDetailSelectedTourIdProvider = Provider<String?>((ref) {
+  return ref.watch(
+    tourDetailScreenProvider.select(
+      (value) => value.valueOrNull?.aboutTourModel.id,
+    ),
+  );
+});
+
+final currentSelectedTourIdForEventProvider = Provider.autoDispose
+    .family<String?, String>((ref, eventId) {
+      final isSelectedEvent = ref.watch(
+        selectedBroadcastModelProvider.select(
+          (broadcast) => broadcast?.id == eventId,
+        ),
+      );
+
+      if (!isSelectedEvent) {
+        return null;
+      }
+
+      return ref.watch(currentTournamentDetailSelectedTourIdProvider);
+    });
+
+class _ForYouComputedPinState {
+  const _ForYouComputedPinState({
+    required this.manualPins,
+    required this.autoPins,
+    required this.unpinnedOverrides,
+    required this.effectivePins,
+  });
+
+  final List<String> manualPins;
+  final List<String> autoPins;
+  final List<String> unpinnedOverrides;
+  final List<String> effectivePins;
+}
+
+class _ForYouResolvedEventData {
+  const _ForYouResolvedEventData({
+    required this.selectedTour,
+    required this.eventTours,
+    required this.selectedTourRounds,
+    required this.roundsByTourId,
+    required this.selectedTourGames,
+    required this.gamesByTourId,
+    required this.liveRoundIds,
+  });
+
+  final Tour selectedTour;
+  final List<Tour> eventTours;
+  final List<Round> selectedTourRounds;
+  final Map<String, List<Round>> roundsByTourId;
+  final List<Games> selectedTourGames;
+  final Map<String, List<Games>> gamesByTourId;
+  final List<String> liveRoundIds;
+}
+
+class _ForYouPinActionController implements ForYouPinAction {
+  const _ForYouPinActionController(this._ref);
+
+  final Ref _ref;
+
+  @override
+  Future<void> togglePin({
+    required String eventId,
+    required String gameId,
+    required String tourId,
+  }) async {
+    final storage = _ref.read(forYouPinStorageProvider);
+    final snapshot =
+        _ref.read(forYouEventGamesWithAutoRefreshProvider(eventId)).valueOrNull;
+    final mode = resolvePinToggleMode(
+      isManualPinned:
+          snapshot?.manualPinnedIds.contains(gameId) ??
+          (await storage.getPinnedGameIds(tourId)).contains(gameId),
+      isAutoPinned: snapshot?.autoPinnedIds.contains(gameId) ?? false,
+      isOverridden:
+          snapshot?.unpinnedOverrideIds.contains(gameId) ??
+          (await storage.getUnpinnedGameIds(tourId)).contains(gameId),
+    );
+
+    switch (mode) {
+      case PinToggleMode.unpinManualOnly:
+        await storage.removePinnedGameId(tourId, gameId);
+        break;
+      case PinToggleMode.unpinWithOverride:
+        await Future.wait([
+          storage.removePinnedGameId(tourId, gameId),
+          storage.addUnpinnedGameId(tourId, gameId),
+        ]);
+        break;
+      case PinToggleMode.repin:
+        await Future.wait([
+          storage.removeUnpinnedGameId(tourId, gameId),
+          storage.addPinnedGameId(tourId, gameId),
+        ]);
+        break;
+    }
+
+    final selectedBroadcast = _ref.read(selectedBroadcastModelProvider);
+    final selectedTourId =
+        _ref.read(tourDetailScreenProvider).valueOrNull?.aboutTourModel.id;
+
+    if (selectedBroadcast?.id == eventId &&
+        selectedTourId != null &&
+        selectedTourId.isNotEmpty) {
+      _ref.invalidate(gamesPinprovider(selectedTourId));
+      _ref.invalidate(gamesTourScreenProvider);
+    }
+
+    bumpEventPinRefreshSignal(_ref, eventId);
+  }
+}
+
 // ============================================================================
 // LAZY GAMES PER EVENT PROVIDER
-// Uses the same sorting logic as the Games tab in event detail screen:
-// 1. Pinned games first (manual + auto, preserving pin order)
-// 2. Round number DESCENDING (latest round first)
-// 3. Game number DESCENDING
-// 4. Board number ASCENDING
+// Mirrors the Games tab for the event's resolved default tour,
+// then lets the UI render only the first 4 visible games.
 // ============================================================================
 
-final eventGamesProvider = FutureProvider.autoDispose.family<
-  List<Games>,
+final eventGamesProvider = StateNotifierProvider.autoDispose.family<
+  _ForYouEventGamesController,
+  AsyncValue<ForYouEventGamesSnapshot>,
   String
->((ref, eventId) async {
-  // Keep data cached for 2 minutes after scrolling out of view,
-  // then dispose to free RAM (PGN strings, player data, etc.)
+>((ref, eventId) {
   final link = ref.keepAlive();
-  final timer = Timer(const Duration(minutes: 2), link.close);
+  final timer = Timer(const Duration(minutes: 5), link.close);
   ref.onDispose(timer.cancel);
 
-  final groupBroadcastRepo = ref.read(groupBroadcastRepositoryProvider);
-  final tourRepository = ref.read(tourRepositoryProvider);
-  final gamesStorage = ref.read(gamesLocalStorage);
+  final controller = _ForYouEventGamesController(ref: ref, eventId: eventId);
 
-  // ── 1. Fetch all tours for this event ──
+  ref.onCancel(controller.handleCancel);
+  ref.onResume(controller.handleResume);
+
+  ref.listen(eventPinRefreshProvider(eventId), (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(forYouEventsRefreshProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(favoritesVersionProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(countryDropdownProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(autoPinPreferencesProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(currentUserProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(liveTourIdProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(liveRoundsIdProvider, (_, __) {
+    controller.requestRefresh();
+  });
+  ref.listen(currentSelectedTourIdForEventProvider(eventId), (_, __) {
+    controller.requestRefresh();
+  });
+
+  return controller;
+});
+
+class _ForYouEventGamesController
+    extends StateNotifier<AsyncValue<ForYouEventGamesSnapshot>> {
+  _ForYouEventGamesController({required this.ref, required this.eventId})
+    : super(const AsyncValue.loading()) {
+    requestRefresh();
+  }
+
+  final Ref ref;
+  final String eventId;
+
+  bool _isObserved = true;
+  bool _isRefreshing = false;
+  bool _queuedRefresh = false;
+
+  void handleCancel() {
+    _isObserved = false;
+  }
+
+  void handleResume() {
+    _isObserved = true;
+    if (_queuedRefresh || state.valueOrNull == null) {
+      requestRefresh();
+    }
+  }
+
+  void requestRefresh() {
+    if (!mounted) {
+      return;
+    }
+
+    if (!_isObserved) {
+      _queuedRefresh = true;
+      return;
+    }
+
+    if (_isRefreshing) {
+      _queuedRefresh = true;
+      return;
+    }
+
+    unawaited(_performRefreshLoop());
+  }
+
+  Future<void> _performRefreshLoop() async {
+    if (_isRefreshing) {
+      return;
+    }
+
+    _isRefreshing = true;
+    try {
+      do {
+        _queuedRefresh = false;
+        await _refreshOnce();
+      } while (mounted && _isObserved && _queuedRefresh);
+    } finally {
+      _isRefreshing = false;
+    }
+  }
+
+  Future<void> _refreshOnce() async {
+    final previousSnapshot = state.valueOrNull;
+
+    if (previousSnapshot == null && !state.isLoading) {
+      state = const AsyncValue.loading();
+    }
+
+    Object? loadError;
+    StackTrace? loadStack;
+
+    try {
+      final cachedSnapshot = await _computeForYouEventGamesSnapshot(
+        ref: ref,
+        eventId: eventId,
+        loadGames: _safeGetGames,
+      );
+      final currentSnapshot = state.valueOrNull;
+      if (currentSnapshot == null ||
+          !areEquivalentForYouSnapshots(currentSnapshot, cachedSnapshot)) {
+        state = AsyncValue.data(cachedSnapshot);
+      }
+    } catch (error, stackTrace) {
+      loadError = error;
+      loadStack = stackTrace;
+      debugPrint('[ForYou] Cache-first snapshot failed for $eventId: $error');
+    }
+
+    try {
+      final refreshedSnapshot = await _computeForYouEventGamesSnapshot(
+        ref: ref,
+        eventId: eventId,
+        loadGames: _safeRefreshGames,
+      );
+      final currentSnapshot = state.valueOrNull;
+      if (currentSnapshot == null ||
+          !areEquivalentForYouSnapshots(currentSnapshot, refreshedSnapshot)) {
+        state = AsyncValue.data(refreshedSnapshot);
+      }
+      return;
+    } catch (error, stackTrace) {
+      loadError ??= error;
+      loadStack ??= stackTrace;
+      debugPrint('[ForYou] Refreshed snapshot failed for $eventId: $error');
+    }
+
+    if (state.valueOrNull == null) {
+      state = AsyncValue.error(loadError, loadStack);
+    } else if (previousSnapshot != null && mounted) {
+      state = AsyncValue.data(previousSnapshot);
+    }
+  }
+}
+
+typedef _GamesStorageLoader =
+    Future<List<Games>> Function({
+      required GamesLocalStorage gamesStorage,
+      required String tourId,
+    });
+
+Future<ForYouEventGamesSnapshot> _computeForYouEventGamesSnapshot({
+  required Ref ref,
+  required String eventId,
+  required _GamesStorageLoader loadGames,
+}) async {
+  final resolvedEventData = await _loadForYouResolvedEventData(
+    ref: ref,
+    eventId: eventId,
+    loadGames: loadGames,
+  );
+
+  if (resolvedEventData == null) {
+    return _emptyForYouEventGamesSnapshot(eventId);
+  }
+
+  final selectedTour = resolvedEventData.selectedTour;
+  final eventTours = resolvedEventData.eventTours;
+  final selectedTourRounds = resolvedEventData.selectedTourRounds;
+  final roundsByTourId = resolvedEventData.roundsByTourId;
+  final selectedTourGames = resolvedEventData.selectedTourGames;
+  final gamesByTourId = resolvedEventData.gamesByTourId;
+  final liveRoundIds = resolvedEventData.liveRoundIds;
+
+  final isKnockout = isKnockoutTour(
+    tour: selectedTour,
+    games: selectedTourGames,
+  );
+
+  final gamesForAutoPin =
+      isKnockout
+          ? gamesByTourId.values
+              .expand((games) => games)
+              .map((game) {
+                try {
+                  return GamesTourModel.fromGame(game);
+                } catch (_) {
+                  return null;
+                }
+              })
+              .whereType<GamesTourModel>()
+              .toList()
+          : sortGamesForGamesTab(games: selectedTourGames, pinnedIds: const []);
+
+  final pinState = await _loadPinnedStateForEvent(
+    ref: ref,
+    relatedTourIds:
+        isKnockout
+            ? eventTours.map((tour) => tour.id).toList(growable: false)
+            : [selectedTour.id],
+    autoPinTourId: selectedTour.id,
+    allRelevantGames: gamesForAutoPin,
+  );
+
+  final snapshot = buildForYouEventGamesSnapshot(
+    eventId: eventId,
+    selectedTour: selectedTour,
+    eventTours: eventTours,
+    selectedTourRounds: selectedTourRounds,
+    roundsByTourId: roundsByTourId,
+    selectedTourGames: selectedTourGames,
+    gamesByTourId: gamesByTourId,
+    liveRoundIds: liveRoundIds,
+    pinnedIds: pinState.effectivePins,
+    manualPinnedIds: pinState.manualPins,
+    autoPinnedIds: pinState.autoPins,
+    unpinnedOverrideIds: pinState.unpinnedOverrides,
+  );
+
+  debugPrint(
+    '[ForYou] Snapshot for $eventId resolved to ${snapshot.tourId} '
+    'with ${snapshot.visibleGames.length} visible Games-tab games',
+  );
+  return snapshot;
+}
+
+Future<bool> _computeForYouEventHasGames({
+  required Ref ref,
+  required String eventId,
+  required _GamesStorageLoader loadGames,
+}) async {
+  final resolvedEventData = await _loadForYouResolvedEventData(
+    ref: ref,
+    eventId: eventId,
+    loadGames: loadGames,
+  );
+
+  if (resolvedEventData == null) {
+    return false;
+  }
+
+  return buildForYouEventGamesSnapshot(
+    eventId: eventId,
+    selectedTour: resolvedEventData.selectedTour,
+    eventTours: resolvedEventData.eventTours,
+    selectedTourRounds: resolvedEventData.selectedTourRounds,
+    roundsByTourId: resolvedEventData.roundsByTourId,
+    selectedTourGames: resolvedEventData.selectedTourGames,
+    gamesByTourId: resolvedEventData.gamesByTourId,
+    liveRoundIds: resolvedEventData.liveRoundIds,
+    pinnedIds: const [],
+  ).hasGames;
+}
+
+Future<_ForYouResolvedEventData?> _loadForYouResolvedEventData({
+  required Ref ref,
+  required String eventId,
+  required _GamesStorageLoader loadGames,
+}) async {
+  final groupBroadcastRepo = ref.read(groupBroadcastRepositoryProvider);
+  final gameRepository = ref.read(gameRepositoryProvider);
+  final gamesStorage = ref.read(gamesLocalStorage);
+  final roundRepository = ref.read(roundRepositoryProvider);
+  final tourRepository = ref.read(tourRepositoryProvider);
+  final liveTourIds = ref.read(liveTourIdProvider).valueOrNull ?? <String>[];
+  final liveRoundIds = ref.read(liveRoundsIdProvider).valueOrNull ?? <String>[];
+
+  final initialResults = await Future.wait<Object?>([
+    _safeLoadEventTours(
+      tourRepository: tourRepository,
+      groupBroadcastRepo: groupBroadcastRepo,
+      eventId: eventId,
+    ),
+    _safeLoadSavedTourId(ref: ref, eventId: eventId),
+  ]);
+  final eventTours = initialResults[0]! as List<Tour>;
+  final savedTourId = initialResults[1] as String?;
+
+  if (eventTours.isEmpty) {
+    return null;
+  }
+
+  final tourModels = _buildEventTourModels(eventTours, liveTourIds);
+  if (tourModels.isEmpty) {
+    return null;
+  }
+
+  final currentSelectedTourId = ref.read(
+    currentSelectedTourIdForEventProvider(eventId),
+  );
+
+  String? activityTourId;
+  if (shouldLoadDeferredActivityTourId(
+    tourModels: tourModels,
+    currentSelectedId: currentSelectedTourId,
+    savedTourId: savedTourId,
+  )) {
+    activityTourId = await _safeLoadActivityTourId(
+      gameRepository: gameRepository,
+      eventId: eventId,
+      tourIds: tourModels.map((model) => model.tour.id).toList(growable: false),
+    );
+  }
+
+  final selectedTour = selectDefaultTour(
+    tourModels: tourModels,
+    liveTourIds: liveTourIds,
+    currentSelectedId: currentSelectedTourId,
+    savedTourId: savedTourId,
+    activityTourId: activityTourId,
+  );
+
+  final selectedTourData = await Future.wait<Object?>([
+    loadGames(gamesStorage: gamesStorage, tourId: selectedTour.id),
+    _safeLoadRounds(roundRepository: roundRepository, tourId: selectedTour.id),
+  ]);
+  final selectedTourGames = selectedTourData[0]! as List<Games>;
+  final selectedTourRounds = selectedTourData[1]! as List<Round>;
+
+  final isKnockout = isKnockoutTour(
+    tour: selectedTour,
+    games: selectedTourGames,
+  );
+
+  final gamesByTourId = <String, List<Games>>{
+    selectedTour.id: selectedTourGames,
+  };
+  final roundsByTourId = <String, List<Round>>{
+    selectedTour.id: selectedTourRounds,
+  };
+
+  if (isKnockout) {
+    final siblingTours = eventTours
+        .where((tour) => tour.id != selectedTour.id)
+        .toList(growable: false);
+
+    if (siblingTours.isNotEmpty) {
+      final siblingTourIds = siblingTours
+          .map((tour) => tour.id)
+          .toList(growable: false);
+      final siblingResults = await Future.wait<Object?>([
+        Future.wait(
+          siblingTours.map(
+            (tour) => loadGames(gamesStorage: gamesStorage, tourId: tour.id),
+          ),
+        ),
+        _safeLoadRoundsByTourIds(
+          roundRepository: roundRepository,
+          tourIds: siblingTourIds,
+        ),
+      ]);
+
+      final siblingGames = siblingResults[0]! as List<List<Games>>;
+      final siblingRoundsByTourId =
+          siblingResults[1]! as Map<String, List<Round>>;
+
+      for (var i = 0; i < siblingTours.length; i++) {
+        final tourId = siblingTours[i].id;
+        gamesByTourId[tourId] = siblingGames[i];
+        roundsByTourId[tourId] =
+            siblingRoundsByTourId[tourId] ?? const <Round>[];
+      }
+    }
+  }
+
+  return _ForYouResolvedEventData(
+    selectedTour: selectedTour,
+    eventTours: eventTours,
+    selectedTourRounds: selectedTourRounds,
+    roundsByTourId: roundsByTourId,
+    selectedTourGames: selectedTourGames,
+    gamesByTourId: gamesByTourId,
+    liveRoundIds: liveRoundIds,
+  );
+}
+
+ForYouEventGamesSnapshot _emptyForYouEventGamesSnapshot(String eventId) {
+  return ForYouEventGamesSnapshot(
+    eventId: eventId,
+    tourId: '',
+    visibleGames: const [],
+    pinnedIds: const [],
+  );
+}
+
+List<TourModel> _buildEventTourModels(
+  List<Tour> tours,
+  List<String> liveTourIds,
+) {
+  final now = DateTime.now();
+  final models = <TourModel>[];
+
+  for (final tour in tours) {
+    if (tour.dates.isEmpty) {
+      final status =
+          liveTourIds.contains(tour.id)
+              ? RoundStatus.live
+              : RoundStatus.completed;
+      models.add(TourModel(tour: tour, roundStatus: status));
+      continue;
+    }
+
+    final status = calculateTourRoundStatus(
+      tourId: tour.id,
+      now: now,
+      startDate: tour.dates.first,
+      endDate: tour.dates.last,
+      liveTourIds: liveTourIds,
+    );
+    models.add(TourModel(tour: tour, roundStatus: status));
+  }
+
+  return models;
+}
+
+Future<List<Games>> _safeRefreshGames({
+  required GamesLocalStorage gamesStorage,
+  required String tourId,
+}) async {
+  try {
+    return await gamesStorage.refresh(tourId);
+  } catch (e) {
+    debugPrint('[ForYou] Error fetching games for tour $tourId: $e');
+    return const <Games>[];
+  }
+}
+
+Future<List<Games>> _safeGetGames({
+  required GamesLocalStorage gamesStorage,
+  required String tourId,
+}) async {
+  try {
+    return await gamesStorage.getCachedGames(tourId);
+  } catch (e) {
+    debugPrint('[ForYou] Error reading cached games for tour $tourId: $e');
+    return const <Games>[];
+  }
+}
+
+Future<List<Tour>> _safeLoadEventTours({
+  required TourRepository tourRepository,
+  required GroupBroadcastRepository groupBroadcastRepo,
+  required String eventId,
+}) async {
   List<Tour> eventTours = [];
+
   try {
     eventTours = await tourRepository.getTourByGroupId(eventId);
   } catch (e) {
     debugPrint('[ForYou] Error fetching tours: $e');
   }
 
-  // ── 2. Order tours deterministically ──
-  // Live tours first, then by avgElo descending, then stable original order.
-  if (eventTours.isNotEmpty) {
-    final liveTourIds = ref.read(liveTourIdProvider).valueOrNull ?? <String>[];
-
-    // Capture original indices for stable tie-breaking
-    final originalOrder = {
-      for (int i = 0; i < eventTours.length; i++) eventTours[i].id: i,
-    };
-
-    eventTours.sort((a, b) {
-      final aLive = liveTourIds.contains(a.id) ? 0 : 1;
-      final bLive = liveTourIds.contains(b.id) ? 0 : 1;
-      if (aLive != bLive) return aLive.compareTo(bLive);
-
-      final aElo = a.avgElo ?? 0;
-      final bElo = b.avgElo ?? 0;
-      if (aElo != bElo) return bElo.compareTo(aElo);
-
-      return (originalOrder[a.id] ?? 0).compareTo(originalOrder[b.id] ?? 0);
-    });
-
-    debugPrint(
-      '[ForYou] Ordered ${eventTours.length} tours for event $eventId: '
-      '${eventTours.map((t) => '"${t.name}" (elo:${t.avgElo}, live:${liveTourIds.contains(t.id)})').join(', ')}',
-    );
-  }
-
-  // Build the list of tour IDs to fetch games from
-  List<String> tourIdsToFetch = eventTours.map((t) => t.id).toList();
-  if (tourIdsToFetch.isEmpty) {
+  if (eventTours.isEmpty) {
     try {
-      tourIdsToFetch = await groupBroadcastRepo.getTourIdsForGroupBroadcast(
+      final tourIds = await groupBroadcastRepo.getTourIdsForGroupBroadcast(
         eventId,
       );
+      eventTours = await tourRepository.getToursByIds(tourIds);
     } catch (e) {
-      debugPrint('[ForYou] Error fetching tour IDs: $e');
-    }
-  }
-  // Final fallback: use eventId as a tour ID
-  if (tourIdsToFetch.isEmpty) {
-    tourIdsToFetch = [eventId];
-  }
-
-  // ── 3. Fetch and filter started games from EVERY tour ──
-  // Always use refresh() to get fresh data from network for For You tab.
-  // This ensures we see new rounds immediately when they start.
-  final fetchedGamesByTour = await Future.wait(
-    tourIdsToFetch.map((tourId) async {
-      try {
-        return await gamesStorage.refresh(tourId);
-      } catch (e) {
-        debugPrint('[ForYou] Error fetching games for tour $tourId: $e');
-        return <Games>[];
-      }
-    }),
-  );
-
-  final allStartedGames = <Games>[];
-  for (final games in fetchedGamesByTour) {
-    for (final game in games) {
-      if (_hasActuallyStarted(game) &&
-          game.players != null &&
-          game.players!.length >= 2) {
-        allStartedGames.add(game);
-      }
+      debugPrint('[ForYou] Error fetching fallback tours: $e');
     }
   }
 
-  if (allStartedGames.isEmpty) {
-    debugPrint('[ForYou] No games found for event $eventId');
-    return [];
-  }
-
-  debugPrint(
-    '[ForYou] Collected ${allStartedGames.length} started games across '
-    '${tourIdsToFetch.length} tours for event $eventId',
-  );
-
-  // ── 4. Aggregate manual pin IDs from ALL tours ──
-  final pinStorage = ref.read(pinGameLocalStorage);
-  final pinsByTour = await Future.wait(
-    tourIdsToFetch.map((tourId) async {
-      try {
-        return await pinStorage.getPinnedGameIds(tourId);
-      } catch (e) {
-        debugPrint('[ForYou] Error fetching pinned games for tour $tourId: $e');
-        return <String>[];
-      }
-    }),
-  );
-
-  final pinnedIds = <String>[];
-  final seenPins = <String>{};
-  for (final pinIds in pinsByTour) {
-    for (final pinId in pinIds) {
-      if (seenPins.add(pinId)) {
-        pinnedIds.add(pinId);
-      }
-    }
-  }
-
-  // ── 5. Collect format strings and select games ──
-  final formatStrings = eventTours.map((t) => t.info.format).toList();
-
-  final result = selectForYouEventGames(
-    allStartedGames: allStartedGames,
-    pinnedIds: pinnedIds,
-    formatStrings: formatStrings,
-  );
-
-  debugPrint(
-    '[ForYou] Selected ${result.length} games for event $eventId '
-    '(from ${allStartedGames.length} started across ${tourIdsToFetch.length} tours)',
-  );
-  return result;
-});
-
-/// Game must have actual moves OR be finished
-/// This filters out games from unstarted rounds that have status='*' but no moves
-/// Note: We don't check pgn.isNotEmpty because future games have PGN headers (~700 chars)
-/// but no actual moves. Only lastMove and lastMoveTime indicate actual play.
-bool _hasActuallyStarted(Games game) {
-  final hasMoves =
-      (game.lastMove?.isNotEmpty ?? false) || game.lastMoveTime != null;
-  final isFinished =
-      game.status == '1-0' ||
-      game.status == '0-1' ||
-      game.status == '1/2-1/2' ||
-      game.status == '½-½';
-  return hasMoves || isFinished;
+  return eventTours;
 }
 
-/// Detects if an event is a 1v1 match format (e.g., "12-game Match").
-/// Returns true when the tour format string contains "match" (case-insensitive)
-/// AND there are at most 2 unique players among the started games.
-bool _isMatchFormatEvent(String? formatString, List<Games> games) {
-  if (formatString == null || formatString.isEmpty || games.isEmpty) {
+Future<String?> _safeLoadSavedTourId({
+  required Ref ref,
+  required String eventId,
+}) async {
+  try {
+    return await ref.read(tourDetailRepoProvider).getSelectedTourId(eventId);
+  } catch (e) {
+    debugPrint('[ForYou] Error reading saved tour selection: $e');
+    return null;
+  }
+}
+
+Future<String?> _safeLoadActivityTourId({
+  required GameRepository gameRepository,
+  required String eventId,
+  required List<String> tourIds,
+}) async {
+  try {
+    return await gameRepository.getMostRelevantTourId(tourIds: tourIds);
+  } catch (e) {
+    debugPrint('[ForYou] Error resolving relevant tour for $eventId: $e');
+    return null;
+  }
+}
+
+Future<List<Round>> _safeLoadRounds({
+  required RoundRepository roundRepository,
+  required String tourId,
+}) async {
+  try {
+    return await roundRepository.getRoundsByTourId(tourId);
+  } catch (e) {
+    debugPrint('[ForYou] Error fetching rounds for tour $tourId: $e');
+    return const <Round>[];
+  }
+}
+
+Future<Map<String, List<Round>>> _safeLoadRoundsByTourIds({
+  required RoundRepository roundRepository,
+  required List<String> tourIds,
+}) async {
+  try {
+    return await roundRepository.getRoundsByTourIds(tourIds);
+  } catch (e) {
+    debugPrint('[ForYou] Error fetching rounds for tours $tourIds: $e');
+    return <String, List<Round>>{
+      for (final tourId in tourIds) tourId: const <Round>[],
+    };
+  }
+}
+
+Future<_ForYouComputedPinState> _loadPinnedStateForEvent({
+  required Ref ref,
+  required List<String> relatedTourIds,
+  required String autoPinTourId,
+  required List<GamesTourModel> allRelevantGames,
+}) async {
+  final pinResults = await Future.wait<Object?>([
+    _loadManualPinsForTours(ref: ref, tourIds: relatedTourIds),
+    _loadUnpinnedOverridesForTours(ref: ref, tourIds: relatedTourIds),
+    _loadAutoPins(
+      ref: ref,
+      tourId: autoPinTourId,
+      allRelevantGames: allRelevantGames,
+    ),
+  ]);
+  final manualPins = pinResults[0]! as List<String>;
+  final unpinnedOverrides = pinResults[1]! as List<String>;
+  final autoPins = pinResults[2]! as List<String>;
+  return _ForYouComputedPinState(
+    manualPins: manualPins,
+    autoPins: autoPins,
+    unpinnedOverrides: unpinnedOverrides,
+    effectivePins: mergeEffectivePins(
+      manualPins: manualPins,
+      autoPins: autoPins,
+      unpinnedOverrides: unpinnedOverrides,
+    ),
+  );
+}
+
+@visibleForTesting
+List<String> mergePinnedIdsPreservingOrder(List<List<String>> pinLists) {
+  final mergedPins = <String>[];
+  final seen = <String>{};
+
+  for (final pinIds in pinLists) {
+    for (final pinId in pinIds) {
+      if (seen.add(pinId)) {
+        mergedPins.add(pinId);
+      }
+    }
+  }
+
+  return mergedPins;
+}
+
+Future<List<String>> _loadManualPinsForTours({
+  required Ref ref,
+  required List<String> tourIds,
+}) async {
+  final storage = ref.read(forYouPinStorageProvider);
+  final pinLists = await Future.wait(
+    tourIds.map((tourId) => storage.getPinnedGameIds(tourId)),
+  );
+  return mergePinnedIdsPreservingOrder(pinLists);
+}
+
+Future<List<String>> _loadUnpinnedOverridesForTours({
+  required Ref ref,
+  required List<String> tourIds,
+}) async {
+  final storage = ref.read(forYouPinStorageProvider);
+  final overrideLists = await Future.wait(
+    tourIds.map((tourId) => storage.getUnpinnedGameIds(tourId)),
+  );
+  return mergePinListsPreservingOrder(overrideLists);
+}
+
+Future<List<String>> _loadAutoPins({
+  required Ref ref,
+  required String tourId,
+  required List<GamesTourModel> allRelevantGames,
+}) async {
+  final prefsRepo = AutoPinPreferencesRepository(AppDatabase.instance);
+  final userId = ref.read(currentUserProvider)?.id;
+  final setupResults = await Future.wait<Object?>([
+    prefsRepo.getTournamentAutoPinDisabled(tourId, userId),
+    ref.read(autoPinPreferencesProvider.future),
+  ]);
+  final autoPinDisabled = setupResults[0]! as bool;
+  if (autoPinDisabled) {
+    return const <String>[];
+  }
+
+  final prefs = setupResults[1]! as AutoPinPreferences;
+  if (!prefs.favoritePlayersAutoPinEnabled && !prefs.countrymenAutoPinEnabled) {
+    return const <String>[];
+  }
+
+  final pinnedIds = <String>{};
+  final dependencyResults = await Future.wait<Object?>([
+    prefs.favoritePlayersAutoPinEnabled
+        ? ref.read(tournamentFavoritePlayersProvider.future)
+        : Future.value(null),
+    prefs.countrymenAutoPinEnabled
+        ? _resolveAutoPinCountryCode(ref)
+        : Future.value(null),
+  ]);
+  final favoritePlayers =
+      dependencyResults[0] as List<PlayerStandingModel>? ??
+      const <PlayerStandingModel>[];
+  final countryCode = dependencyResults[1] as String?;
+
+  if (prefs.favoritePlayersAutoPinEnabled) {
+    for (final game in allRelevantGames) {
+      final matchesFavorite =
+          favoritePlayers.any(
+            (player) =>
+                player.name == game.whitePlayer.name &&
+                (player.countryCode.isEmpty ||
+                    CountryCodeMatcher.matches(
+                      game.whitePlayer.countryCode,
+                      player.countryCode,
+                    )),
+          ) ||
+          favoritePlayers.any(
+            (player) =>
+                player.name == game.blackPlayer.name &&
+                (player.countryCode.isEmpty ||
+                    CountryCodeMatcher.matches(
+                      game.blackPlayer.countryCode,
+                      player.countryCode,
+                    )),
+          );
+      if (matchesFavorite) {
+        pinnedIds.add(game.gameId);
+      }
+    }
+  }
+
+  if (prefs.countrymenAutoPinEnabled) {
+    if (countryCode != null && countryCode.isNotEmpty) {
+      final countryGames =
+          allRelevantGames
+              .where((game) {
+                return CountryCodeMatcher.matches(
+                      game.whitePlayer.countryCode,
+                      countryCode,
+                    ) ||
+                    CountryCodeMatcher.matches(
+                      game.blackPlayer.countryCode,
+                      countryCode,
+                    );
+              })
+              .map((game) => game.gameId)
+              .toList();
+
+      if (countryGames.length < allRelevantGames.length) {
+        pinnedIds.addAll(countryGames);
+      }
+    }
+  }
+
+  return pinnedIds.toList();
+}
+
+@visibleForTesting
+bool shouldLoadDeferredActivityTourId({
+  required List<TourModel> tourModels,
+  String? currentSelectedId,
+  String? savedTourId,
+}) {
+  final hasStartedTours = tourModels.any(
+    (model) => model.roundStatus != RoundStatus.upcoming,
+  );
+
+  bool canUseSelection(TourModel model) {
+    if (!hasStartedTours) {
+      return true;
+    }
+    return model.roundStatus != RoundStatus.upcoming;
+  }
+
+  Tour? findSelectableTour(String? tourId) {
+    if (tourId == null || tourId.isEmpty) {
+      return null;
+    }
+
+    for (final model in tourModels) {
+      if (model.tour.id == tourId && canUseSelection(model)) {
+        return model.tour;
+      }
+    }
+
+    return null;
+  }
+
+  if (findSelectableTour(currentSelectedId) != null) {
     return false;
   }
-  if (!formatString.toLowerCase().contains('match')) return false;
 
-  final players = <String>{};
-  for (final game in games) {
-    final gamePlayers = game.players;
-    if (gamePlayers == null) continue;
-    for (final p in gamePlayers) {
-      players.add(p.name);
-      if (players.length > 2) return false; // early exit
-    }
+  if (findSelectableTour(savedTourId) != null) {
+    return false;
   }
-  return players.length == 2;
-}
 
-/// Sorts games using the same algorithm as the Games tab:
-/// 1. Pinned games first (preserving pin order)
-/// 2. Round number DESCENDING
-/// 3. Game number DESCENDING
-/// 4. Board number ASCENDING
-List<Games> _sortGamesLikeGamesTab(List<Games> games, List<String> pinnedIds) {
-  if (games.isEmpty) return [];
+  if (tourModels.any((model) => model.roundStatus == RoundStatus.live)) {
+    return false;
+  }
 
-  // Pre-parse round/game numbers to avoid repeated regex during sort
-  final gameInfo = <String, (int, int)>{};
-  for (final game in games) {
-    gameInfo[game.id] = (
-      _extractRoundNumber(game.roundSlug),
-      _extractGameNumber(game.roundSlug),
+  final selectableModels =
+      hasStartedTours
+          ? tourModels
+              .where((model) => model.roundStatus != RoundStatus.upcoming)
+              .toList()
+          : List<TourModel>.from(tourModels);
+
+  if (selectableModels.isEmpty) {
+    return true;
+  }
+
+  final toursWithDates =
+      selectableModels.where((model) => model.tour.dates.isNotEmpty).toList();
+
+  if (toursWithDates.isNotEmpty) {
+    final firstStart = toursWithDates.first.tour.dates.first;
+    final allSameStart = toursWithDates.every(
+      (model) =>
+          model.tour.dates.first.year == firstStart.year &&
+          model.tour.dates.first.month == firstStart.month &&
+          model.tour.dates.first.day == firstStart.day,
     );
-  }
 
-  final sortedGames = List<Games>.from(games);
-  sortedGames.sort((a, b) {
-    // 1. Pinned games first (preserving pin order)
-    final aPinned = pinnedIds.contains(a.id);
-    final bPinned = pinnedIds.contains(b.id);
-    if (aPinned && !bPinned) return -1;
-    if (!aPinned && bPinned) return 1;
-
-    // If both are pinned, preserve pin order
-    if (aPinned && bPinned) {
-      final aIndex = pinnedIds.indexOf(a.id);
-      final bIndex = pinnedIds.indexOf(b.id);
-      if (aIndex != bIndex) return aIndex.compareTo(bIndex);
+    if (!allSameStart) {
+      return false;
     }
 
-    final (roundA, gameA) = gameInfo[a.id] ?? (0, 0);
-    final (roundB, gameB) = gameInfo[b.id] ?? (0, 0);
-
-    // 2. Sort by round number DESCENDING (latest round first)
-    if (roundA != roundB) return roundB.compareTo(roundA);
-
-    // 3. Within same round, sort by game number DESCENDING
-    if (gameA != gameB) return gameB.compareTo(gameA);
-
-    // 4. Finally, sort by board number ASCENDING
-    final aBoard = a.boardNr, bBoard = b.boardNr;
-    if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
-    if (aBoard != null) return -1;
-    if (bBoard != null) return 1;
-    return 0;
-  });
-
-  return sortedGames;
-}
-
-int _extractRoundNumber(String roundSlug) {
-  final slug = roundSlug.toLowerCase();
-
-  // Named knockout stages — ranked above any numbered round.
-  // Check more-specific names first to avoid substring false-positives.
-  if (slug.contains('final') &&
-      !slug.contains('quarter') &&
-      !slug.contains('semi')) {
-    return 10000;
-  }
-  if (slug.contains('semifinal') || slug.contains('semi-final')) {
-    return 9000;
-  }
-  if (slug.contains('quarterfinal') || slug.contains('quarter-final')) {
-    return 8000;
+    if (toursWithDates.any((model) => model.tour.avgElo != null)) {
+      return false;
+    }
   }
 
-  final match =
-      RegExp(r'round-?(\d+)', caseSensitive: false).firstMatch(roundSlug) ??
-      RegExp(r'(\d+)').firstMatch(roundSlug);
-  return int.tryParse(match?.group(1) ?? '0') ?? 0;
+  if (selectableModels.any((model) => model.tour.avgElo != null)) {
+    return false;
+  }
+
+  return true;
 }
 
-int _extractGameNumber(String roundSlug) {
-  final match = RegExp(
-    r'game-?(\d+)',
-    caseSensitive: false,
-  ).firstMatch(roundSlug);
-  return int.tryParse(match?.group(1) ?? '0') ?? 0;
-}
-
-// ============================================================================
-// EVENT-LEVEL GAME SELECTOR — FILLS UP TO kGamesPerEvent FROM ALL TOURS
-// ============================================================================
-
-/// Pure selector: picks up to [kGamesPerEvent] started games from a combined
-/// pool of all tours in an event.
-///
-/// - [allStartedGames]: all started games from every tour, already filtered
-///   by [_hasActuallyStarted] and having >= 2 players.
-/// - [pinnedIds]: aggregated pin IDs from all tours (first-seen order, deduped).
-/// - [formatStrings]: format strings from all tours in the event (used to
-///   detect match format when ANY tour is a 1v1 match).
-///
-/// For match-format events: sort all games and take the first 4.
-/// For normal events: take from the primary round (most recent activity) first,
-/// then fill the deficit from remaining rounds ordered by recency.
-@visibleForTesting
-List<Games> selectForYouEventGames({
-  required List<Games> allStartedGames,
-  required List<String> pinnedIds,
-  required List<String?> formatStrings,
-}) {
-  if (allStartedGames.isEmpty) return [];
-
-  // Match format: check if ANY tour triggers match detection with the
-  // combined game pool. _isMatchFormatEvent already returns false when
-  // there are >2 unique players, so multi-tour events with different
-  // players correctly fall through to the normal path.
-  final isMatch = formatStrings.any(
-    (fmt) => _isMatchFormatEvent(fmt, allStartedGames),
+Future<String?> _resolveAutoPinCountryCode(Ref ref) async {
+  final cachedCountryCode = await AppDatabase.instance.getString(
+    'selected_country_code',
   );
-
-  if (isMatch) {
-    final sorted = _sortGamesLikeGamesTab(allStartedGames, pinnedIds);
-    return sorted.take(kGamesPerEvent).toList();
+  if (cachedCountryCode != null && cachedCountryCode.isNotEmpty) {
+    return cachedCountryCode;
   }
 
-  // --- Normal (non-match) path ---
-
-  // 1. Compute per-round recency: max activity timestamp per roundId.
-  //    Fallback chain: lastMoveTime > gameDay > dateStart > Unix epoch.
-  final unknownRoundTime = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
-  final roundRecency = <String, DateTime>{};
-  for (final game in allStartedGames) {
-    final time =
-        game.lastMoveTime ?? game.gameDay ?? game.dateStart ?? unknownRoundTime;
-    final existing = roundRecency[game.roundId];
-    if (existing == null || time.isAfter(existing)) {
-      roundRecency[game.roundId] = time;
-    }
+  final countryAsync = ref.read(countryDropdownProvider);
+  if (countryAsync.hasValue && countryAsync.value != null) {
+    return countryAsync.value!.countryCode;
   }
 
-  // Sort round IDs by recency descending
-  final roundsByRecency =
-      roundRecency.keys.toList()
-        ..sort((a, b) => roundRecency[b]!.compareTo(roundRecency[a]!));
-
-  final primaryRoundId = roundsByRecency.first;
-
-  // 2. Take games from the primary round first
-  final primaryRoundGames =
-      allStartedGames.where((g) => g.roundId == primaryRoundId).toList();
-  final sortedPrimary = _sortGamesLikeGamesTab(primaryRoundGames, pinnedIds);
-  final result = sortedPrimary.take(kGamesPerEvent).toList();
-
-  if (result.length >= kGamesPerEvent) return result;
-
-  // 3. Fill deficit from remaining rounds (by recency descending)
-  final selectedIds = result.map((g) => g.id).toSet();
-
-  for (final roundId in roundsByRecency.skip(1)) {
-    if (result.length >= kGamesPerEvent) break;
-
-    final roundGames =
-        allStartedGames
-            .where((g) => g.roundId == roundId && !selectedIds.contains(g.id))
-            .toList();
-    final sortedRound = _sortGamesLikeGamesTab(roundGames, pinnedIds);
-
-    for (final game in sortedRound) {
-      if (result.length >= kGamesPerEvent) break;
-      if (selectedIds.add(game.id)) {
-        result.add(game);
-      }
-    }
-  }
-
-  return result;
+  return countryAsync.valueOrNull?.countryCode;
 }
 
 // ============================================================================
-// LIVE ROUND WATCHER - DETECTS ROUND STARTS FOR ALL FOR YOU EVENTS
+// LIVE GAME WATCHER - AUTO-REFRESH WHEN GAMES FINISH
 // ============================================================================
 
-/// Tracks the last known set of live round IDs to detect changes
-/// Persists across provider rebuilds to properly detect additions
-final _lastKnownLiveRoundsProvider = StateProvider<Set<String>>((ref) => {});
-
-// ============================================================================
-// LIVE GAME WATCHER - AUTO-REFRESH WHEN GAMES FINISH OR ROUNDS START
-// ============================================================================
-
-/// Watches the status of displayed games and returns updated list
-/// When a live game finishes OR a new round starts, it automatically re-fetches
+/// Watches the status of displayed games and returns updated list.
+/// Round visibility changes are handled by [eventGamesProvider] dependencies.
 final forYouEventGamesWithAutoRefreshProvider = Provider.autoDispose.family<
-  AsyncValue<List<Games>>,
+  AsyncValue<ForYouEventGamesSnapshot>,
   String
 >((ref, eventId) {
-  // Watch the base games provider
-  final gamesAsync = ref.watch(eventGamesProvider(eventId));
+  final snapshotAsync = ref.watch(eventGamesProvider(eventId));
 
-  // Listen for live round changes - this triggers refresh when new rounds start
-  // Using listen instead of watch to get previous value for comparison
-  ref.listen<AsyncValue<List<String>>>(liveRoundsIdProvider, (
-    previous,
-    current,
-  ) {
-    final currRounds = current.valueOrNull;
-    if (currRounds == null) return;
-
-    final currSet = currRounds.toSet();
-    final lastKnown = ref.read(_lastKnownLiveRoundsProvider);
-
-    // Only trigger refresh if we have a baseline AND new rounds were added
-    // This prevents refresh on initial load
-    if (lastKnown.isNotEmpty) {
-      final newRounds = currSet.difference(lastKnown);
-      if (newRounds.isNotEmpty) {
-        debugPrint(
-          '[ForYou] New rounds started: ${newRounds.length} rounds - refreshing games for event $eventId',
-        );
-        // Invalidate to re-fetch games with new round data
-        Future.microtask(() {
-          ref.invalidate(eventGamesProvider(eventId));
-        });
-      }
-    }
-
-    // Update baseline if changed
-    if (!const SetEquality<String>().equals(currSet, lastKnown)) {
-      Future.microtask(() {
-        ref.read(_lastKnownLiveRoundsProvider.notifier).state = currSet;
-      });
-    }
-  }, fireImmediately: true);
-
-  return gamesAsync.when(
-    data: (games) {
-      // Find live games in current selection
+  return snapshotAsync.when(
+    data: (snapshot) {
       final liveGames =
-          games.where((g) => g.status == '*' || g.status == 'ongoing').toList();
+          snapshot.visibleGames
+              .where((game) => game.gameStatus == GameStatus.ongoing)
+              .toList();
 
-      // Watch game update streams for all live games.
-      // Reuses gameUpdatesStreamProvider (same as liveGameCardProvider in game cards)
-      // so Riverpod shares the provider instance — one Realtime channel per game
-      // instead of two separate channels (status + updates).
       for (final game in liveGames) {
-        final updatesAsync = ref.watch(gameUpdatesStreamProvider(game.id));
+        final updatesAsync = ref.watch(gameUpdatesStreamProvider(game.gameId));
         updatesAsync.whenData((data) {
           final status = data?['status'] as String?;
-          // If status changed to finished, invalidate to re-fetch
           if (status != null && _isFinishedStatus(status)) {
             debugPrint(
-              '[ForYou] Game ${game.id} finished ($status), refreshing games for event $eventId',
+              '[ForYou] Game ${game.gameId} finished ($status), refreshing snapshot for event $eventId',
             );
-            // Use Future.microtask to avoid invalidating during build
             Future.microtask(() {
-              ref.invalidate(eventGamesProvider(eventId));
+              bumpEventPinRefreshSignal(ref, eventId);
             });
           }
         });
       }
 
-      return AsyncValue.data(games);
+      return AsyncValue.data(snapshot);
     },
     loading: () => const AsyncValue.loading(),
     error: (e, st) => AsyncValue.error(e, st),
@@ -828,6 +1437,3 @@ final convertedForYouGamesProvider = Provider.autoDispose<List<GamesTourModel>>(
     return const [];
   },
 );
-
-final forYouAnimatedGameIds = <String>{};
-final forYouAnimatedEventIds = <String>{};

--- a/lib/repository/local_storage/tournament/games/games_local_storage.dart
+++ b/lib/repository/local_storage/tournament/games/games_local_storage.dart
@@ -19,7 +19,7 @@ final gamesLocalStorage = AutoDisposeProvider<GamesLocalStorage>((ref) {
 /// Marker prefix for gzip-compressed cache entries.
 const _gzipPrefix = 'gz:';
 
-/// Isolate worker: List<Games> → compressed string ready for SQLite storage.
+/// Isolate worker: `List<Games>` -> compressed string ready for SQLite storage.
 /// Gzip + base64 keeps the row well under Android's 2 MB CursorWindow limit.
 String _encodeAndCompress(List<Games> games) {
   final jsonStrings = games.map((g) => json.encode(g.toJson())).toList();
@@ -28,7 +28,7 @@ String _encodeAndCompress(List<Games> games) {
   return '$_gzipPrefix${base64.encode(compressed)}';
 }
 
-/// Isolate worker: compressed (or legacy raw) cache string → List<Games>.
+/// Isolate worker: compressed (or legacy raw) cache string -> `List<Games>`.
 /// Skips individual corrupted entries instead of throwing away the whole cache.
 List<Games> _decompressAndDecode(String cached) {
   String jsonString;
@@ -99,6 +99,17 @@ class GamesLocalStorage {
 
   String _getCacheKey(String tourId) => 'games_$tourId';
 
+  Future<({bool found, List<Games> games})> _readCachedGames(String tourId) async {
+    final db = ref.read(appDatabaseProvider);
+    final entry = await db.getCache(key: _getCacheKey(tourId));
+    if (entry == null) {
+      return (found: false, games: <Games>[]);
+    }
+
+    final games = await compute(_decompressAndDecode, entry.value);
+    return (found: true, games: games);
+  }
+
   /// Fetch games from Supabase, return immediately, compress+cache in background.
   Future<List<Games>> fetchAndSaveGames(String tourId) async {
     try {
@@ -130,12 +141,9 @@ class GamesLocalStorage {
   /// Read games from cache. Falls through to network fetch on any failure.
   Future<List<Games>> getGames(String tourId) async {
     try {
-      final db = ref.read(appDatabaseProvider);
-      final entry = await db.getCache(key: _getCacheKey(tourId));
-
-      if (entry != null) {
-        // Decompress + decode entirely in a background isolate
-        return await compute(_decompressAndDecode, entry.value);
+      final cachedGames = await _readCachedGames(tourId);
+      if (cachedGames.found) {
+        return cachedGames.games;
       }
       return await fetchAndSaveGames(tourId);
     } catch (error, _) {
@@ -147,6 +155,15 @@ class GamesLocalStorage {
       } catch (_) {
         return <Games>[];
       }
+    }
+  }
+
+  /// Read only cached games. Never falls through to the network.
+  Future<List<Games>> getCachedGames(String tourId) async {
+    try {
+      return (await _readCachedGames(tourId)).games;
+    } catch (error, _) {
+      return <Games>[];
     }
   }
 

--- a/lib/repository/local_storage/tournament/games/pin_games_local_storage.dart
+++ b/lib/repository/local_storage/tournament/games/pin_games_local_storage.dart
@@ -11,6 +11,8 @@ class _PinGameLocalStorage {
   final Ref ref;
 
   String _getListKey(String tournamentId) => 'pinned_games_$tournamentId';
+  String _getUnpinnedListKey(String tournamentId) =>
+      'unpinned_games_$tournamentId';
 
   // Get pinned game IDs for a specific tournament
   Future<List<String>> getPinnedGameIds(String tournamentId) async {
@@ -37,6 +39,49 @@ class _PinGameLocalStorage {
     try {
       final db = ref.read(appDatabaseProvider);
       await db.removeFromList(key: _getListKey(tournamentId), item: gameId);
+    } catch (e) {
+      // Local storage failure is not critical
+    }
+  }
+
+  // Get explicitly unpinned game IDs for a specific tournament
+  Future<List<String>> getUnpinnedGameIds(String tournamentId) async {
+    try {
+      final db = ref.read(appDatabaseProvider);
+      return await db.getList(key: _getUnpinnedListKey(tournamentId));
+    } catch (e) {
+      return [];
+    }
+  }
+
+  // Persist an explicit unpin override for a specific tournament
+  Future<void> addUnpinnedGameId(String tournamentId, String gameId) async {
+    try {
+      final db = ref.read(appDatabaseProvider);
+      await db.addToList(key: _getUnpinnedListKey(tournamentId), item: gameId);
+    } catch (e) {
+      // Local storage failure is not critical
+    }
+  }
+
+  // Remove an explicit unpin override for a specific tournament
+  Future<void> removeUnpinnedGameId(String tournamentId, String gameId) async {
+    try {
+      final db = ref.read(appDatabaseProvider);
+      await db.removeFromList(
+        key: _getUnpinnedListKey(tournamentId),
+        item: gameId,
+      );
+    } catch (e) {
+      // Local storage failure is not critical
+    }
+  }
+
+  // Clear all explicit unpin overrides for a specific tournament
+  Future<void> clearUnpinnedGames(String tournamentId) async {
+    try {
+      final db = ref.read(appDatabaseProvider);
+      await db.clearList(key: _getUnpinnedListKey(tournamentId));
     } catch (e) {
       // Local storage failure is not critical
     }

--- a/lib/repository/supabase/round/round_repository.dart
+++ b/lib/repository/supabase/round/round_repository.dart
@@ -1,6 +1,7 @@
 // repositories/round_repository.dart
 import 'package:chessever2/repository/supabase/base_repository.dart';
 import 'package:chessever2/repository/supabase/round/round.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final roundRepositoryProvider = AutoDisposeProvider<RoundRepository>((ref) {
@@ -18,6 +19,27 @@ class RoundRepository extends BaseRepository {
           .order('created_at', ascending: true);
 
       return (response as List).map((json) => Round.fromJson(json)).toList();
+    });
+  }
+
+  Future<Map<String, List<Round>>> getRoundsByTourIds(
+    List<String> tourIds,
+  ) async {
+    if (tourIds.isEmpty) return <String, List<Round>>{};
+
+    return handleApiCall(() async {
+      final response = await supabase
+          .from('rounds')
+          .select()
+          .inFilter('tour_id', tourIds)
+          .order('created_at', ascending: true);
+
+      final rounds =
+          (response as List).map((json) => Round.fromJson(json)).toList();
+      return groupRoundsByTourIdPreservingOrder(
+        rounds: rounds,
+        tourIds: tourIds,
+      );
     });
   }
 
@@ -197,4 +219,24 @@ class RoundRepository extends BaseRepository {
     }
     return null;
   }
+}
+
+@visibleForTesting
+Map<String, List<Round>> groupRoundsByTourIdPreservingOrder({
+  required List<Round> rounds,
+  required Iterable<String> tourIds,
+}) {
+  final grouped = <String, List<Round>>{
+    for (final tourId in tourIds) tourId: <Round>[],
+  };
+
+  for (final round in rounds) {
+    grouped.putIfAbsent(round.tourId, () => <Round>[]).add(round);
+  }
+
+  for (final groupedRounds in grouped.values) {
+    groupedRounds.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+  }
+
+  return grouped;
 }

--- a/lib/screens/group_event/group_event_screen.dart
+++ b/lib/screens/group_event/group_event_screen.dart
@@ -450,8 +450,11 @@ class GroupEventScreen extends HookConsumerWidget {
                             ? searchScrollController
                             : null;
 
-                    // Only load data for the currently selected tab
-                    if (currentCategory != selectedTourEvent) {
+                    // Only load data for the currently selected tab.
+                    // The For You tab is exempted so its widget stays alive
+                    // across category switches (AutomaticKeepAliveClientMixin
+                    // in ForYouGamesWidget preserves its state in the PageView).
+                    if (currentCategory != selectedTourEvent && !isForYou) {
                       return const SizedBox.shrink();
                     }
 

--- a/lib/screens/group_event/widget/for_you_games_widget.dart
+++ b/lib/screens/group_event/widget/for_you_games_widget.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:chessever2/providers/for_you_games_provider.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
+import 'package:chessever2/screens/group_event/group_event_screen.dart';
 import 'package:chessever2/screens/group_event/providers/group_event_screen_provider.dart';
 import 'package:chessever2/screens/group_event/widget/premium_collection_cards.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
@@ -39,7 +40,10 @@ class ForYouGamesWidget extends ConsumerStatefulWidget {
 }
 
 class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, AutomaticKeepAliveClientMixin {
+  final Set<String> _animatedEventIds = <String>{};
+  final Set<String> _animatedGameIds = <String>{};
+
   @override
   void initState() {
     super.initState();
@@ -49,6 +53,8 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
 
   @override
   void dispose() {
+    _animatedEventIds.clear();
+    _animatedGameIds.clear();
     widget.scrollController.removeListener(_onScroll);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -58,7 +64,14 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
-      unawaited(ref.read(forYouEventsProvider.notifier).refreshIfStale());
+      // Only refresh when For You is the active category. The widget stays
+      // alive offscreen via AutomaticKeepAliveClientMixin, so without this
+      // guard it would trigger background refreshes while the user is on
+      // Current/Past.
+      final selected = ref.read(selectedGroupCategoryProvider);
+      if (selected == GroupEventCategory.forYou) {
+        unawaited(ref.read(forYouEventsProvider.notifier).refreshIfStale());
+      }
     }
   }
 
@@ -72,8 +85,24 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
   }
 
   @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context); // required by AutomaticKeepAliveClientMixin
+
+    // When For You is not the active category, drop all expensive provider
+    // subscriptions by returning early. Riverpod automatically unsubscribes
+    // from providers that were watched in a previous build but not in the
+    // current one — so switching away tears down event snapshot watchers and
+    // live-game stream subscriptions without disposing the widget State.
+    final selectedCategory = ref.watch(selectedGroupCategoryProvider);
+    if (selectedCategory != GroupEventCategory.forYou) {
+      return const SizedBox.shrink();
+    }
+
     final state = ref.watch(forYouEventsProvider);
+    final visibleEvents = ref.watch(forYouVisibleEventsProvider);
 
     if (state.isLoading && state.events.isEmpty) {
       return _buildLoadingState();
@@ -84,7 +113,7 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
       return const GenericErrorWidget();
     }
 
-    if (state.events.isEmpty) {
+    if (visibleEvents.isEmpty) {
       return _buildEmptyState();
     }
 
@@ -95,7 +124,7 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
       color: kPrimaryColor,
       backgroundColor: kBlack2Color,
       child: _buildEventsList(
-        state.events,
+        visibleEvents,
         showLoadingMore: state.hasMore && !state.isLoading,
       ),
     );
@@ -204,6 +233,8 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
           key: ValueKey('event_${event.id}'),
           event: event,
           isFirst: index == 1,
+          animatedEventIds: _animatedEventIds,
+          animatedGameIds: _animatedGameIds,
         );
       },
     );
@@ -278,6 +309,8 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
                 child: _ForYouTabletEventColumn(
                   key: ValueKey('tablet_col_${event1.id}'),
                   event: event1,
+                  animatedEventIds: _animatedEventIds,
+                  animatedGameIds: _animatedGameIds,
                 ),
               ),
               SizedBox(width: columnSpacing),
@@ -288,6 +321,8 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
                         ? _ForYouTabletEventColumn(
                           key: ValueKey('tablet_col_${event2.id}'),
                           event: event2,
+                          animatedEventIds: _animatedEventIds,
+                          animatedGameIds: _animatedGameIds,
                         )
                         : const SizedBox.shrink(),
               ),
@@ -390,10 +425,14 @@ class _ForYouEventSection extends ConsumerWidget {
     super.key,
     required this.event,
     required this.isFirst,
+    required this.animatedEventIds,
+    required this.animatedGameIds,
   });
 
   final GroupEventCardModel event;
   final bool isFirst;
+  final Set<String> animatedEventIds;
+  final Set<String> animatedGameIds;
 
   /// Builds the EventCard with proper constraints for tablet
   /// Tablet uses image-as-background layout which needs bounded height
@@ -423,26 +462,9 @@ class _ForYouEventSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final gamesAsync = ref.watch(
-      forYouEventGamesWithAutoRefreshProvider(event.id),
-    );
-    final hasNoAvailableGames = gamesAsync.when(
-      data: (games) => games.isEmpty,
-      loading: () => false,
-      error: (_, __) => false,
-    );
-
-    if (hasNoAvailableGames) {
-      // Remove event from list so it no longer appears in For You.
-      Future.microtask(() {
-        ref.read(forYouEventsProvider.notifier).removeEvent(event.id);
-      });
-      return const SizedBox.shrink();
-    }
-
-    final shouldAnimate = !forYouAnimatedEventIds.contains(event.id);
+    final shouldAnimate = !animatedEventIds.contains(event.id);
     if (shouldAnimate) {
-      forYouAnimatedEventIds.add(event.id);
+      animatedEventIds.add(event.id);
     }
 
     final section = Column(
@@ -455,7 +477,7 @@ class _ForYouEventSection extends ConsumerWidget {
         ),
 
         // Games for this event (lazy loaded with shimmer)
-        _ForYouEventGames(eventId: event.id),
+        _ForYouEventGames(eventId: event.id, animatedGameIds: animatedGameIds),
       ],
     );
 
@@ -473,32 +495,22 @@ class _ForYouEventSection extends ConsumerWidget {
 /// Single column in the 2-column tablet grid
 /// Contains: event card on top + games stacked below (1 game per row within column)
 class _ForYouTabletEventColumn extends ConsumerWidget {
-  const _ForYouTabletEventColumn({super.key, required this.event});
+  const _ForYouTabletEventColumn({
+    super.key,
+    required this.event,
+    required this.animatedEventIds,
+    required this.animatedGameIds,
+  });
 
   final GroupEventCardModel event;
+  final Set<String> animatedEventIds;
+  final Set<String> animatedGameIds;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final gamesAsync = ref.watch(
-      forYouEventGamesWithAutoRefreshProvider(event.id),
-    );
-    final hasNoAvailableGames = gamesAsync.when(
-      data: (games) => games.isEmpty,
-      loading: () => false,
-      error: (_, __) => false,
-    );
-
-    if (hasNoAvailableGames) {
-      // Remove event from list so tablet rows compact without this event.
-      Future.microtask(() {
-        ref.read(forYouEventsProvider.notifier).removeEvent(event.id);
-      });
-      return const SizedBox.shrink();
-    }
-
-    final shouldAnimate = !forYouAnimatedEventIds.contains(event.id);
+    final shouldAnimate = !animatedEventIds.contains(event.id);
     if (shouldAnimate) {
-      forYouAnimatedEventIds.add(event.id);
+      animatedEventIds.add(event.id);
     }
 
     // Aspect ratio for event card in column layout
@@ -526,7 +538,10 @@ class _ForYouTabletEventColumn extends ConsumerWidget {
         ),
         SizedBox(height: 10.sp),
         // Games for this event (stacked vertically, 1 per row in this column)
-        _ForYouTabletColumnGames(eventId: event.id),
+        _ForYouTabletColumnGames(
+          eventId: event.id,
+          animatedGameIds: animatedGameIds,
+        ),
       ],
     );
 
@@ -544,9 +559,13 @@ class _ForYouTabletEventColumn extends ConsumerWidget {
 /// Games for a single column - shows games in 2-column grid (2 per row)
 /// Uses auto-refresh provider that watches live games and re-fetches when they finish
 class _ForYouTabletColumnGames extends ConsumerWidget {
-  const _ForYouTabletColumnGames({required this.eventId});
+  const _ForYouTabletColumnGames({
+    required this.eventId,
+    required this.animatedGameIds,
+  });
 
   final String eventId;
+  final Set<String> animatedGameIds;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -556,24 +575,18 @@ class _ForYouTabletColumnGames extends ConsumerWidget {
     );
 
     return gamesAsync.when(
-      data: (games) {
-        if (games.isEmpty) {
+      skipLoadingOnRefresh: true,
+      skipLoadingOnReload: true,
+      data: (snapshot) {
+        final orderedGames = snapshot.visibleGames;
+        if (orderedGames.isEmpty) {
           return const SizedBox.shrink();
         }
 
-        // Convert to GamesTourModel - limit to 4 games (2 rows of 2)
-        final allGameModels =
-            games
-                .where((g) => g.players != null && g.players!.length >= 2)
-                .map((g) => GamesTourModel.fromGame(g))
-                .toList();
-
-        if (allGameModels.isEmpty) {
+        final gameModels = orderedGames.take(kGamesPerEvent).toList();
+        if (gameModels.isEmpty) {
           return const SizedBox.shrink();
         }
-
-        // Take only first kGamesPerEvent games for tablet column view
-        final gameModels = allGameModels.take(kGamesPerEvent).toList();
 
         // Build 2-column grid of games (2 per row, max 2 rows = 4 games)
         // Wrap with animated slots for smooth transitions when games change
@@ -594,8 +607,10 @@ class _ForYouTabletColumnGames extends ConsumerWidget {
                       gameId: game1.gameId,
                       child: _TabletGameCard(
                         game: game1,
-                        games: gameModels,
+                        orderedGames: orderedGames,
                         index: i,
+                        eventId: eventId,
+                        pinnedIds: snapshot.pinnedIds,
                       ),
                     ),
                   ),
@@ -608,8 +623,10 @@ class _ForYouTabletColumnGames extends ConsumerWidget {
                               gameId: game2.gameId,
                               child: _TabletGameCard(
                                 game: game2,
-                                games: gameModels,
+                                orderedGames: orderedGames,
                                 index: i + 1,
+                                eventId: eventId,
+                                pinnedIds: snapshot.pinnedIds,
                               ),
                             )
                             : const SizedBox.shrink(),
@@ -683,20 +700,24 @@ class _ForYouTabletColumnGames extends ConsumerWidget {
 class _TabletGameCard extends ConsumerWidget {
   const _TabletGameCard({
     required this.game,
-    required this.games,
+    required this.orderedGames,
     required this.index,
+    required this.eventId,
+    required this.pinnedIds,
   });
 
   final GamesTourModel game;
-  final List<GamesTourModel> games;
+  final List<GamesTourModel> orderedGames;
   final int index;
+  final String eventId;
+  final List<String> pinnedIds;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return GridGameCardWrapperWidget(
       key: ValueKey('tablet_grid_game_${game.gameId}'),
       game: game,
-      orderedGames: games,
+      orderedGames: orderedGames,
       gameIndex: index,
       onChangedWithLiveGames:
           (updatedGames) => ref
@@ -708,8 +729,15 @@ class _TabletGameCard extends ConsumerWidget {
                 onReturnFromChessboard: (_) {},
                 viewSource: ChessboardView.forYou,
               ),
-      pinnedIds: const [],
-      onPinToggle: (_) {},
+      pinnedIds: pinnedIds,
+      onPinToggle:
+          (_) => ref
+              .read(forYouPinActionProvider)
+              .togglePin(
+                eventId: eventId,
+                gameId: game.gameId,
+                tourId: game.tourId,
+              ),
     );
   }
 }
@@ -717,9 +745,13 @@ class _TabletGameCard extends ConsumerWidget {
 /// Games section for one event - loads lazily with shimmer
 /// Uses auto-refresh provider that watches live games and re-fetches when they finish
 class _ForYouEventGames extends ConsumerWidget {
-  const _ForYouEventGames({required this.eventId});
+  const _ForYouEventGames({
+    required this.eventId,
+    required this.animatedGameIds,
+  });
 
   final String eventId;
+  final Set<String> animatedGameIds;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -730,36 +762,39 @@ class _ForYouEventGames extends ConsumerWidget {
     final viewMode = ref.watch(gamesListViewModeProvider);
 
     return gamesAsync.when(
-      data: (games) {
-        if (games.isEmpty) {
+      skipLoadingOnRefresh: true,
+      skipLoadingOnReload: true,
+      data: (snapshot) {
+        final orderedGames = snapshot.visibleGames;
+        if (orderedGames.isEmpty) {
           return const SizedBox.shrink();
         }
 
-        // Convert to GamesTourModel
-        final gameModels =
-            games
-                .where((g) => g.players != null && g.players!.length >= 2)
-                .map((g) => GamesTourModel.fromGame(g))
-                .toList();
-
-        if (gameModels.isEmpty) {
+        final displayedGames = orderedGames.take(kGamesPerEvent).toList();
+        if (displayedGames.isEmpty) {
           return const SizedBox.shrink();
         }
 
         final gamesData = GamesScreenModel(
-          gamesTourModels: gameModels,
-          pinnedGamedIs: const [],
+          gamesTourModels: orderedGames,
+          pinnedGamedIs: snapshot.pinnedIds,
         );
 
         // Grid mode: 2 games per row
         if (viewMode == GamesListViewMode.chessBoardGrid) {
-          return _buildGridGames(context, ref, gameModels);
+          return _buildGridGames(
+            context,
+            ref,
+            displayedGames,
+            orderedGames,
+            snapshot.pinnedIds,
+          );
         }
 
         // List mode: one game per row with smooth transition animation
         return Column(
-          children: List.generate(gameModels.length, (index) {
-            final game = gameModels[index];
+          children: List.generate(displayedGames.length, (index) {
+            final game = displayedGames[index];
             return _AnimatedGameCardSlot(
               key: ValueKey('slot_$index'),
               gameId: game.gameId,
@@ -768,7 +803,8 @@ class _ForYouEventGames extends ConsumerWidget {
                 game: game,
                 gamesData: gamesData,
                 gameIndex: index,
-                allGames: gameModels,
+                eventId: eventId,
+                animatedGameIds: animatedGameIds,
                 viewMode: viewMode,
               ),
             );
@@ -794,13 +830,16 @@ class _ForYouEventGames extends ConsumerWidget {
   Widget _buildGridGames(
     BuildContext context,
     WidgetRef ref,
-    List<GamesTourModel> games,
+    List<GamesTourModel> displayedGames,
+    List<GamesTourModel> orderedGames,
+    List<String> pinnedIds,
   ) {
     final rows = <Widget>[];
 
-    for (int i = 0; i < games.length; i += 2) {
-      final game1 = games[i];
-      final game2 = i + 1 < games.length ? games[i + 1] : null;
+    for (int i = 0; i < displayedGames.length; i += 2) {
+      final game1 = displayedGames[i];
+      final game2 =
+          i + 1 < displayedGames.length ? displayedGames[i + 1] : null;
 
       rows.add(
         Padding(
@@ -814,7 +853,7 @@ class _ForYouEventGames extends ConsumerWidget {
                   child: GridGameCardWrapperWidget(
                     key: ValueKey('grid_game_${game1.gameId}'),
                     game: game1,
-                    orderedGames: games,
+                    orderedGames: orderedGames,
                     gameIndex: i,
                     onChangedWithLiveGames:
                         (updatedGames) => ref
@@ -826,8 +865,15 @@ class _ForYouEventGames extends ConsumerWidget {
                               onReturnFromChessboard: (_) {},
                               viewSource: ChessboardView.forYou,
                             ),
-                    pinnedIds: const [],
-                    onPinToggle: (_) {},
+                    pinnedIds: pinnedIds,
+                    onPinToggle:
+                        (_) => ref
+                            .read(forYouPinActionProvider)
+                            .togglePin(
+                              eventId: eventId,
+                              gameId: game1.gameId,
+                              tourId: game1.tourId,
+                            ),
                   ),
                 ),
               ),
@@ -841,7 +887,7 @@ class _ForYouEventGames extends ConsumerWidget {
                           child: GridGameCardWrapperWidget(
                             key: ValueKey('grid_game_${game2.gameId}'),
                             game: game2,
-                            orderedGames: games,
+                            orderedGames: orderedGames,
                             gameIndex: i + 1,
                             onChangedWithLiveGames:
                                 (updatedGames) => ref
@@ -853,8 +899,15 @@ class _ForYouEventGames extends ConsumerWidget {
                                       onReturnFromChessboard: (_) {},
                                       viewSource: ChessboardView.forYou,
                                     ),
-                            pinnedIds: const [],
-                            onPinToggle: (_) {},
+                            pinnedIds: pinnedIds,
+                            onPinToggle:
+                                (_) => ref
+                                    .read(forYouPinActionProvider)
+                                    .togglePin(
+                                      eventId: eventId,
+                                      gameId: game2.gameId,
+                                      tourId: game2.tourId,
+                                    ),
                           ),
                         )
                         : const SizedBox.shrink(),
@@ -952,23 +1005,25 @@ class _ForYouGameCard extends ConsumerWidget {
     required this.game,
     required this.gamesData,
     required this.gameIndex,
-    required this.allGames,
+    required this.eventId,
+    required this.animatedGameIds,
     required this.viewMode,
   });
 
   final GamesTourModel game;
   final GamesScreenModel gamesData;
   final int gameIndex;
-  final List<GamesTourModel> allGames;
+  final String eventId;
+  final Set<String> animatedGameIds;
   final GamesListViewMode viewMode;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isChessBoardVisible = viewMode == GamesListViewMode.chessBoard;
-    final shouldAnimate = !forYouAnimatedGameIds.contains(game.gameId);
+    final shouldAnimate = !animatedGameIds.contains(game.gameId);
 
     if (shouldAnimate) {
-      forYouAnimatedGameIds.add(game.gameId);
+      animatedGameIds.add(game.gameId);
     }
 
     final card = Padding(
@@ -979,6 +1034,14 @@ class _ForYouGameCard extends ConsumerWidget {
         gameIndex: gameIndex,
         isChessBoardVisible: isChessBoardVisible,
         viewSource: ChessboardView.forYou,
+        onPinToggle:
+            (_) => ref
+                .read(forYouPinActionProvider)
+                .togglePin(
+                  eventId: eventId,
+                  gameId: game.gameId,
+                  tourId: game.tourId,
+                ),
         onReturnFromChessboard: (_) {},
       ),
     );

--- a/lib/screens/tour_detail/games_tour/providers/games_pin_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_pin_provider.dart
@@ -16,40 +16,85 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class GamesPinState {
   final List<String> manualPins;
   final List<String> autoPins;
+  final List<String> unpinnedOverrides;
   final bool autoPinDisabled;
 
   const GamesPinState({
     this.manualPins = const [],
     this.autoPins = const [],
+    this.unpinnedOverrides = const [],
     this.autoPinDisabled = false,
   });
 
   List<String> get allPins {
-    final seen = <String>{};
-    final ordered = <String>[];
-
-    for (final id in manualPins) {
-      if (seen.add(id)) ordered.add(id);
-    }
-
-    for (final id in autoPins) {
-      if (seen.add(id)) ordered.add(id);
-    }
-
-    return ordered;
+    return mergeEffectivePins(
+      manualPins: manualPins,
+      autoPins: autoPins,
+      unpinnedOverrides: unpinnedOverrides,
+    );
   }
 
   GamesPinState copyWith({
     List<String>? manualPins,
     List<String>? autoPins,
+    List<String>? unpinnedOverrides,
     bool? autoPinDisabled,
   }) {
     return GamesPinState(
       manualPins: manualPins ?? this.manualPins,
       autoPins: autoPins ?? this.autoPins,
+      unpinnedOverrides: unpinnedOverrides ?? this.unpinnedOverrides,
       autoPinDisabled: autoPinDisabled ?? this.autoPinDisabled,
     );
   }
+}
+
+enum PinToggleMode { unpinManualOnly, unpinWithOverride, repin }
+
+List<String> mergePinListsPreservingOrder(List<List<String>> pinLists) {
+  final mergedPins = <String>[];
+  final seen = <String>{};
+
+  for (final pinIds in pinLists) {
+    for (final pinId in pinIds) {
+      if (seen.add(pinId)) {
+        mergedPins.add(pinId);
+      }
+    }
+  }
+
+  return mergedPins;
+}
+
+List<String> mergeEffectivePins({
+  required List<String> manualPins,
+  required List<String> autoPins,
+  required List<String> unpinnedOverrides,
+}) {
+  final overrideSet = unpinnedOverrides.toSet();
+  return mergePinListsPreservingOrder([manualPins, autoPins])
+      .where((gameId) => !overrideSet.contains(gameId))
+      .toList(growable: false);
+}
+
+PinToggleMode resolvePinToggleMode({
+  required bool isManualPinned,
+  required bool isAutoPinned,
+  required bool isOverridden,
+}) {
+  if (isOverridden) {
+    return PinToggleMode.repin;
+  }
+
+  if (isManualPinned && !isAutoPinned) {
+    return PinToggleMode.unpinManualOnly;
+  }
+
+  if (isManualPinned || isAutoPinned) {
+    return PinToggleMode.unpinWithOverride;
+  }
+
+  return PinToggleMode.repin;
 }
 
 final gamesPinprovider =
@@ -222,44 +267,66 @@ class _GamesPinController extends StateNotifier<GamesPinState> {
   }
 
   Future<void> loadPinnedGames() async {
-    final manualPins = await ref
-        .read(pinGameLocalStorage)
-        .getPinnedGameIds(tourId);
-    final autoPinnedGames = await ref
-        .read(autoPinLogicProvider)
-        .getAutoPinnedGames(tourId);
+    final storage = ref.read(pinGameLocalStorage);
+    final relatedTourIds = _getRelatedTourIds();
+    final pinResults = await Future.wait<Object?>([
+      Future.wait(
+        relatedTourIds.map((relatedTourId) => storage.getPinnedGameIds(relatedTourId)),
+      ),
+      Future.wait(
+        relatedTourIds.map(
+          (relatedTourId) => storage.getUnpinnedGameIds(relatedTourId),
+        ),
+      ),
+      ref.read(autoPinLogicProvider).getAutoPinnedGames(tourId),
+    ]);
+
+    final manualPinLists = pinResults[0]! as List<List<String>>;
+    final unpinnedOverrideLists = pinResults[1]! as List<List<String>>;
+    final autoPinnedGames = pinResults[2]! as (bool, List<String>);
 
     state = state.copyWith(
-      manualPins: manualPins,
+      manualPins: mergePinListsPreservingOrder(manualPinLists),
       autoPins: autoPinnedGames.$2,
+      unpinnedOverrides: mergePinListsPreservingOrder(unpinnedOverrideLists),
       autoPinDisabled: autoPinnedGames.$1,
     );
   }
 
-  Future<void> togglePin(String gameId) async {
+  Future<void> togglePin({
+    required String gameId,
+    required String sourceTourId,
+  }) async {
     try {
       final storage = ref.read(pinGameLocalStorage);
+      final mode = resolvePinToggleMode(
+        isManualPinned: state.manualPins.contains(gameId),
+        isAutoPinned: state.autoPins.contains(gameId),
+        isOverridden: state.unpinnedOverrides.contains(gameId),
+      );
 
-      if (state.manualPins.contains(gameId) ||
-          state.autoPins.contains(gameId)) {
-        await storage.removePinnedGameId(tourId, gameId);
-        final autoPins = state.autoPins;
-        autoPins.removeWhere((id) => id == gameId);
-
-        state = state.copyWith(
-          manualPins: state.manualPins.where((id) => id != gameId).toList(),
-          autoPins: autoPins,
-        );
-      } else {
-        await storage.addPinnedGameId(tourId, gameId);
-        final autoPins = state.autoPins;
-        autoPins.add(gameId);
-        state = state.copyWith(
-          manualPins: [...state.manualPins, gameId],
-          autoPins: autoPins,
-        );
+      switch (mode) {
+        case PinToggleMode.unpinManualOnly:
+          await storage.removePinnedGameId(sourceTourId, gameId);
+          break;
+        case PinToggleMode.unpinWithOverride:
+          await Future.wait([
+            storage.removePinnedGameId(sourceTourId, gameId),
+            storage.addUnpinnedGameId(sourceTourId, gameId),
+          ]);
+          break;
+        case PinToggleMode.repin:
+          await Future.wait([
+            storage.removeUnpinnedGameId(sourceTourId, gameId),
+            storage.addPinnedGameId(sourceTourId, gameId),
+          ]);
+          break;
       }
-    } catch (e, _) {}
+
+      await loadPinnedGames();
+    } catch (e, _) {
+      debugPrint('Failed to toggle pin for $gameId in $sourceTourId: $e');
+    }
   }
 
   Future<void> enableAutoPin() async {
@@ -273,12 +340,39 @@ class _GamesPinController extends StateNotifier<GamesPinState> {
   }
 
   Future<void> computeAutoPins() async {
-    final autoPinnedGames = await ref
-        .read(autoPinLogicProvider)
-        .getAutoPinnedGames(tourId);
-    state = state.copyWith(
-      autoPins: autoPinnedGames.$2,
-      autoPinDisabled: autoPinnedGames.$1,
-    );
+    await loadPinnedGames();
+  }
+
+  List<String> _getRelatedTourIds() {
+    final detail = ref.read(tourDetailScreenProvider).valueOrNull;
+    if (detail == null || detail.tours.isEmpty) {
+      return [tourId];
+    }
+
+    final matchingTour =
+        detail.tours
+            .firstWhere(
+              (tourModel) => tourModel.tour.id == tourId,
+              orElse: () => detail.tours.first,
+            )
+            .tour;
+
+    final groupBroadcastId = matchingTour.groupBroadcastId;
+    if (groupBroadcastId == null || groupBroadcastId.isEmpty) {
+      return [tourId];
+    }
+
+    final relatedIds = <String>[tourId];
+    for (final tourModel in detail.tours) {
+      final relatedTourId = tourModel.tour.id;
+      if (relatedTourId == tourId) {
+        continue;
+      }
+      if (tourModel.tour.groupBroadcastId == groupBroadcastId) {
+        relatedIds.add(relatedTourId);
+      }
+    }
+
+    return relatedIds;
   }
 }

--- a/lib/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart
@@ -1,4 +1,5 @@
 import 'package:chessever2/repository/local_storage/tournament/games/games_local_storage.dart';
+import 'package:chessever2/providers/event_pin_refresh_provider.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
 import 'package:chessever2/screens/group_event/model/about_tour_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
@@ -8,6 +9,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_pr
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/knockout_tournament_state_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
 import 'package:chessever2/widgets/search/gameSearch/enhanced_game_search.dart';
 import 'package:flutter/foundation.dart';
@@ -385,10 +387,11 @@ class GamesTourScreenProvider
     }
   }
 
-  Future<void> togglePinGame(String gameId) async {
+  Future<void> togglePinGame(String gameId, {required String sourceTourId}) async {
     await ref
         .read(gamesPinprovider(aboutTourModel!.id).notifier)
-        .togglePin(gameId);
+        .togglePin(gameId: gameId, sourceTourId: sourceTourId);
+    bumpEventPinRefreshSignal(ref, ref.read(selectedBroadcastModelProvider)?.id);
   }
 
   void clearSearch() {

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_provider.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_provider.dart
@@ -1,7 +1,5 @@
 import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
-import 'package:chessever2/repository/local_storage/tournament/games/games_local_storage.dart';
-import 'package:chessever2/repository/supabase/game/games.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:flutter/material.dart';
@@ -39,136 +37,7 @@ class _GameCardWrapperProvider {
     }
 
     final safeIndex = gameIndex.clamp(0, orderedGames.length - 1);
-    final currentGame = orderedGames[safeIndex];
-    final tourId = currentGame.tourId;
-
-    if (tourId.isEmpty) {
-      return _ResolvedNavigation(games: orderedGames, index: safeIndex);
-    }
-
-    try {
-      final fullGames = await _ref.read(gamesLocalStorage).getGames(tourId);
-
-      if (fullGames.isEmpty) {
-        return _ResolvedNavigation(games: orderedGames, index: safeIndex);
-      }
-
-      // Sort games to match tour detail screen ordering:
-      // 1. Round number descending (latest round first)
-      // 2. Game number descending
-      // 3. Board number ascending (board 1 first)
-      final sortedGames = _sortGamesForNavigation(fullGames);
-
-      final fullModels = <GamesTourModel>[];
-      for (final game in sortedGames) {
-        try {
-          fullModels.add(GamesTourModel.fromGame(game));
-        } catch (_) {
-          // Skip invalid game rows to keep navigation resilient.
-        }
-      }
-
-      if (fullModels.isEmpty) {
-        return _ResolvedNavigation(games: orderedGames, index: safeIndex);
-      }
-
-      final overrides = {for (final game in orderedGames) game.gameId: game};
-      final mergedModels =
-          fullModels.map((game) {
-            final override = overrides[game.gameId];
-            if (override == null) return game;
-            return game.copyWith(
-              pgn: override.pgn ?? game.pgn,
-              fen: override.fen ?? game.fen,
-              lastMove: override.lastMove ?? game.lastMove,
-              lastMoveTime: override.lastMoveTime ?? game.lastMoveTime,
-              whiteClockSeconds:
-                  override.whiteClockSeconds ?? game.whiteClockSeconds,
-              blackClockSeconds:
-                  override.blackClockSeconds ?? game.blackClockSeconds,
-              gameStatus: override.gameStatus,
-            );
-          }).toList();
-
-      final resolvedIndex = mergedModels.indexWhere(
-        (game) => game.gameId == currentGame.gameId,
-      );
-      final finalIndex =
-          resolvedIndex >= 0
-              ? resolvedIndex
-              : safeIndex.clamp(0, mergedModels.length - 1);
-
-      return _ResolvedNavigation(games: mergedModels, index: finalIndex);
-    } catch (e) {
-      debugPrint('Failed to expand for-you games list: $e');
-      return _ResolvedNavigation(games: orderedGames, index: safeIndex);
-    }
-  }
-
-  /// Sorts games to match tour detail screen ordering.
-  /// Order: round descending → game number descending → board number ascending
-  List<Games> _sortGamesForNavigation(List<Games> games) {
-    if (games.isEmpty) return games;
-
-    // Pre-parse round and game numbers for performance
-    final gameInfo = <String, (int, int)>{};
-    for (final game in games) {
-      gameInfo[game.id] = (
-        _extractRoundNumber(game.roundSlug),
-        _extractGameNumber(game.roundSlug),
-      );
-    }
-
-    final sortedGames = List<Games>.from(games);
-    sortedGames.sort((a, b) {
-      final (roundA, gameA) = gameInfo[a.id] ?? (0, 0);
-      final (roundB, gameB) = gameInfo[b.id] ?? (0, 0);
-
-      // Sort by round number descending (latest round first)
-      if (roundA != roundB) return roundB.compareTo(roundA);
-
-      // Within same round, sort by game number descending
-      if (gameA != gameB) return gameB.compareTo(gameA);
-
-      // Finally, sort by board number ascending (board 1 first)
-      final aBoard = a.boardNr, bBoard = b.boardNr;
-      if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
-      if (aBoard != null) return -1;
-      if (bBoard != null) return 1;
-      return 0;
-    });
-
-    return sortedGames;
-  }
-
-  /// Extracts round number from round slug (e.g., "round-5" -> 5)
-  /// Named knockout stages get high numbers so they sort after numbered rounds.
-  int _extractRoundNumber(String roundSlug) {
-    final slug = roundSlug.toLowerCase();
-    if (slug.contains('final') &&
-        !slug.contains('quarter') &&
-        !slug.contains('semi')) {
-      return 10000;
-    }
-    if (slug.contains('semifinal') || slug.contains('semi-final')) {
-      return 9000;
-    }
-    if (slug.contains('quarterfinal') || slug.contains('quarter-final')) {
-      return 8000;
-    }
-    final match =
-        RegExp(r'round-?(\d+)', caseSensitive: false).firstMatch(roundSlug) ??
-        RegExp(r'(\d+)').firstMatch(roundSlug);
-    return int.tryParse(match?.group(1) ?? '0') ?? 0;
-  }
-
-  /// Extracts game number from round slug (e.g., "round-6--game-2" -> 2)
-  int _extractGameNumber(String roundSlug) {
-    final match = RegExp(
-      r'game-?(\d+)',
-      caseSensitive: false,
-    ).firstMatch(roundSlug);
-    return int.tryParse(match?.group(1) ?? '0') ?? 0;
+    return _ResolvedNavigation(games: orderedGames, index: safeIndex);
   }
 
   void navigateToChessBoard({
@@ -189,6 +58,11 @@ class _GameCardWrapperProvider {
       gameIndex: gameIndex,
       viewSource: viewSource,
     );
+
+    if (!context.mounted) {
+      _ref.read(shouldStreamProvider.notifier).state = true;
+      return;
+    }
 
     final returnedIndex = await Navigator.push<int>(
       context,

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart
@@ -14,6 +14,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
   final GamesScreenModel gamesData;
   final int gameIndex;
   final bool isChessBoardVisible;
+  final Future<void> Function(GamesTourModel game)? onPinToggle;
   final void Function(int)? onReturnFromChessboard;
   final ChessboardView viewSource;
 
@@ -23,6 +24,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
     required this.gamesData,
     required this.gameIndex,
     required this.isChessBoardVisible,
+    this.onPinToggle,
     this.onReturnFromChessboard,
     this.viewSource = ChessboardView.tour,
   });
@@ -43,6 +45,17 @@ class GameCardWrapperWidget extends ConsumerWidget {
       return games;
     }
 
+    Future<void> handlePinToggle(GamesTourModel game) async {
+      if (onPinToggle != null) {
+        await onPinToggle!(game);
+        return;
+      }
+
+      await ref
+          .read(gamesTourScreenProvider.notifier)
+          .togglePinGame(game.gameId, sourceTourId: game.tourId);
+    }
+
     return isChessBoardVisible
         ? ChessBoardFromFENNew(
           key: ValueKey(keyValue),
@@ -58,10 +71,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
                     viewSource: viewSource,
                   ),
           pinnedIds: gamesData.pinnedGamedIs,
-          onPinToggle:
-              (_) async => await ref
-                  .read(gamesTourScreenProvider.notifier)
-                  .togglePinGame(liveGame.gameId),
+          onPinToggle: handlePinToggle,
         )
         : GameCard(
           key: ValueKey(keyValue),
@@ -70,10 +80,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
             comparison: MatchComparison.sameOrder,
           ),
           pinnedIds: gamesData.pinnedGamedIs,
-          onPinToggle:
-              (_) async => await ref
-                  .read(gamesTourScreenProvider.notifier)
-                  .togglePinGame(liveGame.gameId),
+          onPinToggle: handlePinToggle,
           onTap:
               () => ref
                   .read(gameCardWrapperProvider)

--- a/lib/screens/tour_detail/games_tour/widgets/games_list_view.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/games_list_view.dart
@@ -349,7 +349,7 @@ class GamesListView extends ConsumerWidget {
       onPinToggle:
           (_) async => await ref
               .read(gamesTourScreenProvider.notifier)
-              .togglePinGame(game.gameId),
+              .togglePinGame(game.gameId, sourceTourId: game.tourId),
     );
   }
 

--- a/lib/screens/tour_detail/games_tour/widgets/group_event_games_card.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/group_event_games_card.dart
@@ -48,7 +48,7 @@ class _GroupEventGamesCardState extends ConsumerState<GroupEventGamesCard> {
           onPinToggle: (game) async {
             await ref
                 .read(gamesTourScreenProvider.notifier)
-                .togglePinGame(game.gameId);
+                .togglePinGame(game.gameId, sourceTourId: game.tourId);
           },
           pinnedIds: widget.gamesData.pinnedGamedIs,
           onTap: () {

--- a/lib/screens/tour_detail/games_tour/widgets/group_event_match_card.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/group_event_match_card.dart
@@ -319,7 +319,10 @@ class GroupEventMatchCard extends ConsumerWidget {
       onPinToggle:
           (_) async => await ref
               .read(gamesTourScreenProvider.notifier)
-              .togglePinGame(matchWithComparison.game.gameId),
+              .togglePinGame(
+                matchWithComparison.game.gameId,
+                sourceTourId: matchWithComparison.game.tourId,
+              ),
     );
   }
 }

--- a/lib/screens/tour_detail/provider/tour_detail_screen_provider.dart
+++ b/lib/screens/tour_detail/provider/tour_detail_screen_provider.dart
@@ -11,6 +11,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/live_tour_id
 import 'package:chessever2/screens/tour_detail/provider/interface/itour_detail_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_repo_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_selection_logic.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -310,16 +311,13 @@ class _TourDetailScreenNotifier
     DateTime endDate,
     List<String> liveTourIds,
   ) {
-    // Never treat future tours as live, even if settings contain stale IDs.
-    if (now.isBefore(startDate)) {
-      return RoundStatus.upcoming;
-    } else if (now.isAfter(endDate)) {
-      return RoundStatus.completed;
-    } else if (liveTourIds.contains(tourId)) {
-      return RoundStatus.live;
-    } else {
-      return RoundStatus.ongoing;
-    }
+    return calculateTourRoundStatus(
+      tourId: tourId,
+      now: now,
+      startDate: startDate,
+      endDate: endDate,
+      liveTourIds: liveTourIds,
+    );
   }
 
   @override
@@ -328,26 +326,8 @@ class _TourDetailScreenNotifier
     TourDetailViewModel? currentState,
     List<String> liveTourIds,
   ) async {
-    final hasStartedTours = tourModels.any(
-      (model) => model.roundStatus != RoundStatus.upcoming,
-    );
-
-    bool canUseSelection(TourModel model) {
-      // If we already have started tours in this event, never lock into a purely upcoming tour.
-      if (!hasStartedTours) return true;
-      return model.roundStatus != RoundStatus.upcoming;
-    }
-
-    // 1️⃣ If user already selected a tour during this session, keep it.
     final currentSelectedId = currentState?.aboutTourModel.id;
-    if (currentSelectedId != null && currentSelectedId.isNotEmpty) {
-      final currentModel = findTourModel(tourModels, currentSelectedId);
-      if (currentModel != null && canUseSelection(currentModel)) {
-        return currentModel.tour;
-      }
-    }
 
-    // 2️⃣ If user previously selected a tour, respect that choice.
     String? savedTourId;
     try {
       savedTourId = await ref
@@ -357,157 +337,22 @@ class _TourDetailScreenNotifier
       savedTourId = null;
     }
 
-    if (savedTourId != null) {
-      final savedModel = findTourModel(tourModels, savedTourId);
-      if (savedModel != null && canUseSelection(savedModel)) {
-        return savedModel.tour;
-      }
-    }
-
-    // 3️⃣ Prefer live tours — a tour with active games always takes priority
-    final liveModels =
-        tourModels
-            .where((model) => model.roundStatus == RoundStatus.live)
-            .toList();
-
-    if (liveModels.isNotEmpty) {
-      // If multiple are live, pick the one that started most recently
-      if (liveModels.length > 1) {
-        liveModels.sort((a, b) {
-          final aDate =
-              a.tour.dates.isNotEmpty ? a.tour.dates.first : DateTime(1970);
-          final bDate =
-              b.tour.dates.isNotEmpty ? b.tour.dates.first : DateTime(1970);
-          return bDate.compareTo(aDate);
-        });
-      }
-      return liveModels.first.tour;
-    }
-
-    // 4️⃣ Default selection based on start times:
-    //    Same start time → highest average rating
-    //    Different start times → latest starting event
-    final selectableModels =
-        hasStartedTours
-            ? tourModels
-                .where((m) => m.roundStatus != RoundStatus.upcoming)
-                .toList()
-            : tourModels;
-
-    if (selectableModels.isNotEmpty) {
-      final toursWithDates =
-          selectableModels.where((m) => m.tour.dates.isNotEmpty).toList();
-
-      if (toursWithDates.isNotEmpty) {
-        // Check if all tours share the same start date
-        final firstStart = toursWithDates.first.tour.dates.first;
-        final allSameStart = toursWithDates.every(
-          (m) =>
-              m.tour.dates.first.year == firstStart.year &&
-              m.tour.dates.first.month == firstStart.month &&
-              m.tour.dates.first.day == firstStart.day,
-        );
-
-        if (allSameStart) {
-          // Same start → pick highest avgElo
-          final withElo =
-              toursWithDates.where((m) => m.tour.avgElo != null).toList();
-          if (withElo.isNotEmpty) {
-            withElo.sort(
-              (a, b) => b.tour.avgElo!.compareTo(a.tour.avgElo!),
-            );
-            return withElo.first.tour;
-          }
-        } else {
-          // Different start times → pick latest starting event, tiebreak by avgElo
-          toursWithDates.sort((a, b) {
-            final dateCompare =
-                b.tour.dates.first.compareTo(a.tour.dates.first);
-            if (dateCompare != 0) return dateCompare;
-            final aElo = a.tour.avgElo ?? 0;
-            final bElo = b.tour.avgElo ?? 0;
-            return bElo.compareTo(aElo);
-          });
-          return toursWithDates.first.tour;
-        }
-      }
-
-      // Fallback when date-based selection didn't apply: pick highest avgElo from selectableModels
-      final withElo =
-          selectableModels.where((m) => m.tour.avgElo != null).toList();
-      if (withElo.isNotEmpty) {
-        withElo.sort((a, b) => b.tour.avgElo!.compareTo(a.tour.avgElo!));
-        return withElo.first.tour;
-      }
-    }
-
-    // 5️⃣ Fallback — choose by actual game activity across all tours.
-    // This avoids opening future categories with no played games.
+    String? activityTourId;
     try {
-      final activityTourId = await ref
+      activityTourId = await ref
           .read(gameRepositoryProvider)
           .getMostRelevantTourId(
             tourIds: tourModels.map((m) => m.tour.id).toList(),
           );
-      if (activityTourId != null) {
-        final activityModel = findTourModel(tourModels, activityTourId);
-        if (activityModel != null && canUseSelection(activityModel)) {
-          return activityModel.tour;
-        }
-      }
     } catch (_) {}
 
-    // 6️⃣ If no ELO signal, prefer started tours (ongoing first, then completed).
-    final ongoingTours =
-        tourModels
-            .where((model) => model.roundStatus == RoundStatus.ongoing)
-            .toList()
-          ..sort((a, b) {
-            final aDate =
-                a.tour.dates.isNotEmpty ? a.tour.dates.first : DateTime(1970);
-            final bDate =
-                b.tour.dates.isNotEmpty ? b.tour.dates.first : DateTime(1970);
-            return bDate.compareTo(aDate);
-          });
-    if (ongoingTours.isNotEmpty) {
-      return ongoingTours.first.tour;
-    }
-
-    final completedTours =
-        tourModels
-            .where((model) => model.roundStatus == RoundStatus.completed)
-            .toList()
-          ..sort((a, b) {
-            // Handle tours with empty dates (use epoch as fallback)
-            final aDate =
-                a.tour.dates.isNotEmpty ? a.tour.dates.last : DateTime(1970);
-            final bDate =
-                b.tour.dates.isNotEmpty ? b.tour.dates.last : DateTime(1970);
-            return bDate.compareTo(aDate);
-          });
-
-    if (completedTours.isNotEmpty) {
-      return completedTours.first.tour;
-    }
-
-    // 7️⃣ If everything is upcoming, prefer the nearest one.
-    final upcomingTours =
-        tourModels
-            .where((model) => model.roundStatus == RoundStatus.upcoming)
-            .toList()
-          ..sort((a, b) {
-            final aDate =
-                a.tour.dates.isNotEmpty ? a.tour.dates.first : DateTime(1970);
-            final bDate =
-                b.tour.dates.isNotEmpty ? b.tour.dates.first : DateTime(1970);
-            return aDate.compareTo(bDate);
-          });
-    if (upcomingTours.isNotEmpty) {
-      return upcomingTours.first.tour;
-    }
-
-    // 8️⃣ Fallback: first tour
-    return tourModels.first.tour;
+    return selectDefaultTour(
+      tourModels: tourModels,
+      liveTourIds: liveTourIds,
+      currentSelectedId: currentSelectedId,
+      savedTourId: savedTourId,
+      activityTourId: activityTourId,
+    );
   }
 
   @override
@@ -530,7 +375,11 @@ class _TourDetailScreenNotifier
 
   @override
   TourModel? findTourModel(List<TourModel> tourModels, String tourId) {
-    return tourModels.where((model) => model.tour.id == tourId).firstOrNull;
+    final tour = findTourById(tourModels, tourId);
+    if (tour == null) {
+      return null;
+    }
+    return tourModels.where((model) => model.tour.id == tour.id).firstOrNull;
   }
 
   @override

--- a/lib/screens/tour_detail/provider/tour_selection_logic.dart
+++ b/lib/screens/tour_detail/provider/tour_selection_logic.dart
@@ -1,0 +1,193 @@
+import 'package:chessever2/repository/supabase/tour/tour.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
+
+RoundStatus calculateTourRoundStatus({
+  required String tourId,
+  required DateTime now,
+  required DateTime startDate,
+  required DateTime endDate,
+  required List<String> liveTourIds,
+}) {
+  if (now.isBefore(startDate)) {
+    return RoundStatus.upcoming;
+  } else if (now.isAfter(endDate)) {
+    return RoundStatus.completed;
+  } else if (liveTourIds.contains(tourId)) {
+    return RoundStatus.live;
+  } else {
+    return RoundStatus.ongoing;
+  }
+}
+
+Tour? findTourById(List<TourModel> tourModels, String? tourId) {
+  if (tourId == null || tourId.isEmpty) {
+    return null;
+  }
+
+  for (final tourModel in tourModels) {
+    if (tourModel.tour.id == tourId) {
+      return tourModel.tour;
+    }
+  }
+
+  return null;
+}
+
+Tour selectDefaultTour({
+  required List<TourModel> tourModels,
+  required List<String> liveTourIds,
+  String? currentSelectedId,
+  String? savedTourId,
+  String? activityTourId,
+}) {
+  final hasStartedTours = tourModels.any(
+    (model) => model.roundStatus != RoundStatus.upcoming,
+  );
+
+  bool canUseSelection(TourModel model) {
+    if (!hasStartedTours) {
+      return true;
+    }
+    return model.roundStatus != RoundStatus.upcoming;
+  }
+
+  Tour? findSelectableTour(String? tourId) {
+    if (tourId == null || tourId.isEmpty) {
+      return null;
+    }
+
+    for (final model in tourModels) {
+      if (model.tour.id == tourId && canUseSelection(model)) {
+        return model.tour;
+      }
+    }
+
+    return null;
+  }
+
+  final currentTour = findSelectableTour(currentSelectedId);
+  if (currentTour != null) {
+    return currentTour;
+  }
+
+  final savedTour = findSelectableTour(savedTourId);
+  if (savedTour != null) {
+    return savedTour;
+  }
+
+  final liveModels =
+      tourModels
+          .where((model) => model.roundStatus == RoundStatus.live)
+          .toList()
+        ..sort((a, b) {
+          final aDate =
+              a.tour.dates.isNotEmpty ? a.tour.dates.first : DateTime(1970);
+          final bDate =
+              b.tour.dates.isNotEmpty ? b.tour.dates.first : DateTime(1970);
+          return bDate.compareTo(aDate);
+        });
+  if (liveModels.isNotEmpty) {
+    return liveModels.first.tour;
+  }
+
+  final selectableModels =
+      hasStartedTours
+          ? tourModels
+              .where((model) => model.roundStatus != RoundStatus.upcoming)
+              .toList()
+          : List<TourModel>.from(tourModels);
+
+  if (selectableModels.isNotEmpty) {
+    final toursWithDates =
+        selectableModels.where((model) => model.tour.dates.isNotEmpty).toList();
+
+    if (toursWithDates.isNotEmpty) {
+      final firstStart = toursWithDates.first.tour.dates.first;
+      final allSameStart = toursWithDates.every(
+        (model) =>
+            model.tour.dates.first.year == firstStart.year &&
+            model.tour.dates.first.month == firstStart.month &&
+            model.tour.dates.first.day == firstStart.day,
+      );
+
+      if (allSameStart) {
+        final withElo =
+            toursWithDates.where((model) => model.tour.avgElo != null).toList()
+              ..sort((a, b) => b.tour.avgElo!.compareTo(a.tour.avgElo!));
+        if (withElo.isNotEmpty) {
+          return withElo.first.tour;
+        }
+      } else {
+        toursWithDates.sort((a, b) {
+          final dateCompare = b.tour.dates.first.compareTo(a.tour.dates.first);
+          if (dateCompare != 0) {
+            return dateCompare;
+          }
+          final aElo = a.tour.avgElo ?? 0;
+          final bElo = b.tour.avgElo ?? 0;
+          return bElo.compareTo(aElo);
+        });
+        return toursWithDates.first.tour;
+      }
+    }
+
+    final withElo =
+        selectableModels.where((model) => model.tour.avgElo != null).toList()
+          ..sort((a, b) => b.tour.avgElo!.compareTo(a.tour.avgElo!));
+    if (withElo.isNotEmpty) {
+      return withElo.first.tour;
+    }
+  }
+
+  final activityTour = findSelectableTour(activityTourId);
+  if (activityTour != null) {
+    return activityTour;
+  }
+
+  final ongoingTours =
+      tourModels
+          .where((model) => model.roundStatus == RoundStatus.ongoing)
+          .toList()
+        ..sort((a, b) {
+          final aDate =
+              a.tour.dates.isNotEmpty ? a.tour.dates.first : DateTime(1970);
+          final bDate =
+              b.tour.dates.isNotEmpty ? b.tour.dates.first : DateTime(1970);
+          return bDate.compareTo(aDate);
+        });
+  if (ongoingTours.isNotEmpty) {
+    return ongoingTours.first.tour;
+  }
+
+  final completedTours =
+      tourModels
+          .where((model) => model.roundStatus == RoundStatus.completed)
+          .toList()
+        ..sort((a, b) {
+          final aDate =
+              a.tour.dates.isNotEmpty ? a.tour.dates.last : DateTime(1970);
+          final bDate =
+              b.tour.dates.isNotEmpty ? b.tour.dates.last : DateTime(1970);
+          return bDate.compareTo(aDate);
+        });
+  if (completedTours.isNotEmpty) {
+    return completedTours.first.tour;
+  }
+
+  final upcomingTours =
+      tourModels
+          .where((model) => model.roundStatus == RoundStatus.upcoming)
+          .toList()
+        ..sort((a, b) {
+          final aDate =
+              a.tour.dates.isNotEmpty ? a.tour.dates.first : DateTime(1970);
+          final bDate =
+              b.tour.dates.isNotEmpty ? b.tour.dates.first : DateTime(1970);
+          return aDate.compareTo(bDate);
+        });
+  if (upcomingTours.isNotEmpty) {
+    return upcomingTours.first.tour;
+  }
+
+  return tourModels.first.tour;
+}

--- a/test/for_you_event_selection_test.dart
+++ b/test/for_you_event_selection_test.dart
@@ -1,393 +1,766 @@
-import 'package:chessever2/providers/for_you_games_provider.dart';
+import 'package:chessever2/providers/for_you_games_logic.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/repository/supabase/round/round.dart';
+import 'package:chessever2/repository/supabase/tour/tour.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_selection_logic.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Helper to create a minimal [Games] object for testing.
+TournamentPlayer _tourPlayer({required String name, String? team}) {
+  return TournamentPlayer(name: name, played: 0, team: team);
+}
+
+Tour _makeTour({
+  required String id,
+  required String name,
+  required List<DateTime> dates,
+  String? groupBroadcastId = 'event-1',
+  int? avgElo = 2700,
+  String? format = 'Swiss',
+  List<TournamentPlayer> players = const [],
+}) {
+  return Tour.fromJson({
+    'id': id,
+    'name': name,
+    'slug': id,
+    'info': {
+      'format': format,
+      'tc': '90+30',
+      'players': '',
+      'location': 'Test City',
+    },
+    'created_at': DateTime(2025, 1, 1, 12).toIso8601String(),
+    'url': 'https://example.com/$id',
+    'tier': 1,
+    'dates': dates.map((date) => date.toIso8601String()).toList(),
+    'players': players.map((player) => player.toJson()).toList(),
+    'search': const <String>[],
+    'group_broadcast_id': groupBroadcastId,
+    'avg_elo': avgElo,
+  });
+}
+
+Round _makeRound({
+  required String id,
+  required String tourId,
+  required String name,
+  required DateTime startsAt,
+}) {
+  return Round(
+    id: id,
+    slug: id,
+    tourId: tourId,
+    tourSlug: tourId,
+    name: name,
+    createdAt: startsAt.subtract(const Duration(hours: 1)),
+    startsAt: startsAt,
+    url: 'https://example.com/$id',
+  );
+}
+
+Player _player({required String name, String team = '', int fideId = 1}) {
+  return Player(
+    name: name,
+    title: 'GM',
+    rating: 2700,
+    fideId: fideId,
+    fed: 'USA',
+    clock: 0,
+    team: team,
+  );
+}
+
 Games _makeGame({
   required String id,
   required String roundId,
-  String roundSlug = 'round-1',
-  String tourId = 'tour-1',
-  String tourSlug = 'tour-slug',
-  String? lastMove = 'e2e4',
-  DateTime? lastMoveTime,
-  DateTime? gameDay,
-  DateTime? dateStart,
-  String status = '*',
+  required String roundSlug,
+  required String tourId,
+  required List<Player> players,
   int? boardNr,
-  List<Player>? players,
+  String? status = '*',
+  DateTime? lastMoveTime,
 }) {
   return Games(
     id: id,
     roundId: roundId,
     roundSlug: roundSlug,
     tourId: tourId,
-    tourSlug: tourSlug,
-    lastMove: lastMove,
-    lastMoveTime: lastMoveTime,
-    gameDay: gameDay,
-    dateStart: dateStart,
-    status: status,
+    tourSlug: tourId,
+    players: players,
     boardNr: boardNr,
-    players:
-        players ??
-        [
-          Player(
-            name: 'White $id',
-            title: 'GM',
-            rating: 2700,
-            fideId: 1,
-            fed: 'USA',
-            clock: 0,
-            team: '',
-          ),
-          Player(
-            name: 'Black $id',
-            title: 'GM',
-            rating: 2700,
-            fideId: 2,
-            fed: 'USA',
-            clock: 0,
-            team: '',
-          ),
-        ],
+    status: status,
+    lastMove: 'e2e4',
+    lastMoveTime: lastMoveTime,
   );
 }
 
 void main() {
-  group('selectForYouEventGames', () {
-    test(
-      'latest round has 4+ started games — returns exactly 4 from that round',
-      () {
-        final now = DateTime(2025, 6, 1, 12, 0);
-        final games = List.generate(
-          6,
-          (i) => _makeGame(
-            id: 'game-$i',
-            roundId: 'round-5',
-            roundSlug: 'round-5',
-            lastMoveTime: now,
-            boardNr: i + 1,
-          ),
-        );
+  group('selectDefaultTour', () {
+    test('reuses saved valid selection', () {
+      final now = DateTime.now();
+      final tourA = _makeTour(
+        id: 'tour-a',
+        name: 'Open',
+        dates: [now.subtract(const Duration(days: 1)), now],
+      );
+      final tourB = _makeTour(
+        id: 'tour-b',
+        name: 'Challengers',
+        dates: [now.subtract(const Duration(days: 1)), now],
+        avgElo: 2600,
+      );
 
-        final result = selectForYouEventGames(
-          allStartedGames: games,
-          pinnedIds: [],
-          formatStrings: ['9-round Swiss'],
-        );
+      final selected = selectDefaultTour(
+        tourModels: [
+          TourModel(tour: tourA, roundStatus: RoundStatus.ongoing),
+          TourModel(tour: tourB, roundStatus: RoundStatus.ongoing),
+        ],
+        liveTourIds: const [],
+        savedTourId: 'tour-b',
+      );
 
-        expect(result.length, 4);
-        expect(result.every((g) => g.roundId == 'round-5'), isTrue);
-      },
-    );
+      expect(selected.id, 'tour-b');
+    });
 
-    test('latest round has 2 games — fills from older rounds', () {
-      final now = DateTime(2025, 6, 1, 12, 0);
-      final older = now.subtract(const Duration(hours: 2));
+    test('ignores upcoming saved selection when a started tour exists', () {
+      final now = DateTime.now();
+      final liveTour = _makeTour(
+        id: 'tour-live',
+        name: 'Live Section',
+        dates: [now.subtract(const Duration(hours: 2)), now],
+      );
+      final upcomingTour = _makeTour(
+        id: 'tour-upcoming',
+        name: 'Future Section',
+        dates: [
+          now.add(const Duration(days: 1)),
+          now.add(const Duration(days: 2)),
+        ],
+      );
 
+      final selected = selectDefaultTour(
+        tourModels: [
+          TourModel(tour: liveTour, roundStatus: RoundStatus.live),
+          TourModel(tour: upcomingTour, roundStatus: RoundStatus.upcoming),
+        ],
+        liveTourIds: const ['tour-live'],
+        savedTourId: 'tour-upcoming',
+      );
+
+      expect(selected.id, 'tour-live');
+    });
+
+    test('falls back to activity tour when other signals are absent', () {
+      final now = DateTime.now();
+      final tourA = _makeTour(
+        id: 'tour-a',
+        name: 'Older',
+        dates: [
+          now.subtract(const Duration(days: 4)),
+          now.subtract(const Duration(days: 3)),
+        ],
+        avgElo: null,
+      );
+      final tourB = _makeTour(
+        id: 'tour-b',
+        name: 'Recent Activity',
+        dates: [
+          now.subtract(const Duration(days: 4)),
+          now.subtract(const Duration(days: 3)),
+        ],
+        avgElo: null,
+      );
+
+      final selected = selectDefaultTour(
+        tourModels: [
+          TourModel(tour: tourA, roundStatus: RoundStatus.completed),
+          TourModel(tour: tourB, roundStatus: RoundStatus.completed),
+        ],
+        liveTourIds: const [],
+        activityTourId: 'tour-b',
+      );
+
+      expect(selected.id, 'tour-b');
+    });
+  });
+
+  group('buildForYouEventGamesSnapshot', () {
+    test('regular event returns Games-tab visible order', () {
+      final now = DateTime.now();
+      final tour = _makeTour(
+        id: 'tour-1',
+        name: 'Masters',
+        dates: [now.subtract(const Duration(days: 1)), now],
+      );
+      final rounds = [
+        _makeRound(
+          id: 'round-2',
+          tourId: 'tour-1',
+          name: 'Round 2',
+          startsAt: now.subtract(const Duration(hours: 2)),
+        ),
+        _makeRound(
+          id: 'round-1',
+          tourId: 'tour-1',
+          name: 'Round 1',
+          startsAt: now.subtract(const Duration(days: 1)),
+        ),
+      ];
       final games = [
-        // 2 games in latest round
         _makeGame(
           id: 'g1',
-          roundId: 'r2',
+          roundId: 'round-2',
           roundSlug: 'round-2',
-          lastMoveTime: now,
+          tourId: 'tour-1',
           boardNr: 1,
+          lastMoveTime: now,
+          players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
         ),
         _makeGame(
           id: 'g2',
-          roundId: 'r2',
+          roundId: 'round-2',
           roundSlug: 'round-2',
-          lastMoveTime: now,
+          tourId: 'tour-1',
           boardNr: 2,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'C', fideId: 3),
+            _player(name: 'D', fideId: 4),
+          ],
         ),
-        // 3 games in older round
         _makeGame(
           id: 'g3',
-          roundId: 'r1',
+          roundId: 'round-1',
           roundSlug: 'round-1',
-          lastMoveTime: older,
+          tourId: 'tour-1',
           boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(hours: 5)),
+          players: [
+            _player(name: 'E', fideId: 5),
+            _player(name: 'F', fideId: 6),
+          ],
         ),
         _makeGame(
           id: 'g4',
-          roundId: 'r1',
+          roundId: 'round-1',
           roundSlug: 'round-1',
-          lastMoveTime: older,
+          tourId: 'tour-1',
           boardNr: 2,
+          lastMoveTime: now.subtract(const Duration(hours: 5)),
+          players: [
+            _player(name: 'G', fideId: 7),
+            _player(name: 'H', fideId: 8),
+          ],
         ),
         _makeGame(
           id: 'g5',
-          roundId: 'r1',
+          roundId: 'round-1',
           roundSlug: 'round-1',
-          lastMoveTime: older,
+          tourId: 'tour-1',
           boardNr: 3,
+          lastMoveTime: now.subtract(const Duration(hours: 5)),
+          players: [
+            _player(name: 'I', fideId: 9),
+            _player(name: 'J', fideId: 10),
+          ],
         ),
       ];
 
-      final result = selectForYouEventGames(
-        allStartedGames: games,
-        pinnedIds: [],
-        formatStrings: ['9-round Swiss'],
+      final snapshot = buildForYouEventGamesSnapshot(
+        eventId: 'event-1',
+        selectedTour: tour,
+        eventTours: [tour],
+        selectedTourRounds: rounds,
+        roundsByTourId: {'tour-1': rounds},
+        selectedTourGames: games,
+        gamesByTourId: {'tour-1': games},
+        liveRoundIds: const [],
+        pinnedIds: const [],
       );
 
-      expect(result.length, 4);
-      // First 2 from latest round
-      expect(result[0].roundId, 'r2');
-      expect(result[1].roundId, 'r2');
-      // Next 2 filled from older round
-      expect(result[2].roundId, 'r1');
-      expect(result[3].roundId, 'r1');
+      expect(snapshot.visibleGames.map((game) => game.gameId).take(4), [
+        'g1',
+        'g2',
+        'g3',
+        'g4',
+      ]);
     });
 
-    test('multi-tour event: games from different tours fill to 4', () {
-      final now = DateTime(2025, 6, 1, 12, 0);
-
-      final games = [
-        // Tour A, round 3 (latest)
-        _makeGame(
-          id: 'a1',
-          roundId: 'r3a',
-          roundSlug: 'round-3',
-          tourId: 'tour-a',
-          lastMoveTime: now,
-          boardNr: 1,
-        ),
-        _makeGame(
-          id: 'a2',
-          roundId: 'r3a',
-          roundSlug: 'round-3',
-          tourId: 'tour-a',
-          lastMoveTime: now,
-          boardNr: 2,
-        ),
-        // Tour B, round 2 (slightly older)
-        _makeGame(
-          id: 'b1',
-          roundId: 'r2b',
-          roundSlug: 'round-2',
-          tourId: 'tour-b',
-          lastMoveTime: now.subtract(const Duration(minutes: 30)),
-          boardNr: 1,
-        ),
-        _makeGame(
-          id: 'b2',
-          roundId: 'r2b',
-          roundSlug: 'round-2',
-          tourId: 'tour-b',
-          lastMoveTime: now.subtract(const Duration(minutes: 30)),
-          boardNr: 2,
-        ),
-      ];
-
-      final result = selectForYouEventGames(
-        allStartedGames: games,
-        pinnedIds: [],
-        formatStrings: ['9-round Swiss', '6-round Swiss'],
-      );
-
-      expect(result.length, 4);
-      // Primary round from tour A first
-      expect(result.where((g) => g.tourId == 'tour-a').length, 2);
-      // Filled from tour B
-      expect(result.where((g) => g.tourId == 'tour-b').length, 2);
-    });
-
-    test('null-timestamp rounds remain eligible for backfill', () {
-      final now = DateTime(2025, 6, 1, 12, 0);
-
-      final games = [
-        _makeGame(
-          id: 'recent-1',
-          roundId: 'r2',
-          roundSlug: 'round-2',
-          lastMoveTime: now,
-          boardNr: 1,
-        ),
-        _makeGame(
-          id: 'recent-2',
-          roundId: 'r2',
-          roundSlug: 'round-2',
-          lastMoveTime: now,
-          boardNr: 2,
-        ),
-        _makeGame(
-          id: 'unknown-1',
-          roundId: 'r1',
-          roundSlug: 'round-1',
-          lastMoveTime: null,
-          gameDay: null,
-          dateStart: null,
-          boardNr: 1,
-        ),
-        _makeGame(
-          id: 'unknown-2',
-          roundId: 'r1',
-          roundSlug: 'round-1',
-          lastMoveTime: null,
-          gameDay: null,
-          dateStart: null,
-          boardNr: 2,
-        ),
-      ];
-
-      final result = selectForYouEventGames(
-        allStartedGames: games,
-        pinnedIds: [],
-        formatStrings: ['9-round Swiss'],
-      );
-
-      expect(result.length, 4);
-      expect(result[0].roundId, 'r2');
-      expect(result[1].roundId, 'r2');
-      expect(result[2].roundId, 'r1');
-      expect(result[3].roundId, 'r1');
-    });
-
-    test('match format: returns latest 4 across entire match', () {
-      final now = DateTime(2025, 6, 1, 12, 0);
-      final matchPlayers = [
-        Player(
-          name: 'Carlsen',
-          title: 'GM',
-          rating: 2830,
-          fideId: 1,
-          fed: 'NOR',
-          clock: 0,
-          team: '',
-        ),
-        Player(
-          name: 'Nepo',
-          title: 'GM',
-          rating: 2790,
-          fideId: 2,
-          fed: 'RUS',
-          clock: 0,
-          team: '',
-        ),
-      ];
-
-      // 6 games across 6 different rounds (game-1 through game-6)
-      final games = List.generate(
-        6,
-        (i) => _makeGame(
-          id: 'match-$i',
-          roundId: 'game-${i + 1}',
-          roundSlug: 'game-${i + 1}',
-          lastMoveTime: now.subtract(Duration(days: 5 - i)),
-          players: matchPlayers,
-          status: i < 5 ? '1/2-1/2' : '*',
-        ),
-      );
-
-      final result = selectForYouEventGames(
-        allStartedGames: games,
-        pinnedIds: [],
-        formatStrings: ['12-game Match'],
-      );
-
-      expect(result.length, 4);
-      // Should not be restricted to a single round
-      final roundIds = result.map((g) => g.roundId).toSet();
-      expect(roundIds.length, greaterThan(1));
-    });
-
-    test('event with fewer than 4 started games returns only available', () {
-      final now = DateTime(2025, 6, 1, 12, 0);
-
-      // 0 games
-      expect(
-        selectForYouEventGames(
-          allStartedGames: [],
-          pinnedIds: [],
-          formatStrings: [],
-        ),
-        isEmpty,
-      );
-
-      // 1 game
-      final result1 = selectForYouEventGames(
-        allStartedGames: [
-          _makeGame(id: 'g1', roundId: 'r1', lastMoveTime: now),
+    test('group event flattens matchup cards without round headers', () {
+      final now = DateTime.now();
+      final tour = _makeTour(
+        id: 'team-tour',
+        name: 'Team Championship',
+        dates: [now.subtract(const Duration(days: 1)), now],
+        players: [
+          _tourPlayer(name: 'A1', team: 'Team A'),
+          _tourPlayer(name: 'B1', team: 'Team B'),
         ],
-        pinnedIds: [],
-        formatStrings: ['Swiss'],
       );
-      expect(result1.length, 1);
-
-      // 3 games
-      final result3 = selectForYouEventGames(
-        allStartedGames: List.generate(
-          3,
-          (i) => _makeGame(
-            id: 'g-$i',
-            roundId: 'r1',
-            roundSlug: 'round-1',
-            lastMoveTime: now,
-            boardNr: i,
-          ),
+      final rounds = [
+        _makeRound(
+          id: 'round-1',
+          tourId: 'team-tour',
+          name: 'Round 1',
+          startsAt: now.subtract(const Duration(hours: 2)),
         ),
-        pinnedIds: [],
-        formatStrings: ['Swiss'],
-      );
-      expect(result3.length, 3);
-    });
-
-    test('pinned game from non-primary round gets priority', () {
-      final now = DateTime(2025, 6, 1, 12, 0);
-      final older = now.subtract(const Duration(hours: 2));
-
+      ];
       final games = [
-        // 3 games in latest round
         _makeGame(
-          id: 'new1',
-          roundId: 'r2',
-          roundSlug: 'round-2',
-          lastMoveTime: now,
+          id: 'match-a-1',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'team-tour',
           boardNr: 1,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'A1', team: 'Team A', fideId: 1),
+            _player(name: 'B1', team: 'Team B', fideId: 2),
+          ],
         ),
         _makeGame(
-          id: 'new2',
-          roundId: 'r2',
-          roundSlug: 'round-2',
-          lastMoveTime: now,
+          id: 'match-c-1',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'team-tour',
           boardNr: 2,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'C1', team: 'Team C', fideId: 3),
+            _player(name: 'D1', team: 'Team D', fideId: 4),
+          ],
         ),
         _makeGame(
-          id: 'new3',
-          roundId: 'r2',
-          roundSlug: 'round-2',
-          lastMoveTime: now,
+          id: 'match-a-2',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'team-tour',
           boardNr: 3,
-        ),
-        // 2 games in older round, one is pinned
-        _makeGame(
-          id: 'old-pinned',
-          roundId: 'r1',
-          roundSlug: 'round-1',
-          lastMoveTime: older,
-          boardNr: 1,
-        ),
-        _makeGame(
-          id: 'old2',
-          roundId: 'r1',
-          roundSlug: 'round-1',
-          lastMoveTime: older,
-          boardNr: 2,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'A2', team: 'Team A', fideId: 5),
+            _player(name: 'B2', team: 'Team B', fideId: 6),
+          ],
         ),
       ];
 
-      final result = selectForYouEventGames(
-        allStartedGames: games,
-        pinnedIds: ['old-pinned'],
-        formatStrings: ['9-round Swiss'],
+      final snapshot = buildForYouEventGamesSnapshot(
+        eventId: 'event-1',
+        selectedTour: tour,
+        eventTours: [tour],
+        selectedTourRounds: rounds,
+        roundsByTourId: {'team-tour': rounds},
+        selectedTourGames: games,
+        gamesByTourId: {'team-tour': games},
+        liveRoundIds: const [],
+        pinnedIds: const [],
       );
 
-      expect(result.length, 4);
-      // Primary round (r2) contributes 3 games; the pinned game from r1 fills
-      // the 4th slot. The pinned game should be present in the result.
-      expect(result.any((g) => g.id == 'old-pinned'), isTrue);
+      expect(snapshot.visibleGames.map((game) => game.gameId), [
+        'match-a-1',
+        'match-a-2',
+        'match-c-1',
+      ]);
+    });
+
+    test('group event keeps matchup grouping when team name contains vs', () {
+      final now = DateTime.now();
+      final tour = _makeTour(
+        id: 'team-tour',
+        name: 'Team Championship',
+        dates: [now.subtract(const Duration(days: 1)), now],
+        players: [
+          _tourPlayer(name: 'P1', team: 'Team vs Shadows'),
+          _tourPlayer(name: 'P2', team: 'Rivals Club'),
+        ],
+      );
+      final rounds = [
+        _makeRound(
+          id: 'round-1',
+          tourId: 'team-tour',
+          name: 'Round 1',
+          startsAt: now.subtract(const Duration(hours: 2)),
+        ),
+      ];
+      final games = [
+        _makeGame(
+          id: 'match-1-board-1',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'team-tour',
+          boardNr: 1,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'A1', team: 'Team vs Shadows', fideId: 1),
+            _player(name: 'B1', team: 'Rivals Club', fideId: 2),
+          ],
+        ),
+        _makeGame(
+          id: 'other-match',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'team-tour',
+          boardNr: 2,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'C1', team: 'Knights', fideId: 3),
+            _player(name: 'D1', team: 'Bishops', fideId: 4),
+          ],
+        ),
+        _makeGame(
+          id: 'match-1-board-2',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'team-tour',
+          boardNr: 3,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'B2', team: 'Rivals Club', fideId: 5),
+            _player(name: 'A2', team: 'Team vs Shadows', fideId: 6),
+          ],
+        ),
+      ];
+
+      final snapshot = buildForYouEventGamesSnapshot(
+        eventId: 'event-1',
+        selectedTour: tour,
+        eventTours: [tour],
+        selectedTourRounds: rounds,
+        roundsByTourId: {'team-tour': rounds},
+        selectedTourGames: games,
+        gamesByTourId: {'team-tour': games},
+        liveRoundIds: const [],
+        pinnedIds: const [],
+      );
+
+      expect(snapshot.visibleGames.map((game) => game.gameId), [
+        'match-1-board-1',
+        'match-1-board-2',
+        'other-match',
+      ]);
+    });
+
+    test('multi-stage knockout includes sibling stages in Games-tab order', () {
+      final now = DateTime.now();
+      final stage1 = _makeTour(
+        id: 'stage-1',
+        name: 'World Cup | Round 1',
+        dates: [
+          now.subtract(const Duration(days: 2)),
+          now.subtract(const Duration(days: 1)),
+        ],
+        format: 'Knockout',
+      );
+      final stage2 = _makeTour(
+        id: 'stage-2',
+        name: 'World Cup | Round 2',
+        dates: [now.subtract(const Duration(hours: 8)), now],
+        format: 'Knockout',
+      );
+      final stage1Rounds = [
+        _makeRound(
+          id: 'stage-1-round',
+          tourId: 'stage-1',
+          name: 'Stage 1',
+          startsAt: now.subtract(const Duration(days: 2)),
+        ),
+      ];
+      final stage2Rounds = [
+        _makeRound(
+          id: 'stage-2-round',
+          tourId: 'stage-2',
+          name: 'Stage 2',
+          startsAt: now.subtract(const Duration(hours: 8)),
+        ),
+      ];
+      final stage1Games = [
+        _makeGame(
+          id: 's1-g1',
+          roundId: 'stage-1-round',
+          roundSlug: 'game-1',
+          tourId: 'stage-1',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(days: 1)),
+          players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
+        ),
+        _makeGame(
+          id: 's1-g2',
+          roundId: 'stage-1-round',
+          roundSlug: 'game-2',
+          tourId: 'stage-1',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(days: 1)),
+          players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
+        ),
+      ];
+      final stage2Games = [
+        _makeGame(
+          id: 's2-g1',
+          roundId: 'stage-2-round',
+          roundSlug: 'game-1',
+          tourId: 'stage-2',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(hours: 2)),
+          players: [
+            _player(name: 'C', fideId: 3),
+            _player(name: 'D', fideId: 4),
+          ],
+        ),
+        _makeGame(
+          id: 's2-g2',
+          roundId: 'stage-2-round',
+          roundSlug: 'game-2',
+          tourId: 'stage-2',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(hours: 1)),
+          players: [
+            _player(name: 'C', fideId: 3),
+            _player(name: 'D', fideId: 4),
+          ],
+        ),
+      ];
+
+      final snapshot = buildForYouEventGamesSnapshot(
+        eventId: 'event-1',
+        selectedTour: stage2,
+        eventTours: [stage1, stage2],
+        selectedTourRounds: stage2Rounds,
+        roundsByTourId: {'stage-1': stage1Rounds, 'stage-2': stage2Rounds},
+        selectedTourGames: stage2Games,
+        gamesByTourId: {'stage-1': stage1Games, 'stage-2': stage2Games},
+        liveRoundIds: const [],
+        pinnedIds: const [],
+      );
+
+      expect(snapshot.visibleGames.map((game) => game.gameId).take(4), [
+        's2-g1',
+        's2-g2',
+        's1-g1',
+        's1-g2',
+      ]);
+    });
+
+    test('multi-stage knockout keeps sibling-stage pins in snapshot', () {
+      final now = DateTime.now();
+      final stage1 = _makeTour(
+        id: 'stage-1',
+        name: 'World Cup | Round 1',
+        dates: [
+          now.subtract(const Duration(days: 2)),
+          now.subtract(const Duration(days: 1)),
+        ],
+        format: 'Knockout',
+      );
+      final stage2 = _makeTour(
+        id: 'stage-2',
+        name: 'World Cup | Round 2',
+        dates: [now.subtract(const Duration(hours: 8)), now],
+        format: 'Knockout',
+      );
+      final stage1Rounds = [
+        _makeRound(
+          id: 'stage-1-round',
+          tourId: 'stage-1',
+          name: 'Stage 1',
+          startsAt: now.subtract(const Duration(days: 2)),
+        ),
+      ];
+      final stage2Rounds = [
+        _makeRound(
+          id: 'stage-2-round',
+          tourId: 'stage-2',
+          name: 'Stage 2',
+          startsAt: now.subtract(const Duration(hours: 8)),
+        ),
+      ];
+      final stage1Games = [
+        _makeGame(
+          id: 's1-g1',
+          roundId: 'stage-1-round',
+          roundSlug: 'game-1',
+          tourId: 'stage-1',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(days: 1)),
+          players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
+        ),
+        _makeGame(
+          id: 's1-g2',
+          roundId: 'stage-1-round',
+          roundSlug: 'game-2',
+          tourId: 'stage-1',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(days: 1)),
+          players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
+        ),
+      ];
+      final stage2Games = [
+        _makeGame(
+          id: 's2-g1',
+          roundId: 'stage-2-round',
+          roundSlug: 'game-1',
+          tourId: 'stage-2',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(hours: 2)),
+          players: [
+            _player(name: 'C', fideId: 3),
+            _player(name: 'D', fideId: 4),
+          ],
+        ),
+        _makeGame(
+          id: 's2-g2',
+          roundId: 'stage-2-round',
+          roundSlug: 'game-2',
+          tourId: 'stage-2',
+          boardNr: 1,
+          lastMoveTime: now.subtract(const Duration(hours: 1)),
+          players: [
+            _player(name: 'C', fideId: 3),
+            _player(name: 'D', fideId: 4),
+          ],
+        ),
+      ];
+
+      final snapshot = buildForYouEventGamesSnapshot(
+        eventId: 'event-1',
+        selectedTour: stage2,
+        eventTours: [stage1, stage2],
+        selectedTourRounds: stage2Rounds,
+        roundsByTourId: {'stage-1': stage1Rounds, 'stage-2': stage2Rounds},
+        selectedTourGames: stage2Games,
+        gamesByTourId: {'stage-1': stage1Games, 'stage-2': stage2Games},
+        liveRoundIds: const [],
+        pinnedIds: const ['s1-g2'],
+      );
+
+      expect(snapshot.pinnedIds, ['s1-g2']);
+      expect(
+        snapshot.visibleGames.map((game) => game.gameId).take(4),
+        containsAll(['s2-g1', 's2-g2', 's1-g1', 's1-g2']),
+      );
+    });
+
+    test(
+      'pins are applied with Games-tab priority inside the selected tour',
+      () {
+        final now = DateTime.now();
+        final tour = _makeTour(
+          id: 'tour-1',
+          name: 'Pinned Event',
+          dates: [now.subtract(const Duration(days: 1)), now],
+        );
+        final rounds = [
+          _makeRound(
+            id: 'round-1',
+            tourId: 'tour-1',
+            name: 'Round 1',
+            startsAt: now.subtract(const Duration(hours: 2)),
+          ),
+        ];
+        final games = [
+          _makeGame(
+            id: 'g1',
+            roundId: 'round-1',
+            roundSlug: 'round-1',
+            tourId: 'tour-1',
+            boardNr: 1,
+            lastMoveTime: now,
+            players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
+          ),
+          _makeGame(
+            id: 'g2',
+            roundId: 'round-1',
+            roundSlug: 'round-1',
+            tourId: 'tour-1',
+            boardNr: 2,
+            lastMoveTime: now,
+            players: [
+              _player(name: 'C', fideId: 3),
+              _player(name: 'D', fideId: 4),
+            ],
+          ),
+          _makeGame(
+            id: 'g3',
+            roundId: 'round-1',
+            roundSlug: 'round-1',
+            tourId: 'tour-1',
+            boardNr: 3,
+            lastMoveTime: now,
+            players: [
+              _player(name: 'E', fideId: 5),
+              _player(name: 'F', fideId: 6),
+            ],
+          ),
+        ];
+
+        final snapshot = buildForYouEventGamesSnapshot(
+          eventId: 'event-1',
+          selectedTour: tour,
+          eventTours: [tour],
+          selectedTourRounds: rounds,
+          roundsByTourId: {'tour-1': rounds},
+          selectedTourGames: games,
+          gamesByTourId: {'tour-1': games},
+          liveRoundIds: const [],
+          pinnedIds: const ['g3'],
+        );
+
+        expect(snapshot.visibleGames.first.gameId, 'g3');
+        expect(snapshot.pinnedIds, ['g3']);
+      },
+    );
+
+    test('returns only available visible games when fewer than four exist', () {
+      final now = DateTime.now();
+      final tour = _makeTour(
+        id: 'tour-1',
+        name: 'Small Event',
+        dates: [now.subtract(const Duration(days: 1)), now],
+      );
+      final rounds = [
+        _makeRound(
+          id: 'round-1',
+          tourId: 'tour-1',
+          name: 'Round 1',
+          startsAt: now.subtract(const Duration(hours: 2)),
+        ),
+      ];
+      final games = [
+        _makeGame(
+          id: 'g1',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'tour-1',
+          boardNr: 1,
+          lastMoveTime: now,
+          players: [_player(name: 'A'), _player(name: 'B', fideId: 2)],
+        ),
+        _makeGame(
+          id: 'g2',
+          roundId: 'round-1',
+          roundSlug: 'round-1',
+          tourId: 'tour-1',
+          boardNr: 2,
+          lastMoveTime: now,
+          players: [
+            _player(name: 'C', fideId: 3),
+            _player(name: 'D', fideId: 4),
+          ],
+        ),
+      ];
+
+      final snapshot = buildForYouEventGamesSnapshot(
+        eventId: 'event-1',
+        selectedTour: tour,
+        eventTours: [tour],
+        selectedTourRounds: rounds,
+        roundsByTourId: {'tour-1': rounds},
+        selectedTourGames: games,
+        gamesByTourId: {'tour-1': games},
+        liveRoundIds: const [],
+        pinnedIds: const [],
+      );
+
+      expect(snapshot.visibleGames, hasLength(2));
     });
   });
 }

--- a/test/for_you_games_provider_test.dart
+++ b/test/for_you_games_provider_test.dart
@@ -1,0 +1,665 @@
+import 'package:chessever2/providers/event_pin_refresh_provider.dart';
+import 'package:chessever2/providers/for_you_games_provider.dart';
+import 'package:chessever2/providers/for_you_games_logic.dart';
+import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.dart';
+import 'package:chessever2/repository/supabase/round/round.dart';
+import 'package:chessever2/repository/supabase/round/round_repository.dart';
+import 'package:chessever2/repository/supabase/tour/tour.dart';
+import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_provider.dart';
+import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class _FakeForYouPinStorage implements ForYouPinStorage {
+  final Map<String, List<String>> pinsByTourId;
+  final Map<String, List<String>> unpinnedOverridesByTourId;
+
+  _FakeForYouPinStorage({
+    Map<String, List<String>>? initialPins,
+    Map<String, List<String>>? initialUnpinnedOverrides,
+  }) : pinsByTourId = {
+         for (final entry
+             in (initialPins ?? const <String, List<String>>{}).entries)
+           entry.key: List<String>.from(entry.value),
+       },
+       unpinnedOverridesByTourId = {
+         for (final entry
+             in (initialUnpinnedOverrides ?? const <String, List<String>>{})
+                 .entries)
+           entry.key: List<String>.from(entry.value),
+       };
+
+  @override
+  Future<void> addPinnedGameId(String tourId, String gameId) async {
+    final pins = pinsByTourId.putIfAbsent(tourId, () => <String>[]);
+    if (!pins.contains(gameId)) {
+      pins.add(gameId);
+    }
+  }
+
+  @override
+  Future<List<String>> getPinnedGameIds(String tourId) async {
+    return List<String>.from(pinsByTourId[tourId] ?? const <String>[]);
+  }
+
+  @override
+  Future<List<String>> getUnpinnedGameIds(String tourId) async {
+    return List<String>.from(
+      unpinnedOverridesByTourId[tourId] ?? const <String>[],
+    );
+  }
+
+  @override
+  Future<void> removePinnedGameId(String tourId, String gameId) async {
+    final pins = pinsByTourId[tourId];
+    if (pins == null) {
+      return;
+    }
+    pins.removeWhere((pinnedGameId) => pinnedGameId == gameId);
+  }
+
+  @override
+  Future<void> addUnpinnedGameId(String tourId, String gameId) async {
+    final overrides = unpinnedOverridesByTourId.putIfAbsent(
+      tourId,
+      () => <String>[],
+    );
+    if (!overrides.contains(gameId)) {
+      overrides.add(gameId);
+    }
+  }
+
+  @override
+  Future<void> removeUnpinnedGameId(String tourId, String gameId) async {
+    final overrides = unpinnedOverridesByTourId[tourId];
+    if (overrides == null) {
+      return;
+    }
+    overrides.removeWhere((pinnedGameId) => pinnedGameId == gameId);
+  }
+}
+
+GroupEventCardModel _event(String id) {
+  return GroupEventCardModel(
+    id: id,
+    title: 'Event $id',
+    dates: 'Mar 2026',
+    maxAvgElo: 2700,
+    timeUntilStart: 'Live',
+    tourEventCategory: TourEventCategory.ongoing,
+    timeControl: 'Standard',
+    endDate: DateTime(2026, 3, 26),
+    startDate: DateTime(2026, 3, 25),
+  );
+}
+
+PlayerCard _player(String name) {
+  return PlayerCard(
+    name: name,
+    federation: 'USA',
+    title: 'GM',
+    rating: 2700,
+    countryCode: 'USA',
+    team: null,
+  );
+}
+
+GamesTourModel _game(String id, {String tourId = 'tour-1'}) {
+  return GamesTourModel(
+    gameId: id,
+    whitePlayer: _player('White $id'),
+    blackPlayer: _player('Black $id'),
+    whiteTimeDisplay: '--:--',
+    blackTimeDisplay: '--:--',
+    whiteClockCentiseconds: 0,
+    blackClockCentiseconds: 0,
+    gameStatus: GameStatus.ongoing,
+    roundId: 'round-1',
+    tourId: tourId,
+  );
+}
+
+ForYouEventGamesSnapshot _snapshot(
+  String eventId, {
+  String tourId = 'tour-1',
+  List<GamesTourModel> visibleGames = const <GamesTourModel>[],
+  List<String> pinnedIds = const <String>[],
+  List<String> manualPinnedIds = const <String>[],
+  List<String> autoPinnedIds = const <String>[],
+  List<String> unpinnedOverrideIds = const <String>[],
+}) {
+  return ForYouEventGamesSnapshot(
+    eventId: eventId,
+    tourId: tourId,
+    visibleGames: visibleGames,
+    pinnedIds: pinnedIds,
+    manualPinnedIds: manualPinnedIds,
+    autoPinnedIds: autoPinnedIds,
+    unpinnedOverrideIds: unpinnedOverrideIds,
+  );
+}
+
+Tour _tour({
+  required String id,
+  required List<DateTime> dates,
+  int? avgElo = 2700,
+}) {
+  return Tour.fromJson({
+    'id': id,
+    'name': 'Tour $id',
+    'slug': id,
+    'info': {
+      'format': 'Swiss',
+      'tc': '90+30',
+      'players': '',
+      'location': 'Test City',
+    },
+    'created_at': DateTime(2026, 3, 25, 8).toIso8601String(),
+    'url': 'https://example.com/$id',
+    'tier': 1,
+    'dates': dates.map((date) => date.toIso8601String()).toList(),
+    'players': const <Map<String, dynamic>>[],
+    'search': const <String>[],
+    'group_broadcast_id': 'event-1',
+    'avg_elo': avgElo,
+  });
+}
+
+Round _round({
+  required String id,
+  required String tourId,
+  required DateTime createdAt,
+}) {
+  return Round(
+    id: id,
+    slug: id,
+    tourId: tourId,
+    tourSlug: tourId,
+    name: 'Round $id',
+    createdAt: createdAt,
+    startsAt: createdAt.add(const Duration(hours: 1)),
+    url: 'https://example.com/$id',
+  );
+}
+
+GroupBroadcast _broadcast(String id) {
+  return GroupBroadcast(
+    id: id,
+    createdAt: DateTime(2026, 3, 25, 12),
+    name: 'Broadcast $id',
+    search: const <String>[],
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final triggerPinRefreshProvider = Provider.family<void Function(), String?>((
+    ref,
+    eventId,
+  ) {
+    return () => bumpEventPinRefreshSignal(ref, eventId);
+  });
+
+  group('currentSelectedTourIdForEventProvider', () {
+    test(
+      'does not react to selected broadcast changes for unrelated events',
+      () {
+        final detailTourIdProvider = StateProvider<String?>((ref) => 'tour-a');
+        final container = ProviderContainer(
+          overrides: [
+            currentTournamentDetailSelectedTourIdProvider.overrideWith(
+              (ref) => ref.watch(detailTourIdProvider),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final values = <String?>[];
+        final subscription = container.listen<String?>(
+          currentSelectedTourIdForEventProvider('event-y'),
+          (previous, next) => values.add(next),
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        expect(values, [null]);
+
+        container
+            .read(selectedBroadcastModelProvider.notifier)
+            .state = _broadcast('event-x');
+
+        expect(subscription.read(), isNull);
+        expect(values, [null]);
+
+        container.read(detailTourIdProvider.notifier).state = 'tour-b';
+
+        expect(subscription.read(), isNull);
+        expect(values, [null]);
+      },
+    );
+
+    test('tracks tournament detail selection only for the active event', () {
+      final detailTourIdProvider = StateProvider<String?>((ref) => 'tour-a');
+      final container = ProviderContainer(
+        overrides: [
+          currentTournamentDetailSelectedTourIdProvider.overrideWith(
+            (ref) => ref.watch(detailTourIdProvider),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final values = <String?>[];
+      final subscription = container.listen<String?>(
+        currentSelectedTourIdForEventProvider('event-x'),
+        (previous, next) => values.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      expect(values, [null]);
+
+      container
+          .read(selectedBroadcastModelProvider.notifier)
+          .state = _broadcast('event-x');
+
+      expect(subscription.read(), 'tour-a');
+      expect(values, [null, 'tour-a']);
+
+      container.read(detailTourIdProvider.notifier).state = 'tour-b';
+
+      expect(subscription.read(), 'tour-b');
+      expect(values, [null, 'tour-a', 'tour-b']);
+
+      container
+          .read(selectedBroadcastModelProvider.notifier)
+          .state = _broadcast('event-y');
+
+      expect(subscription.read(), isNull);
+      expect(values, [null, 'tour-a', 'tour-b', null]);
+    });
+  });
+
+  group('shouldLoadDeferredActivityTourId', () {
+    test('skips activity lookup when saved selection is already valid', () {
+      final now = DateTime(2026, 3, 25, 12);
+      final tourA = _tour(
+        id: 'tour-a',
+        dates: [now.subtract(const Duration(days: 1)), now],
+      );
+      final tourB = _tour(
+        id: 'tour-b',
+        dates: [now.subtract(const Duration(days: 1)), now],
+        avgElo: 2600,
+      );
+
+      final shouldLoad = shouldLoadDeferredActivityTourId(
+        tourModels: [
+          TourModel(tour: tourA, roundStatus: RoundStatus.ongoing),
+          TourModel(tour: tourB, roundStatus: RoundStatus.ongoing),
+        ],
+        savedTourId: 'tour-b',
+      );
+
+      expect(shouldLoad, isFalse);
+    });
+
+    test(
+      'skips activity lookup when a live tour already resolves selection',
+      () {
+        final now = DateTime(2026, 3, 25, 12);
+        final liveTour = _tour(
+          id: 'tour-live',
+          dates: [now.subtract(const Duration(hours: 2)), now],
+        );
+        final otherTour = _tour(
+          id: 'tour-other',
+          dates: [now.subtract(const Duration(days: 1)), now],
+          avgElo: null,
+        );
+
+        final shouldLoad = shouldLoadDeferredActivityTourId(
+          tourModels: [
+            TourModel(tour: liveTour, roundStatus: RoundStatus.live),
+            TourModel(tour: otherTour, roundStatus: RoundStatus.ongoing),
+          ],
+        );
+
+        expect(shouldLoad, isFalse);
+      },
+    );
+
+    test(
+      'requires activity lookup when earlier fallbacks cannot break the tie',
+      () {
+        final now = DateTime(2026, 3, 25, 12);
+        final tourA = _tour(
+          id: 'tour-a',
+          dates: [now.subtract(const Duration(days: 3)), now],
+          avgElo: null,
+        );
+        final tourB = _tour(
+          id: 'tour-b',
+          dates: [now.subtract(const Duration(days: 3)), now],
+          avgElo: null,
+        );
+
+        final shouldLoad = shouldLoadDeferredActivityTourId(
+          tourModels: [
+            TourModel(tour: tourA, roundStatus: RoundStatus.ongoing),
+            TourModel(tour: tourB, roundStatus: RoundStatus.ongoing),
+          ],
+        );
+
+        expect(shouldLoad, isTrue);
+      },
+    );
+  });
+
+  test('mergePinnedIdsPreservingOrder keeps first-seen tour order', () {
+    final merged = mergePinnedIdsPreservingOrder([
+      ['game-a', 'game-b'],
+      ['game-b', 'game-c'],
+      ['game-a', 'game-d'],
+    ]);
+
+    expect(merged, ['game-a', 'game-b', 'game-c', 'game-d']);
+  });
+
+  test('eventPinRefreshProvider only increments the matching event key', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(eventPinRefreshProvider('event-a')), 0);
+    expect(container.read(eventPinRefreshProvider('event-b')), 0);
+
+    container.read(triggerPinRefreshProvider('event-a'))();
+    container.read(triggerPinRefreshProvider(''))();
+    container.read(triggerPinRefreshProvider(null))();
+
+    expect(container.read(eventPinRefreshProvider('event-a')), 1);
+    expect(container.read(eventPinRefreshProvider('event-b')), 0);
+  });
+
+  test('mergeEffectivePins keeps legacy ordering when no overrides exist', () {
+    final merged = mergeEffectivePins(
+      manualPins: const ['game-a', 'game-b'],
+      autoPins: const ['game-b', 'game-c'],
+      unpinnedOverrides: const [],
+    );
+
+    expect(merged, ['game-a', 'game-b', 'game-c']);
+  });
+
+  test('areEquivalentForYouSnapshots matches identical rendered content', () {
+    final first = _snapshot(
+      'event-1',
+      tourId: 'tour-1',
+      visibleGames: [_game('game-1')],
+      pinnedIds: const ['game-1'],
+      manualPinnedIds: const ['game-1'],
+    );
+    final second = _snapshot(
+      'event-1',
+      tourId: 'tour-1',
+      visibleGames: [_game('game-1')],
+      pinnedIds: const ['game-1'],
+      manualPinnedIds: const ['game-1'],
+    );
+
+    expect(areEquivalentForYouSnapshots(first, second), isTrue);
+  });
+
+  test('areEquivalentForYouSnapshots detects visible game changes', () {
+    final first = _snapshot('event-1', visibleGames: [_game('game-1')]);
+    final second = _snapshot(
+      'event-1',
+      visibleGames: [
+        _game('game-1').copyWith(gameStatus: GameStatus.whiteWins),
+      ],
+    );
+
+    expect(areEquivalentForYouSnapshots(first, second), isFalse);
+  });
+
+  group('resolvePinToggleMode', () {
+    test('keeps legacy manual-only unpin behavior', () {
+      expect(
+        resolvePinToggleMode(
+          isManualPinned: true,
+          isAutoPinned: false,
+          isOverridden: false,
+        ),
+        PinToggleMode.unpinManualOnly,
+      );
+    });
+
+    test('uses persistent override for auto-pinned games', () {
+      expect(
+        resolvePinToggleMode(
+          isManualPinned: false,
+          isAutoPinned: true,
+          isOverridden: false,
+        ),
+        PinToggleMode.unpinWithOverride,
+      );
+    });
+
+    test('repin clears override and restores manual pin', () {
+      expect(
+        resolvePinToggleMode(
+          isManualPinned: false,
+          isAutoPinned: false,
+          isOverridden: true,
+        ),
+        PinToggleMode.repin,
+      );
+    });
+  });
+
+  test(
+    'groupRoundsByTourIdPreservingOrder sorts each tour by createdAt and keeps empty tours',
+    () {
+      final now = DateTime(2026, 3, 25, 12);
+
+      final grouped = groupRoundsByTourIdPreservingOrder(
+        rounds: [
+          _round(
+            id: 'tour-b-late',
+            tourId: 'tour-b',
+            createdAt: now.add(const Duration(hours: 1)),
+          ),
+          _round(
+            id: 'tour-a-late',
+            tourId: 'tour-a',
+            createdAt: now.add(const Duration(hours: 2)),
+          ),
+          _round(id: 'tour-a-early', tourId: 'tour-a', createdAt: now),
+          _round(
+            id: 'tour-b-early',
+            tourId: 'tour-b',
+            createdAt: now.subtract(const Duration(hours: 1)),
+          ),
+        ],
+        tourIds: const ['tour-a', 'tour-b', 'tour-c'],
+      );
+
+      expect(grouped['tour-a']!.map((round) => round.id), [
+        'tour-a-early',
+        'tour-a-late',
+      ]);
+      expect(grouped['tour-b']!.map((round) => round.id), [
+        'tour-b-early',
+        'tour-b-late',
+      ]);
+      expect(grouped['tour-c'], isEmpty);
+    },
+  );
+
+  test(
+    'forYouVisibleEventsProvider filters events with no available games',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          forYouEventListProvider.overrideWith(
+            (ref) => [_event('event-hidden'), _event('event-visible')],
+          ),
+          forYouEventHasGamesProvider.overrideWith((ref, eventId) async {
+            return eventId == 'event-visible';
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(forYouEventHasGamesProvider('event-hidden').future);
+      await container.read(forYouEventHasGamesProvider('event-visible').future);
+      final visibleEvents = container.read(forYouVisibleEventsProvider);
+
+      expect(visibleEvents.map((event) => event.id), ['event-visible']);
+    },
+  );
+
+  test(
+    'forYouVisibleEventsProvider does not depend on full event snapshots',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          forYouEventListProvider.overrideWith(
+            (ref) => [_event('event-hidden'), _event('event-visible')],
+          ),
+          forYouEventHasGamesProvider.overrideWith((ref, eventId) async {
+            return eventId == 'event-visible';
+          }),
+          forYouEventGamesWithAutoRefreshProvider.overrideWith((ref, eventId) {
+            throw StateError('full event snapshot should not be used here');
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(forYouEventHasGamesProvider('event-hidden').future);
+      await container.read(forYouEventHasGamesProvider('event-visible').future);
+      final visibleEvents = container.read(forYouVisibleEventsProvider);
+
+      expect(visibleEvents.map((event) => event.id), ['event-visible']);
+    },
+  );
+
+  test(
+    'forYouPinActionProvider writes manual pins against the provided tour id',
+    () async {
+      final storage = _FakeForYouPinStorage();
+      final container = ProviderContainer(
+        overrides: [
+          forYouPinStorageProvider.overrideWithValue(storage),
+          forYouEventGamesWithAutoRefreshProvider.overrideWith((ref, eventId) {
+            return AsyncValue.data(_snapshot(eventId));
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(forYouPinActionProvider)
+          .togglePin(eventId: 'event-1', gameId: 'game-1', tourId: 'tour-b');
+
+      expect(storage.pinsByTourId['tour-b'], ['game-1']);
+      expect(storage.pinsByTourId['tour-a'], isNull);
+      expect(storage.unpinnedOverridesByTourId['tour-b'], isNull);
+    },
+  );
+
+  test(
+    'forYouPinActionProvider removes existing manual pins from the same tour',
+    () async {
+      final storage = _FakeForYouPinStorage(
+        initialPins: {
+          'tour-b': ['game-1', 'game-2'],
+        },
+      );
+      final container = ProviderContainer(
+        overrides: [
+          forYouPinStorageProvider.overrideWithValue(storage),
+          forYouEventGamesWithAutoRefreshProvider.overrideWith((ref, eventId) {
+            return AsyncValue.data(
+              _snapshot(
+                eventId,
+                manualPinnedIds: const ['game-1', 'game-2'],
+                pinnedIds: const ['game-1', 'game-2'],
+              ),
+            );
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(forYouPinActionProvider)
+          .togglePin(eventId: 'event-1', gameId: 'game-1', tourId: 'tour-b');
+
+      expect(storage.pinsByTourId['tour-b'], ['game-2']);
+      expect(storage.unpinnedOverridesByTourId['tour-b'], isNull);
+    },
+  );
+
+  test(
+    'forYouPinActionProvider stores persistent unpin overrides for auto-pinned games',
+    () async {
+      final storage = _FakeForYouPinStorage();
+      final container = ProviderContainer(
+        overrides: [
+          forYouPinStorageProvider.overrideWithValue(storage),
+          forYouEventGamesWithAutoRefreshProvider.overrideWith((ref, eventId) {
+            return AsyncValue.data(
+              _snapshot(
+                eventId,
+                autoPinnedIds: const ['game-1'],
+                pinnedIds: const ['game-1'],
+              ),
+            );
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(forYouPinActionProvider)
+          .togglePin(eventId: 'event-1', gameId: 'game-1', tourId: 'tour-b');
+
+      expect(storage.pinsByTourId['tour-b'], isNull);
+      expect(storage.unpinnedOverridesByTourId['tour-b'], ['game-1']);
+    },
+  );
+
+  test(
+    'forYouPinActionProvider re-pins games by clearing the override first',
+    () async {
+      final storage = _FakeForYouPinStorage(
+        initialUnpinnedOverrides: {
+          'tour-b': ['game-1'],
+        },
+      );
+      final container = ProviderContainer(
+        overrides: [
+          forYouPinStorageProvider.overrideWithValue(storage),
+          forYouEventGamesWithAutoRefreshProvider.overrideWith((ref, eventId) {
+            return AsyncValue.data(
+              _snapshot(eventId, unpinnedOverrideIds: const ['game-1']),
+            );
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(forYouPinActionProvider)
+          .togglePin(eventId: 'event-1', gameId: 'game-1', tourId: 'tour-b');
+
+      expect(storage.pinsByTourId['tour-b'], ['game-1']);
+      expect(storage.unpinnedOverridesByTourId['tour-b'], isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
1. Use the same selected-tour, ordering, and pin logic as Games tab for For You events, and render the first 4 games without round headers. Also adds parity coverage for tour selection and game ordering.
2. Fix the unpin feature in For You,
3. Implement 0 reload for for you tab