### PR TITLE
fix: keep favorite current events visible in for you

### DIFF
--- a/lib/providers/for_you_games_provider.dart
+++ b/lib/providers/for_you_games_provider.dart
@@ -23,6 +23,37 @@ const int kGamesPerEvent = 4;
 const int _kPageSize = 20;
 const Duration _kForYouStaleThreshold = Duration(minutes: 5);
 
+@visibleForTesting
+List<GroupBroadcast> mergeMissingFavoriteCurrentBroadcasts({
+  required List<GroupBroadcast> pageBroadcasts,
+  required List<GroupBroadcast> favoriteBroadcasts,
+  required List<String> favoriteIds,
+}) {
+  if (favoriteIds.isEmpty || favoriteBroadcasts.isEmpty) {
+    return pageBroadcasts;
+  }
+
+  final existingIds = pageBroadcasts.map((broadcast) => broadcast.id).toSet();
+  final favoriteById = {
+    for (final broadcast in favoriteBroadcasts) broadcast.id: broadcast,
+  };
+
+  final missingFavorites = <GroupBroadcast>[];
+  for (final favoriteId in favoriteIds) {
+    if (existingIds.contains(favoriteId)) continue;
+    final broadcast = favoriteById[favoriteId];
+    if (broadcast == null) continue;
+    missingFavorites.add(broadcast);
+    existingIds.add(favoriteId);
+  }
+
+  if (missingFavorites.isEmpty) {
+    return pageBroadcasts;
+  }
+
+  return [...missingFavorites, ...pageBroadcasts];
+}
+
 // ============================================================================
 // FOR YOU EVENTS - PAGINATED WITH SUPABASE QUERIES
 // ============================================================================
@@ -136,13 +167,39 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
 
       // Query Supabase with filters
       final repo = ref.read(groupBroadcastRepositoryProvider);
-      final broadcasts = await repo.getCurrentGroupBroadcasts(
+      var broadcasts = await repo.getCurrentGroupBroadcasts(
         limit: _kPageSize,
         offset: _offset,
         timeControlFilters: formatFilters.isNotEmpty ? formatFilters : null,
         minElo: hasEloFilter ? minElo : null,
         maxElo: hasEloFilter ? maxElo : null,
       );
+      final fetchedPageLength = broadcasts.length;
+
+      final hasDefaultFilters =
+          formatFilters.isEmpty && statusFilters.isEmpty && !hasEloFilter;
+      if (isInitial && hasDefaultFilters) {
+        final favoriteEvents = ref.read(favoriteEventsProvider).valueOrNull ?? [];
+        final favoriteIds = favoriteEvents
+            .map((event) => event.eventId)
+            .where((eventId) => eventId.isNotEmpty)
+            .toList();
+        final pageIds = broadcasts.map((broadcast) => broadcast.id).toSet();
+        final missingFavoriteIds = favoriteIds
+            .where((eventId) => !pageIds.contains(eventId))
+            .toList();
+
+        if (missingFavoriteIds.isNotEmpty) {
+          final favoriteBroadcasts = await repo.getCurrentGroupBroadcastsByIds(
+            missingFavoriteIds,
+          );
+          broadcasts = mergeMissingFavoriteCurrentBroadcasts(
+            pageBroadcasts: broadcasts,
+            favoriteBroadcasts: favoriteBroadcasts,
+            favoriteIds: favoriteIds,
+          );
+        }
+      }
 
       debugPrint('[ForYou] Fetched ${broadcasts.length} from Supabase (offset: $_offset, filters: format=$formatFilters, elo=$hasEloFilter)');
 
@@ -175,17 +232,21 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
         state = ForYouState(
           events: sortedModels,
           isLoading: false,
-          hasMore: broadcasts.length >= _kPageSize,
+          hasMore: fetchedPageLength >= _kPageSize,
         );
         _lastRefreshAt = DateTime.now();
       } else {
+        final existingIds = state.events.map((event) => event.id).toSet();
+        final newEvents = sortedModels
+            .where((event) => !existingIds.contains(event.id))
+            .toList();
         state = state.copyWith(
-          events: [...state.events, ...sortedModels],
-          hasMore: broadcasts.length >= _kPageSize,
+          events: [...state.events, ...newEvents],
+          hasMore: fetchedPageLength >= _kPageSize,
         );
       }
 
-      _offset += broadcasts.length;
+      _offset += fetchedPageLength;
 
     } catch (e, stack) {
       debugPrint('[ForYou] Error: $e');

--- a/lib/repository/supabase/group_broadcast/group_tour_repository.dart
+++ b/lib/repository/supabase/group_broadcast/group_tour_repository.dart
@@ -138,6 +138,23 @@ class GroupBroadcastRepository extends BaseRepository {
     });
   }
 
+  Future<List<GroupBroadcast>> getCurrentGroupBroadcastsByIds(
+    List<String> ids,
+  ) async {
+    if (ids.isEmpty) return <GroupBroadcast>[];
+
+    return handleApiCall(() async {
+      final response = await supabase
+          .from('group_broadcasts_current')
+          .select()
+          .inFilter('id', ids);
+
+      return (response as List)
+          .map((json) => GroupBroadcast.fromJson(json))
+          .toList();
+    });
+  }
+
   Future<List<GroupBroadcast>> getUpcomingGroupBroadcasts({
     int? limit,
     int? offset,

--- a/test/for_you_games_provider_test.dart
+++ b/test/for_you_games_provider_test.dart
@@ -1,0 +1,88 @@
+import 'package:chessever2/providers/for_you_games_provider.dart';
+import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mergeMissingFavoriteCurrentBroadcasts', () {
+    test(
+      'prepends favorite current broadcasts missing from the first page',
+      () {
+        final page = [
+          _broadcast('krefelder', '13. Krefelder Pfingstopen 2026'),
+          _broadcast('zalakarosi', '45. Zalakarosi Sakkfesztivál'),
+        ];
+        final favoriteBroadcasts = [
+          _broadcast('olimpiada', 'Olimpiada Nacional CONADE San Luis Potosí'),
+        ];
+
+        final merged = mergeMissingFavoriteCurrentBroadcasts(
+          pageBroadcasts: page,
+          favoriteBroadcasts: favoriteBroadcasts,
+          favoriteIds: const ['olimpiada'],
+        );
+
+        expect(merged.map((broadcast) => broadcast.id), [
+          'olimpiada',
+          'krefelder',
+          'zalakarosi',
+        ]);
+      },
+    );
+
+    test('does not duplicate favorites already present on the page', () {
+      final page = [
+        _broadcast('olimpiada', 'Olimpiada Nacional CONADE San Luis Potosí'),
+        _broadcast('krefelder', '13. Krefelder Pfingstopen 2026'),
+      ];
+      final favoriteBroadcasts = [
+        _broadcast('olimpiada', 'Olimpiada Nacional CONADE San Luis Potosí'),
+      ];
+
+      final merged = mergeMissingFavoriteCurrentBroadcasts(
+        pageBroadcasts: page,
+        favoriteBroadcasts: favoriteBroadcasts,
+        favoriteIds: const ['olimpiada'],
+      );
+
+      expect(merged, page);
+    });
+
+    test(
+      'keeps favorite timestamp order when multiple favorites are injected',
+      () {
+        final page = [
+          _broadcast('krefelder', '13. Krefelder Pfingstopen 2026'),
+        ];
+        final favoriteBroadcasts = [
+          _broadcast('olimpiada', 'Olimpiada Nacional CONADE San Luis Potosí'),
+          _broadcast('serbian', '12th Serbian Cup'),
+        ];
+
+        final merged = mergeMissingFavoriteCurrentBroadcasts(
+          pageBroadcasts: page,
+          favoriteBroadcasts: favoriteBroadcasts,
+          favoriteIds: const ['serbian', 'olimpiada'],
+        );
+
+        expect(merged.map((broadcast) => broadcast.id), [
+          'serbian',
+          'olimpiada',
+          'krefelder',
+        ]);
+      },
+    );
+  });
+}
+
+GroupBroadcast _broadcast(String id, String name) {
+  return GroupBroadcast(
+    id: id,
+    createdAt: DateTime.utc(2026, 5, 24),
+    name: name,
+    search: const [],
+    maxAvgElo: 2200,
+    dateStart: DateTime.utc(2026, 5, 21),
+    dateEnd: DateTime.utc(2026, 5, 24),
+    timeControl: 'standard',
+  );
+}


### PR DESCRIPTION
## Summary
- Ensures favorited current events missing from the first For You page are fetched from `group_broadcasts_current` and merged into the initial For You feed.
- Keeps pagination offset based on the original Supabase page size so injected favorites do not skip later events.
- De-dupes later paginated results so an injected favorite cannot appear twice.
- Adds focused regression coverage for missing-favorite merge behavior.

## Why
Vasif saw `Olimpiada Nacional CONADE San Luis Potosí...` at the top of Current but had a hard time finding it in For You. The For You feed paginates the first 20 current broadcasts before favorite sorting, so a user-favorited/current event outside that DB page can be absent from the initial For You list even though it is prominent in Current.

## Test plan
- [x] `flutter test test/for_you_games_provider_test.dart`
- [x] `flutter analyze lib/providers/for_you_games_provider.dart lib/repository/supabase/group_broadcast/group_tour_repository.dart test/for_you_games_provider_test.dart`
- [x] `git diff --check`
