### PR TITLE
Fix scorecard K=10 for selected 2400+ rating

### DIFF
--- a/lib/screens/standings/score_card_screen.dart
+++ b/lib/screens/standings/score_card_screen.dart
@@ -5,6 +5,7 @@ import 'package:chessever2/widgets/fullscreen_image_viewer.dart';
 import 'package:chessever2/screens/standings/providers/player_ratings_provider.dart'
     show AllRatingsRequest, allRatingsProvider;
 import 'package:chessever2/screens/standings/providers/player_utils_provider.dart';
+import 'package:chessever2/screens/standings/utils/fide_rating_change.dart';
 import 'package:chessever2/screens/standings/widget/scoreboard_card_widget.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
@@ -143,15 +144,6 @@ class ScoreCardScreen extends ConsumerWidget {
     return 1500.0;
   }
 
-  // Calculate K-factor
-  int _getKFactor(double rating) {
-    if (rating >= 2400) {
-      return 10;
-    } else {
-      return 20;
-    }
-  }
-
   // Calculate FIDE Elo rating change
   double _calculateFideRatingChange(
     double playerRating,
@@ -177,12 +169,11 @@ class ScoreCardScreen extends ConsumerWidget {
         return 0;
     }
 
-    double ratingDiff = (opponentRating - playerRating).clamp(-400.0, 400.0);
-    double expectedScore = 1 / (1 + math.pow(10, ratingDiff / 400.0));
-    int kFactor = _getKFactor(playerRating);
-    double ratingChange = kFactor * (actualScore - expectedScore);
-
-    return ratingChange;
+    return calculateFideRatingChange(
+      playerRating: playerRating,
+      opponentRating: opponentRating,
+      actualScore: actualScore,
+    );
   }
 
   List<GamesTourModel> _toGamesTourModels(List<Games> games) {

--- a/lib/screens/standings/utils/fide_rating_change.dart
+++ b/lib/screens/standings/utils/fide_rating_change.dart
@@ -1,0 +1,26 @@
+import 'dart:math' as math;
+
+/// Returns the simple FIDE K-factor fallback for the rating selected by the
+/// event's time-control bucket.
+///
+/// The caller must pass the rating that is actually used for the calculation
+/// (standard/classical rating for standard events, rapid rating for rapid
+/// events, blitz rating for blitz events). If that selected rating is 2400 or
+/// higher, FIDE uses K=10 for that rating bucket.
+int fideKFactorForSelectedRating(num selectedRating) {
+  return selectedRating >= 2400 ? 10 : 20;
+}
+
+/// Calculates a single-game FIDE Elo rating change using ChessEver's current
+/// simple fallback K-factor rule.
+double calculateFideRatingChange({
+  required num playerRating,
+  required num opponentRating,
+  required double actualScore,
+}) {
+  final ratingDiff =
+      (opponentRating - playerRating).clamp(-400, 400).toDouble();
+  final expectedScore = 1 / (1 + math.pow(10, ratingDiff / 400.0));
+  final kFactor = fideKFactorForSelectedRating(playerRating);
+  return kFactor * (actualScore - expectedScore);
+}

--- a/test/standings/fide_rating_change_test.dart
+++ b/test/standings/fide_rating_change_test.dart
@@ -1,0 +1,42 @@
+import 'package:chessever2/screens/standings/utils/fide_rating_change.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('fideKFactorForSelectedRating', () {
+    test('uses K=10 when the selected rating is 2400 or higher', () {
+      expect(fideKFactorForSelectedRating(2400), 10);
+      expect(fideKFactorForSelectedRating(2491), 10);
+      expect(fideKFactorForSelectedRating(2610), 10);
+    });
+
+    test('keeps the simple K=20 fallback below 2400', () {
+      expect(fideKFactorForSelectedRating(2399), 20);
+      expect(fideKFactorForSelectedRating(1500), 20);
+    });
+  });
+
+  group('calculateFideRatingChange', () {
+    test(
+      'draw vs higher-rated opponent uses K=10 for selected 2400+ rating',
+      () {
+        final change = calculateFideRatingChange(
+          playerRating: 2491,
+          opponentRating: 2605,
+          actualScore: 0.5,
+        );
+
+        expect(change, closeTo(1.58, 0.01));
+      },
+    );
+
+    test('same draw would be doubled with K=20 below 2400', () {
+      final change = calculateFideRatingChange(
+        playerRating: 2399,
+        opponentRating: 2513,
+        actualScore: 0.5,
+      );
+
+      expect(change, closeTo(3.16, 0.01));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Move the score-card FIDE rating-change math into a small tested helper.
- Lock the simple K-factor rule Vasif requested: after selecting the rating used for the calculation, any selected rating of 2400+ uses K=10.
- Add focused tests covering 2400/2491/2610 => K=10 and a draw vs a higher-rated opponent using the K=10 result.

## Scope
This intentionally does not implement the historical sticky-K case for players who once crossed 2400 and later dropped below 2400. It only fixes/locks the current selected-rating >= 2400 rule.

## Test plan
- `git diff --check`
- `flutter analyze lib/screens/standings/utils/fide_rating_change.dart lib/screens/standings/score_card_screen.dart test/standings/fide_rating_change_test.dart`
- `flutter test test/standings/fide_rating_change_test.dart`
