### PR TITLE
Fix duplicate grouped event notifications

### DIFF
--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -701,16 +701,23 @@ async function applyPreferences(
     const isEventFav = eventUserIds.has(userId);
     const isPlayerFav = playerUserIds.has(userId);
 
-    if (eventType === "game_started" || eventType === "game_finished") {
-      const eventAllowed = !prefs || prefs.favorite_event_alerts !== false;
+    if (eventType === "game_started") {
+      // Game-start notifications are for favorite-player matches only.
+      // Event-starred users are notified at the round/event level, so including
+      // them here can produce two pushes for the same visible game when the
+      // user has also favorited one or both players.
       const playerAllowed = !prefs || prefs.favorite_player_alerts !== false;
-      if (isEventFav && eventAllowed) {
-        filtered.add(userId);
-        continue;
-      }
       if (isPlayerFav && playerAllowed) {
         filtered.add(userId);
-        continue;
+      }
+      continue;
+    }
+
+    if (eventType === "game_finished") {
+      const eventAllowed = !prefs || prefs.favorite_event_alerts !== false;
+      const playerAllowed = !prefs || prefs.favorite_player_alerts !== false;
+      if ((isEventFav && eventAllowed) || (isPlayerFav && playerAllowed)) {
+        filtered.add(userId);
       }
       continue;
     }
@@ -1985,7 +1992,15 @@ async function sendOneSignal(
   userIds: string[],
   notification: NotificationPayload,
 ) {
-  const chunks = chunk(userIds, 1000);
+  // Defensive recipient de-dupe: a user can match both sides of a game
+  // (e.g. Alireza and Magnus are both favorites) or match by both FIDE ID and
+  // player name. OneSignal receives each external user id at most once per
+  // notification payload.
+  const uniqueUserIds = Array.from(new Set(userIds.filter(Boolean)));
+  if (uniqueUserIds.length === 0) return;
+
+  const chunks = chunk(uniqueUserIds, 1000);
+  const collapseId = notificationCollapseId(notification);
 
   for (const batch of chunks) {
     const payload: Record<string, unknown> = {
@@ -1995,6 +2010,10 @@ async function sendOneSignal(
       contents: { en: notification.body },
       data: notification.data,
     };
+
+    if (collapseId) {
+      payload.collapse_id = collapseId;
+    }
 
     if (notification.url) {
       payload.url = notification.url;
@@ -2013,6 +2032,31 @@ async function sendOneSignal(
 
     await sendOneSignalPayload(payload);
   }
+}
+
+function notificationCollapseId(notification: NotificationPayload): string | null {
+  const type = typeof notification.data?.type === "string"
+    ? notification.data.type
+    : null;
+  const gameId = typeof notification.data?.game_id === "string"
+    ? notification.data.game_id
+    : null;
+  const roundId = typeof notification.data?.round_id === "string"
+    ? notification.data.round_id
+    : null;
+
+  if (gameId) return compactCollapseId(`game:${type ?? "update"}:${gameId}`);
+  if (roundId) return compactCollapseId(`round:${type ?? "update"}:${roundId}`);
+  return null;
+}
+
+function compactCollapseId(value: string): string {
+  if (value.length <= 64) return value;
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
+  }
+  return `${value.slice(0, 48)}:${Math.abs(hash).toString(36)}`;
 }
 
 function chunk<T>(list: T[], size: number) {

--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -43,6 +43,13 @@ type RoundRow = {
   starts_at: string | null;
 };
 
+type TourRow = {
+  id: string;
+  name: string | null;
+  slug: string | null;
+  group_broadcast_id: string | null;
+};
+
 type LiveSubscriptionRow = {
   user_id: string;
   platform: "ios" | "android";
@@ -186,6 +193,24 @@ async function processItem(item: OutboxItem, cloudEvalState: CloudEvalState) {
 
   try {
     const context = await buildContext(item);
+    if (item.event_type === "round_started") {
+      if (await hasEarlierGroupedRoundStart(item, context)) {
+        await markSkipped(item.id, "duplicate_grouped_round_start");
+        return {
+          id: item.id,
+          status: "skipped",
+          reason: "duplicate_grouped_round_start",
+        };
+      }
+    }
+    if (item.event_type === "round_finished" && isCombinedTour(context.tour)) {
+      await markSkipped(item.id, "combined_round_results_suppressed");
+      return {
+        id: item.id,
+        status: "skipped",
+        reason: "combined_round_results_suppressed",
+      };
+    }
     if (item.event_type === "live_game_update") {
       if (!item.game_id) {
         await markSkipped(item.id, "missing_game_id");
@@ -513,6 +538,7 @@ async function markFailed(id: string, attempts: number, error: string) {
 async function buildContext(item: OutboxItem) {
   let game: GameRow | null = null;
   let round: RoundRow | null = null;
+  let tour: TourRow | null = null;
   let eventName: string | null = null;
   let groupBroadcastId = item.group_broadcast_id ?? null;
 
@@ -537,13 +563,14 @@ async function buildContext(item: OutboxItem) {
   }
 
   const tourId = item.tour_id ?? game?.tour_id ?? round?.tour_id ?? null;
-  if (!groupBroadcastId && tourId) {
+  if (tourId) {
     const { data } = await supabase
       .from("tours")
-      .select("group_broadcast_id")
+      .select("id,name,slug,group_broadcast_id")
       .eq("id", tourId)
       .maybeSingle();
-    groupBroadcastId = data?.group_broadcast_id ?? null;
+    tour = (data ?? null) as TourRow | null;
+    groupBroadcastId = groupBroadcastId ?? tour?.group_broadcast_id ?? null;
   }
 
   if (groupBroadcastId) {
@@ -596,11 +623,48 @@ async function buildContext(item: OutboxItem) {
   return {
     game,
     round,
+    tour,
     eventName,
     groupBroadcastId,
     eventUserIds,
     playerUserIds,
   };
+}
+
+function isCombinedTour(tour: TourRow | null): boolean {
+  const label = `${tour?.name ?? ""} ${tour?.slug ?? ""}`.toLowerCase();
+  return /(^|[^a-z0-9])combined([^a-z0-9]|$)/.test(label);
+}
+
+function groupedRoundStartCollapseKey(
+  context: { round: RoundRow | null; groupBroadcastId: string | null },
+): string | null {
+  const startsAt = context.round?.starts_at;
+  const groupId = context.groupBroadcastId;
+  if (!startsAt || !groupId) return null;
+  return `round_started:${groupId}:${startsAt}`;
+}
+
+async function hasEarlierGroupedRoundStart(
+  item: OutboxItem,
+  context: { round: RoundRow | null; groupBroadcastId: string | null },
+): Promise<boolean> {
+  const startsAt = context.round?.starts_at;
+  const groupId = context.groupBroadcastId;
+  if (!startsAt || !groupId) return false;
+
+  const { data, error } = await supabase
+    .from("notification_outbox")
+    .select("id")
+    .eq("event_type", "round_started")
+    .eq("group_broadcast_id", groupId)
+    .neq("id", item.id)
+    .eq("status", "sent")
+    .contains("payload", { starts_at: startsAt })
+    .limit(1);
+
+  if (error) return false;
+  return (data ?? []).length > 0;
 }
 
 async function fetchRoundPlayers(roundId: string) {
@@ -1118,7 +1182,11 @@ function buildRoundNotification(
     title,
     body,
     url: context.groupBroadcastId ? `https://chessever.com` : null,
-    data: { type: "round_started", round_id: context.round?.id },
+    data: {
+      type: "round_started",
+      round_id: context.round?.id,
+      grouped_round_start_key: groupedRoundStartCollapseKey(context),
+    },
     androidChannelId: channelForEvent("round_started"),
   };
 }
@@ -2046,6 +2114,12 @@ function notificationCollapseId(notification: NotificationPayload): string | nul
     : null;
 
   if (gameId) return compactCollapseId(`game:${type ?? "update"}:${gameId}`);
+  if (type === "round_started") {
+    const groupedRoundStartKey = notification.data?.grouped_round_start_key;
+    if (typeof groupedRoundStartKey === "string" && groupedRoundStartKey) {
+      return compactCollapseId(groupedRoundStartKey);
+    }
+  }
   if (roundId) return compactCollapseId(`round:${type ?? "update"}:${roundId}`);
   return null;
 }

--- a/supabase/migrations/024_grouped_round_start_exact_time_dedupe.sql
+++ b/supabase/migrations/024_grouped_round_start_exact_time_dedupe.sql
@@ -1,0 +1,39 @@
+-- Migration: grouped round-start notification dedupe by exact start time
+-- Purpose: A grouped event can contain several underlying tours (for example
+--          Open, Women, Combined Boards) that start at the exact same time.
+--          Queue one user-visible round-start notification for that grouped
+--          event/start instant instead of one per raw tour round.
+
+CREATE OR REPLACE FUNCTION public.queue_round_start_notifications()
+RETURNS void AS $$
+DECLARE
+  now_ts TIMESTAMPTZ := now();
+BEGIN
+  INSERT INTO public.notification_outbox (
+    event_type,
+    round_id,
+    tour_id,
+    group_broadcast_id,
+    payload,
+    dedupe_key
+  )
+  SELECT
+    'round_started',
+    r.id,
+    r.tour_id,
+    t.group_broadcast_id,
+    jsonb_build_object(
+      'round_name', r.name,
+      'starts_at', r.starts_at
+    ),
+    'round_started:' ||
+      COALESCE(t.group_broadcast_id::text, r.tour_id::text, r.id::text) || ':' ||
+      EXTRACT(EPOCH FROM r.starts_at)::bigint::text
+  FROM public.rounds r
+  JOIN public.tours t ON t.id = r.tour_id
+  WHERE r.starts_at IS NOT NULL
+    AND r.starts_at <= now_ts
+    AND r.starts_at >= now_ts - interval '10 minutes'
+  ON CONFLICT (dedupe_key) DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;

--- a/test_notification_dispatch_dedupe.py
+++ b/test_notification_dispatch_dedupe.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 
 EDGE_FUNCTION = Path("supabase/functions/onesignal-dispatch/index.ts")
+ROUND_START_DEDUPE_MIGRATION = Path(
+    "supabase/migrations/024_grouped_round_start_exact_time_dedupe.sql"
+)
 
 
 def _source() -> str:
@@ -33,3 +36,39 @@ def test_game_notifications_have_device_collapse_id() -> None:
     assert "const collapseId = notificationCollapseId(notification)" in source
     assert "payload.collapse_id = collapseId" in source
     assert 'game:${type ?? "update"}:${gameId}' in source
+
+
+def test_round_started_uses_grouped_exact_start_collapse_id() -> None:
+    source = _source()
+
+    assert "function groupedRoundStartCollapseKey" in source
+    assert "round_started:${groupId}:${startsAt}" in source
+    assert "grouped_round_start_key: groupedRoundStartCollapseKey(context)" in source
+    assert "typeof groupedRoundStartKey" in source
+
+
+def test_dispatcher_skips_duplicate_grouped_round_starts() -> None:
+    source = _source()
+
+    assert "hasEarlierGroupedRoundStart(item, context)" in source
+    assert "duplicate_grouped_round_start" in source
+    assert '.eq("event_type", "round_started")' in source
+    assert '.eq("group_broadcast_id", groupId)' in source
+    assert '.contains("payload", { starts_at: startsAt })' in source
+
+
+def test_combined_tours_do_not_send_round_result_notifications() -> None:
+    source = _source()
+
+    assert 'item.event_type === "round_finished" && isCombinedTour(context.tour)' in source
+    assert "combined_round_results_suppressed" in source
+    assert "function isCombinedTour" in source
+
+
+def test_round_start_queue_dedupe_is_exact_group_start_time_not_two_hour_bucket() -> None:
+    migration = ROUND_START_DEDUPE_MIGRATION.read_text(encoding="utf-8")
+
+    assert "CREATE OR REPLACE FUNCTION public.queue_round_start_notifications()" in migration
+    assert "COALESCE(t.group_broadcast_id::text, r.tour_id::text, r.id::text)" in migration
+    assert "EXTRACT(EPOCH FROM r.starts_at)::bigint::text" in migration
+    assert "/ 7200" not in migration

--- a/test_notification_dispatch_dedupe.py
+++ b/test_notification_dispatch_dedupe.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+EDGE_FUNCTION = Path("supabase/functions/onesignal-dispatch/index.ts")
+
+
+def _source() -> str:
+    return EDGE_FUNCTION.read_text(encoding="utf-8")
+
+
+def test_onesignal_recipients_are_deduped_before_send() -> None:
+    source = _source()
+
+    assert "const uniqueUserIds = Array.from(new Set(userIds.filter(Boolean)))" in source
+    assert "const chunks = chunk(uniqueUserIds, 1000)" in source
+
+
+def test_game_started_notifications_do_not_reinclude_event_only_recipients() -> None:
+    source = _source()
+    game_block_start = source.index('if (eventType === "game_started")')
+    game_block_end = source.index('if (eventType === "game_finished")', game_block_start)
+    game_block = source[game_block_start:game_block_end]
+
+    assert "favorite_player_alerts" in game_block
+    assert "filtered.add(userId)" in game_block
+    assert "favorite_event_alerts" not in game_block
+    assert "isEventFav && eventAllowed" not in game_block
+
+
+def test_game_notifications_have_device_collapse_id() -> None:
+    source = _source()
+
+    assert "const collapseId = notificationCollapseId(notification)" in source
+    assert "payload.collapse_id = collapseId" in source
+    assert 'game:${type ?? "update"}:${gameId}' in source


### PR DESCRIPTION
## Summary
- Dedupe OneSignal external user IDs before every push send so a user matching both players in the same game is only targeted once.
- Add game/round collapse ids to notification payloads so duplicate device-level deliveries collapse for the same notification target.
- Keep game-start pushes scoped to favorite-player recipients only; event-starred users continue to get round/event-level notifications instead of a second game-start push.
- Collapse grouped-event round-start notifications by exact `group_broadcast_id + starts_at`, so Open/Women/Combined tours starting at the same time produce one visible start push.
- Suppress `round_finished` result notifications for tours named/sluggified as `Combined`, while keeping real Open/Women event-result notifications and favorite game-result notifications intact.

## Tests
- `pytest -q test_notification_dispatch_dedupe.py`
- `python3 -m py_compile test_notification_dispatch_dedupe.py`
- `git diff --check`
- `npm --cache /tmp/npm-cache exec --yes --package=esbuild esbuild -- supabase/functions/onesignal-dispatch/index.ts --bundle --platform=neutral --format=esm --external:jsr:* --external:npm:* --outfile=/tmp/onesignal-dispatch-check.js`
