### PR TITLE
Remove third-party product wording

### DIFF
--- a/lib/screens/chessboard/widgets/save_analysis_sheet.dart
+++ b/lib/screens/chessboard/widgets/save_analysis_sheet.dart
@@ -81,9 +81,7 @@ class _SaveAnalysisSheet extends ConsumerWidget {
             ],
             minFlingSpeed: 600.0,
           ),
-          builder: (context) => _SaveAnalysisPage(
-            config: config,
-          ),
+          builder: (context) => _SaveAnalysisPage(config: config),
         ),
       ],
     );
@@ -93,10 +91,7 @@ class _SaveAnalysisSheet extends ConsumerWidget {
         isContentScrollAware: true,
       ),
       child: PagedSheet(
-        decoration: ChessSheetDecoration.dark(
-          alpha: 0.97,
-          borderRadius: 28.sp,
-        ),
+        decoration: ChessSheetDecoration.dark(alpha: 0.97, borderRadius: 28.sp),
         shrinkChildToAvoidDynamicOverlap: true,
         navigator: navigator,
       ),
@@ -130,9 +125,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
   @override
   void initState() {
     super.initState();
-    _titleController = TextEditingController(
-      text: _generateDefaultTitle(),
-    );
+    _titleController = TextEditingController(text: _generateDefaultTitle());
     _newFolderNameController = TextEditingController();
     _titleFocusNode = FocusNode();
     _newFolderNameFocusNode = FocusNode();
@@ -196,7 +189,8 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
         final newFolderName = _newFolderNameController.text.trim();
         final newFolder = await repository.createFolder(
           name: newFolderName,
-          color: '#${_selectedFolderColor.toARGB32().toRadixString(16).substring(2)}',
+          color:
+              '#${_selectedFolderColor.toARGB32().toRadixString(16).substring(2)}',
         );
         targetFolderId = newFolder.id;
       }
@@ -330,7 +324,12 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 _buildHeader()
                     .animate()
                     .fadeIn(duration: 300.ms, delay: 50.ms)
-                    .slideY(begin: 0.1, end: 0, duration: 350.ms, curve: Curves.easeOutCubic),
+                    .slideY(
+                      begin: 0.1,
+                      end: 0,
+                      duration: 350.ms,
+                      curve: Curves.easeOutCubic,
+                    ),
 
                 SizedBox(height: 24.h),
 
@@ -338,7 +337,12 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 _buildTitleSection()
                     .animate()
                     .fadeIn(duration: 300.ms, delay: 100.ms)
-                    .slideY(begin: 0.1, end: 0, duration: 350.ms, curve: Curves.easeOutCubic),
+                    .slideY(
+                      begin: 0.1,
+                      end: 0,
+                      duration: 350.ms,
+                      curve: Curves.easeOutCubic,
+                    ),
 
                 SizedBox(height: 24.h),
 
@@ -346,7 +350,12 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 _buildFolderSection(foldersAsync)
                     .animate()
                     .fadeIn(duration: 300.ms, delay: 150.ms)
-                    .slideY(begin: 0.1, end: 0, duration: 350.ms, curve: Curves.easeOutCubic),
+                    .slideY(
+                      begin: 0.1,
+                      end: 0,
+                      duration: 350.ms,
+                      curve: Curves.easeOutCubic,
+                    ),
 
                 // Error messages
                 if (_errorMessage != null) ...[
@@ -363,7 +372,12 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 _buildActionButtons()
                     .animate()
                     .fadeIn(duration: 300.ms, delay: 200.ms)
-                    .slideY(begin: 0.1, end: 0, duration: 350.ms, curve: Curves.easeOutCubic),
+                    .slideY(
+                      begin: 0.1,
+                      end: 0,
+                      duration: 350.ms,
+                      curve: Curves.easeOutCubic,
+                    ),
 
                 SizedBox(height: 16.h),
               ],
@@ -490,9 +504,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
               focusNode: _titleFocusNode,
               enabled: !_isSaving,
               maxLength: 100,
-              style: AppTypography.textMdRegular.copyWith(
-                color: kWhiteColor,
-              ),
+              style: AppTypography.textMdRegular.copyWith(color: kWhiteColor),
               decoration: InputDecoration(
                 hintText: 'Enter a memorable title...',
                 hintStyle: AppTypography.textMdRegular.copyWith(
@@ -554,7 +566,10 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 onTap: _isSaving ? null : _toggleCreateNewFolder,
                 child: AnimatedContainer(
                   duration: const Duration(milliseconds: 200),
-                  padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 6.h),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 12.w,
+                    vertical: 6.h,
+                  ),
                   decoration: BoxDecoration(
                     color: _isCreatingNewFolder
                         ? kPrimaryColor.withValues(alpha: 0.15)
@@ -604,15 +619,15 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
             transitionBuilder: (child, animation) {
               return FadeTransition(
                 opacity: animation,
-                child: SizeTransition(
-                  sizeFactor: animation,
-                  child: child,
-                ),
+                child: SizeTransition(sizeFactor: animation, child: child),
               );
             },
             child: _isCreatingNewFolder
                 ? _buildNewFolderInput(key: const ValueKey('new_folder'))
-                : _buildFolderList(foldersAsync, key: const ValueKey('folder_list')),
+                : _buildFolderList(
+                    foldersAsync,
+                    key: const ValueKey('folder_list'),
+                  ),
           ),
         ],
       ),
@@ -641,9 +656,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
             focusNode: _newFolderNameFocusNode,
             enabled: !_isSaving,
             maxLength: 50,
-            style: AppTypography.textMdRegular.copyWith(
-              color: kWhiteColor,
-            ),
+            style: AppTypography.textMdRegular.copyWith(color: kWhiteColor),
             decoration: InputDecoration(
               hintText: 'Folder name',
               hintStyle: AppTypography.textMdRegular.copyWith(
@@ -721,10 +734,14 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                         width: 36.w,
                         height: 36.h,
                         decoration: BoxDecoration(
-                          color: color.withValues(alpha: 0.2 + (animValue * 0.3)),
+                          color: color.withValues(
+                            alpha: 0.2 + (animValue * 0.3),
+                          ),
                           shape: BoxShape.circle,
                           border: Border.all(
-                            color: color.withValues(alpha: 0.5 + (animValue * 0.5)),
+                            color: color.withValues(
+                              alpha: 0.5 + (animValue * 0.5),
+                            ),
                             width: 2 + animValue,
                           ),
                           boxShadow: isSelected
@@ -756,7 +773,10 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
     );
   }
 
-  Widget _buildFolderList(AsyncValue<List<LibraryFolder>> foldersAsync, {Key? key}) {
+  Widget _buildFolderList(
+    AsyncValue<List<LibraryFolder>> foldersAsync, {
+    Key? key,
+  }) {
     return foldersAsync.when(
       data: (folders) => _buildFolderListContent(folders, key: key),
       loading: () => _buildFolderListLoading(key: key),
@@ -820,11 +840,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(
-                      Icons.add_rounded,
-                      size: 16.sp,
-                      color: kPrimaryColor,
-                    ),
+                    Icon(Icons.add_rounded, size: 16.sp, color: kPrimaryColor),
                     SizedBox(width: 6.w),
                     Text(
                       'Create Folder',
@@ -927,9 +943,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
       decoration: BoxDecoration(
         color: kRedColor.withValues(alpha: 0.08),
         borderRadius: BorderRadius.circular(16.br),
-        border: Border.all(
-          color: kRedColor.withValues(alpha: 0.2),
-        ),
+        border: Border.all(color: kRedColor.withValues(alpha: 0.2)),
       ),
       child: Row(
         children: [
@@ -967,9 +981,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
         decoration: BoxDecoration(
           color: kRedColor.withValues(alpha: 0.08),
           borderRadius: BorderRadius.circular(14.br),
-          border: Border.all(
-            color: kRedColor.withValues(alpha: 0.2),
-          ),
+          border: Border.all(color: kRedColor.withValues(alpha: 0.2)),
         ),
         child: Row(
           children: [
@@ -1006,7 +1018,8 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
     // - A folder is selected, OR new folder mode is on with a non-empty name
     final trimmedNewFolderName = _newFolderNameController.text.trim();
     final hasExistingFolder = _selectedFolder != null;
-    final hasValidNewFolderName = _isCreatingNewFolder && trimmedNewFolderName.isNotEmpty;
+    final hasValidNewFolderName =
+        _isCreatingNewFolder && trimmedNewFolderName.isNotEmpty;
     final canSave = !_isSaving && (hasValidNewFolderName || hasExistingFolder);
 
     return Padding(
@@ -1027,9 +1040,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 decoration: BoxDecoration(
                   color: kWhiteColor.withValues(alpha: 0.05),
                   borderRadius: BorderRadius.circular(14.br),
-                  border: Border.all(
-                    color: kWhiteColor.withValues(alpha: 0.1),
-                  ),
+                  border: Border.all(color: kWhiteColor.withValues(alpha: 0.1)),
                 ),
                 child: Center(
                   child: Text(
@@ -1069,7 +1080,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                                 end: Alignment.bottomRight,
                               )
                             : null,
-                        color: canSave ? null : kWhiteColor.withValues(alpha: 0.08),
+                        color: canSave
+                            ? null
+                            : kWhiteColor.withValues(alpha: 0.08),
                         borderRadius: BorderRadius.circular(14.br),
                         boxShadow: canSave
                             ? [
@@ -1108,8 +1121,8 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                                     canSave
                                         ? 'Save Analysis'
                                         : _isCreatingNewFolder
-                                            ? 'Name your folder'
-                                            : 'Select a Folder',
+                                        ? 'Name your folder'
+                                        : 'Select a Folder',
                                     style: AppTypography.textSmBold.copyWith(
                                       color: canSave
                                           ? kWhiteColor
@@ -1181,10 +1194,14 @@ class _FolderListItem extends StatelessWidget {
                 Container(
                   padding: EdgeInsets.all(8.sp),
                   decoration: BoxDecoration(
-                    color: folderColor.withValues(alpha: 0.12 + (animValue * 0.08)),
+                    color: folderColor.withValues(
+                      alpha: 0.12 + (animValue * 0.08),
+                    ),
                     borderRadius: BorderRadius.circular(10.br),
                     border: Border.all(
-                      color: folderColor.withValues(alpha: 0.2 + (animValue * 0.2)),
+                      color: folderColor.withValues(
+                        alpha: 0.2 + (animValue * 0.2),
+                      ),
                       width: 1,
                     ),
                   ),
@@ -1243,7 +1260,9 @@ class _FolderListItem extends StatelessWidget {
 }
 
 /// Provider to fetch folders for the current user
-final _foldersProvider = FutureProvider.autoDispose<List<LibraryFolder>>((ref) async {
+final _foldersProvider = FutureProvider.autoDispose<List<LibraryFolder>>((
+  ref,
+) async {
   final repository = ref.watch(libraryRepositoryProvider);
   return repository.getFolders();
 });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -913,26 +913,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1606,10 +1606,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   timezone:
     dependency: transitive
     description:
@@ -1851,5 +1851,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"


### PR DESCRIPTION
## Summary
- Replaces remaining named third-party database product wording in comments/source labels with neutral reference/legacy database wording.
- Keeps the existing URL source detection behavior without exposing the product name in source text.

## Why
Vasif asked us to reduce avoidable trademark/copying optics in public GitHub text.

## Verification
- `git grep -i -n "<removed third-party product term>" -- . ':(exclude)pubspec.lock' ':(exclude).dart_tool' ':(exclude)build'` → no matches
- `flutter analyze lib/screens/chessboard/widgets/save_analysis_sheet.dart lib/utils/location_service_provider.dart`
- `git diff --check`