### PR TITLE
Trust server-side standings on chess-results-flagged tours

### DIFF
--- a/lib/repository/supabase/tour/tour.dart
+++ b/lib/repository/supabase/tour/tour.dart
@@ -301,6 +301,11 @@ class _TourInfo {
   final String? location; // Tournament location
   final String? timeZone; // Time zone
   final String? standings; // Standings URL
+  // Set by the data hub when it reorders [Tour.players] from an external
+  // source (currently 'chess-results'). Absent => Lichess-feed order, and
+  // consumers should compute their own standings.
+  final String? standingsSource;
+  final DateTime? standingsUpdatedAt;
 
   const _TourInfo({
     this.tc,
@@ -311,6 +316,8 @@ class _TourInfo {
     this.location,
     this.timeZone,
     this.standings,
+    this.standingsSource,
+    this.standingsUpdatedAt,
   });
 
   factory _TourInfo.fromJson(Map<String, dynamic> json) {
@@ -323,7 +330,14 @@ class _TourInfo {
       location: json['location'] as String?,
       timeZone: json['timeZone'] as String?,
       standings: json['standings'] as String?,
+      standingsSource: json['standingsSource'] as String?,
+      standingsUpdatedAt: _parseTimestamp(json['standingsUpdatedAt']),
     );
+  }
+
+  static DateTime? _parseTimestamp(dynamic v) {
+    if (v is String && v.isNotEmpty) return DateTime.tryParse(v);
+    return null;
   }
 
   Map<String, dynamic> toJson() {
@@ -336,6 +350,9 @@ class _TourInfo {
       if (location != null) 'location': location,
       if (timeZone != null) 'timeZone': timeZone,
       if (standings != null) 'standings': standings,
+      if (standingsSource != null) 'standingsSource': standingsSource,
+      if (standingsUpdatedAt != null)
+        'standingsUpdatedAt': standingsUpdatedAt!.toIso8601String(),
     };
   }
 
@@ -430,6 +447,22 @@ class Tour {
       'avg_elo': avgElo,
     };
   }
+
+  /// True when the data hub has populated [players] in canonical ranking
+  /// order from an external source (currently chess-results.com). Standings
+  /// consumers should skip their own re-sort and trust the array order.
+  /// False for past tours that pre-date the data hub PR, future tours, and
+  /// tours mid-round-1 where no game has finished + 20 min yet.
+  bool get usesExternalStandings =>
+      info.standingsSource == 'chess-results' &&
+      info.standingsUpdatedAt != null;
+
+  /// Human-readable name of the standings source, or null when standings are
+  /// computed client-side.
+  String? get standingsSourceLabel =>
+      usesExternalStandings && info.standingsSource == 'chess-results'
+          ? 'chess-results.com'
+          : null;
 
   // Format time until start
   static String timeUntilStart(List<DateTime> dates) {

--- a/lib/screens/tour_detail/player_tour/player_tour_screen_provider.dart
+++ b/lib/screens/tour_detail/player_tour/player_tour_screen_provider.dart
@@ -257,9 +257,19 @@ class PlayerTourScreenNotifier
       allPlayers.addAll(tourModel.tour.players);
     }
 
+    // Trust the server-side standings order only when scope is a single tour
+    // that the data hub has flagged as canonically sorted (currently from
+    // chess-results.com). Multi-tour pagination categories (e.g. "Boards 1-66"
+    // + "Boards 67-126") interleave players from independent standings, so the
+    // concatenation is not meaningful — fall back to client-side sort there.
+    final useExternalOrder =
+        relatedTours.length == 1 &&
+        relatedTours.first.tour.usesExternalStandings;
+
     final builtStandings = await _buildStandingsFromData(
       tournamentPlayers: allPlayers,
       gamesTourModels: allGames,
+      useExternalOrder: useExternalOrder,
     );
 
     if (builtStandings.isEmpty) {
@@ -383,6 +393,7 @@ class PlayerTourScreenNotifier
   Future<List<PlayerStandingModel>> _buildStandingsFromData({
     required List<TournamentPlayer> tournamentPlayers,
     required List<GamesTourModel> gamesTourModels,
+    bool useExternalOrder = false,
   }) async {
     var players = List<TournamentPlayer>.from(tournamentPlayers);
 
@@ -604,18 +615,25 @@ class PlayerTourScreenNotifier
       buchholzByKey[key] = buchholz;
     }
 
-    // Sort by absolute score, then Buchholz Cut-1, then current rating.
-    enrichedPlayers.sort((a, b) {
-      final aScore = a.score ?? 0.0;
-      final bScore = b.score ?? 0.0;
-      if (bScore != aScore) return bScore.compareTo(aScore);
+    // Sort by absolute score, then Buchholz Cut-1, then current rating —
+    // unless the caller has signalled that the server already supplied a
+    // canonical order (e.g. chess-results.com tiebreaks). In that case we
+    // preserve the input order so the displayed ranking matches the official
+    // tournament standings, while keeping all the per-player enrichment
+    // (score, Buchholz for display, rating diff, etc.).
+    if (!useExternalOrder) {
+      enrichedPlayers.sort((a, b) {
+        final aScore = a.score ?? 0.0;
+        final bScore = b.score ?? 0.0;
+        if (bScore != aScore) return bScore.compareTo(aScore);
 
-      final aBuch = buchholzByKey[_canonicalName(a.name)] ?? 0.0;
-      final bBuch = buchholzByKey[_canonicalName(b.name)] ?? 0.0;
-      if (bBuch != aBuch) return bBuch.compareTo(aBuch);
+        final aBuch = buchholzByKey[_canonicalName(a.name)] ?? 0.0;
+        final bBuch = buchholzByKey[_canonicalName(b.name)] ?? 0.0;
+        if (bBuch != aBuch) return bBuch.compareTo(aBuch);
 
-      return (b.rating ?? 0).compareTo(a.rating ?? 0);
-    });
+        return (b.rating ?? 0).compareTo(a.rating ?? 0);
+      });
+    }
 
     return enrichedPlayers
         .map((player) => PlayerStandingModel.fromPlayer(player))


### PR DESCRIPTION
## Summary
- For tours the data hub has flagged as canonically sorted by chess-results.com (`info.standingsSource == 'chess-results'`, `info.standingsUpdatedAt` set), the standings UI now preserves the server's array order instead of re-computing `score → Buchholz Cut-1 → rating` client-side.
- All per-player enrichment (score, Buchholz for display, rating diff, etc.) **still runs** — only the final ordering is taken from the backend. So cells render the same; only the ranking changes.
- Adds two fields to `_TourInfo` (`standingsSource`, `standingsUpdatedAt`) and two getters on `Tour` (`usesExternalStandings`, `standingsSourceLabel`).

## Companion PR / release requirement
- Must ship together with [chessever-data-hub#20](https://github.com/Chessever/chessever-data-hub/pull/20) for the visible standings fix.
- Data-hub #20 writes and preserves the marker fields; this frontend PR consumes those markers and skips the client-side re-sort.
- This frontend PR is forward-compatible by itself: until data-hub #20 is deployed and at least one tour has been reordered, no tour has `usesExternalStandings == true`, so behavior is unchanged.
- No PostgreSQL migration is required for this feature; the marker fields live inside existing `tours.info` JSONB.

## When this kicks in
Trust server order **only** when:
- Exactly one tour is in scope (skips multi-tour pagination categories like "Boards 1-66" + "Boards 67-126" that concat independent standings), AND
- That tour has both marker fields set.

Falls back to the existing client-side sort for:
- Past tours from before the data-hub PR was deployed (no marker)
- Live tours mid-round-1 where no game has finished + 20 min yet (no marker)
- Tours with non-chess-results standings sources

## Backed by
- [chessever-data-hub#19](https://github.com/Chessever/chessever-data-hub/pull/19) — the reorder code (already merged)
- [chessever-data-hub#20](https://github.com/Chessever/chessever-data-hub/pull/20) — adds and preserves the marker fields (open)

## Realistic blast radius
~3,265 of 8,368 tours have a chess-results.com URL, but only ~38 are live + ~13 ended in last 24h at any given moment. Those ~50 tours are the rolling window where this code path actually activates.

## Followups (out of scope here)
- Add a small visible "Source: chess-results.com" affordance on the standings header. The Tour model already exposes `standingsSourceLabel` for this; left out so design can pick the placement and styling.

## Test plan
- [ ] After data-hub #20 deploys: open a live broadcast with a chess-results.com URL where at least one game finished >20 min ago. Standings should match the order on `chess-results.com/tnrXXXXX.aspx`, not the local Buchholz computation.
- [ ] Open a finished tour from last week — standings come from client-side calc (marker absent because reorder never fired for that tour).
- [ ] Open a tour with no `info.standings` (or a non-chess-results URL) — behavior unchanged.
- [ ] Open a multi-tour pagination category — falls back to client-side sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)