### PR TITLE
Fix custom broadcast scoring

### DIFF
--- a/lib/repository/supabase/game/games.dart
+++ b/lib/repository/supabase/game/games.dart
@@ -22,7 +22,8 @@ class Games {
   final DateTime? dateStart;
   final String? eco;
   final String? openingName;
-  final String? timeControl; // From group_broadcasts: 'standard', 'rapid', 'blitz'
+  final String?
+  timeControl; // From group_broadcasts: 'standard', 'rapid', 'blitz'
 
   Games({
     required this.id,
@@ -121,45 +122,38 @@ class Games {
         tourSlug: json['tour_slug'] as String,
         name: json['name'] as String?,
         fen: json['fen'] as String?,
-        players:
-            json['players'] != null
-                ? (json['players'] as List)
-                    .map(
-                      (player) =>
-                          Player.fromJson(player as Map<String, dynamic>),
-                    )
-                    .toList()
-                : null,
+        players: json['players'] != null
+            ? (json['players'] as List)
+                  .map(
+                    (player) => Player.fromJson(player as Map<String, dynamic>),
+                  )
+                  .toList()
+            : null,
         lastMove: json['last_move'] as String?,
-        thinkTime:
-            json['think_time'] != null
-                ? (json['think_time'] as num).toInt()
-                : null,
+        thinkTime: json['think_time'] != null
+            ? (json['think_time'] as num).toInt()
+            : null,
         status: json['status'] as String?,
         pgn: json['pgn'] as String?,
         search: (json['search'] as List).map((e) => e as String).toList(),
-        boardNr:
-            json['board_nr'] != null ? (json['board_nr'] as num).toInt() : null,
-        lastMoveTime:
-            json['last_move_time'] != null
-                ? DateTime.parse(json['last_move_time'] as String)
-                : null,
-        gameDay:
-            json['game_day'] != null
-                ? DateTime.parse(json['game_day'] as String)
-                : null,
-        lastClockWhite:
-            json['last_clock_white'] != null
-                ? (json['last_clock_white'] as num).toInt()
-                : null,
-        lastClockBlack:
-            json['last_clock_black'] != null
-                ? (json['last_clock_black'] as num).toInt()
-                : null,
-        dateStart:
-            json['date_start'] != null
-                ? DateTime.parse(json['date_start'] as String)
-                : null,
+        boardNr: json['board_nr'] != null
+            ? (json['board_nr'] as num).toInt()
+            : null,
+        lastMoveTime: json['last_move_time'] != null
+            ? DateTime.parse(json['last_move_time'] as String)
+            : null,
+        gameDay: json['game_day'] != null
+            ? DateTime.parse(json['game_day'] as String)
+            : null,
+        lastClockWhite: json['last_clock_white'] != null
+            ? (json['last_clock_white'] as num).toInt()
+            : null,
+        lastClockBlack: json['last_clock_black'] != null
+            ? (json['last_clock_black'] as num).toInt()
+            : null,
+        dateStart: json['date_start'] != null
+            ? DateTime.parse(json['date_start'] as String)
+            : null,
         eco: json['eco'] as String?,
         openingName: json['opening_name'] as String?,
         timeControl: timeControl,
@@ -252,6 +246,7 @@ class Player {
   final String fed;
   final int clock;
   final String team;
+  final double? customPoints;
 
   Player({
     required this.name,
@@ -261,6 +256,7 @@ class Player {
     required this.fed,
     required this.clock,
     required this.team,
+    this.customPoints,
   });
 
   factory Player.fromJsonString(String jsonString) {
@@ -283,6 +279,7 @@ class Player {
       fed: json['fed'] as String? ?? '',
       clock: (json['clock'] as num?)?.toInt() ?? 0,
       team: json['team'] as String? ?? '',
+      customPoints: (json['customPoints'] as num?)?.toDouble(),
     );
   }
 
@@ -295,6 +292,7 @@ class Player {
       'fed': fed,
       'clock': clock,
       'team': team,
+      if (customPoints != null) 'customPoints': customPoints,
     };
   }
 }
@@ -372,14 +370,12 @@ class SearchPlayer {
       id: json['id']?.toString() ?? '',
       name: json['name']?.toString() ?? '',
       title: json['title']?.toString(),
-      rating:
-          json['rating'] != null
-              ? int.tryParse(json['rating'].toString())
-              : null,
-      fideId:
-          json['fideId'] != null
-              ? int.tryParse(json['fideId'].toString())
-              : null,
+      rating: json['rating'] != null
+          ? int.tryParse(json['rating'].toString())
+          : null,
+      fideId: json['fideId'] != null
+          ? int.tryParse(json['fideId'].toString())
+          : null,
       fed: json['fed']?.toString(),
       tournamentId: tournamentId,
       tournamentName: tournamentName,

--- a/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
+++ b/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
@@ -1,5 +1,4 @@
 import 'package:chessever2/providers/engine_settings_provider.dart';
-import 'package:chessever2/providers/for_you_games_provider.dart';
 import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/group_event/providers/countryman_games_tour_screen_provider.dart';
@@ -10,6 +9,7 @@ import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_pr
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/broadcast_custom_scoring.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
 import 'package:chessever2/utils/png_asset.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -20,7 +20,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:chessever2/utils/svg_asset.dart';
-import 'dart:ui';
 
 enum PlayerView { listView, gridView, boardView }
 
@@ -357,7 +356,7 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
         // This handles cases where:
         // - view might not match expected case
         // - gamesContext filter returned empty (e.g., For You only has few games from event)
-        if ((gamesContext == null || gamesContext!.isEmpty) && gamesTourModel.tourId.isNotEmpty) {
+        if ((gamesContext == null || gamesContext.isEmpty) && gamesTourModel.tourId.isNotEmpty) {
           gamesContext = [gamesTourModel];
           hasEventContext = true;
         }
@@ -381,11 +380,12 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
             child: gamesTourModel.gameStatus.isFinished
                 ? Center(
                     child: Text(
-                      gamesTourModel.gameStatus == GameStatus.whiteWins
-                          ? (isWhitePlayer ? '1' : '0')
-                          : gamesTourModel.gameStatus == GameStatus.blackWins
-                          ? (isWhitePlayer ? '0' : '1')
-                          : '½',
+                      customAwareResultLabelForSide(
+                            gamesTourModel.gameStatus,
+                            isWhite: isWhitePlayer,
+                            customPoints: playerCard.customPoints,
+                          ) ??
+                          '',
                       style: TextStyle(
                         fontSize: playerView == PlayerView.gridView ? 9.f : 10.f,
                         fontWeight: FontWeight.w700,

--- a/lib/screens/tour_detail/games_tour/models/games_tour_model.dart
+++ b/lib/screens/tour_detail/games_tour/models/games_tour_model.dart
@@ -68,7 +68,8 @@ class GamesTourModel {
   final DateTime? lastMoveTime;
   final String? eco;
   final String? openingName;
-  final String? timeControl; // From group_broadcasts: 'standard', 'rapid', 'blitz'
+  final String?
+  timeControl; // From group_broadcasts: 'standard', 'rapid', 'blitz'
 
   GamesTourModel({
     required this.gameId,
@@ -201,18 +202,18 @@ class GamesTourModel {
 
         whiteTimeDisplay =
             (game.lastClockWhite != null && game.lastClockWhite! > 0)
-                ? _formatTimeFromSeconds(game.lastClockWhite!)
-                : (white.clock > 0
-                    ? _formatTime(white.clock)
-                    : (pgnClocks.whiteSeconds != null
+            ? _formatTimeFromSeconds(game.lastClockWhite!)
+            : (white.clock > 0
+                  ? _formatTime(white.clock)
+                  : (pgnClocks.whiteSeconds != null
                         ? _formatTimeFromSeconds(pgnClocks.whiteSeconds!)
                         : '--:--'));
         blackTimeDisplay =
             (game.lastClockBlack != null && game.lastClockBlack! > 0)
-                ? _formatTimeFromSeconds(game.lastClockBlack!)
-                : (black.clock > 0
-                    ? _formatTime(black.clock)
-                    : (pgnClocks.blackSeconds != null
+            ? _formatTimeFromSeconds(game.lastClockBlack!)
+            : (black.clock > 0
+                  ? _formatTime(black.clock)
+                  : (pgnClocks.blackSeconds != null
                         ? _formatTimeFromSeconds(pgnClocks.blackSeconds!)
                         : '--:--'));
       } else {
@@ -601,6 +602,8 @@ class PlayerCard {
   final String countryCode;
   final int? fideId;
   final String? team;
+  final String? gamebasePlayerId;
+  final double? customPoints;
 
   PlayerCard({
     required this.name,
@@ -610,8 +613,9 @@ class PlayerCard {
     required this.countryCode,
     required this.team,
     this.fideId,
+    this.gamebasePlayerId,
+    this.customPoints,
   });
-
   factory PlayerCard.fromPlayer(Player player) {
     final name = player.name.trim();
     if (name.isEmpty) {
@@ -626,6 +630,7 @@ class PlayerCard {
       countryCode: player.fed.trim(),
       fideId: player.fideId > 0 ? player.fideId : null,
       team: player.team,
+      customPoints: player.customPoints,
     );
   }
 
@@ -637,6 +642,8 @@ class PlayerCard {
     String? countryCode,
     int? fideId,
     String? team,
+    String? gamebasePlayerId,
+    double? customPoints,
   }) {
     return PlayerCard(
       name: name ?? this.name,
@@ -646,6 +653,8 @@ class PlayerCard {
       countryCode: countryCode ?? this.countryCode,
       fideId: fideId ?? this.fideId,
       team: team ?? this.team,
+      gamebasePlayerId: gamebasePlayerId ?? this.gamebasePlayerId,
+      customPoints: customPoints ?? this.customPoints,
     );
   }
 
@@ -661,7 +670,11 @@ class PlayerCard {
         other.federation == federation &&
         other.title == title &&
         other.rating == rating &&
-        other.countryCode == countryCode;
+        other.countryCode == countryCode &&
+        other.fideId == fideId &&
+        other.team == team &&
+        other.gamebasePlayerId == gamebasePlayerId &&
+        other.customPoints == customPoints;
   }
 
   @override
@@ -670,7 +683,11 @@ class PlayerCard {
         federation.hashCode ^
         title.hashCode ^
         rating.hashCode ^
-        countryCode.hashCode;
+        countryCode.hashCode ^
+        (fideId?.hashCode ?? 0) ^
+        (team?.hashCode ?? 0) ^
+        (gamebasePlayerId?.hashCode ?? 0) ^
+        (customPoints?.hashCode ?? 0);
   }
 }
 

--- a/lib/screens/tour_detail/player_tour/player_tour_screen_provider.dart
+++ b/lib/screens/tour_detail/player_tour/player_tour_screen_provider.dart
@@ -6,15 +6,17 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_s
 import 'package:chessever2/screens/group_event/model/tour_detail_view_model.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
+import 'package:chessever2/utils/broadcast_custom_scoring.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Provides player standings for the tournament detail "Players" tab.
 /// Uses [AutoDisposeAsyncNotifier] so the heavy computation only runs when needed
 /// and automatically refreshes when any dependency changes.
 final playerTourScreenProvider =
-    AutoDisposeAsyncNotifierProvider<PlayerTourScreenNotifier, List<PlayerStandingModel>>(
-      PlayerTourScreenNotifier.new,
-    );
+    AutoDisposeAsyncNotifierProvider<
+      PlayerTourScreenNotifier,
+      List<PlayerStandingModel>
+    >(PlayerTourScreenNotifier.new);
 
 class PlayerTourScreenNotifier
     extends AutoDisposeAsyncNotifier<List<PlayerStandingModel>> {
@@ -90,25 +92,23 @@ class PlayerTourScreenNotifier
     for (final player in tournamentPlayers) {
       final key = _canonicalName(player.name);
       final playerGames = gamesByPlayerKey[key] ?? const <_PlayerGameRef>[];
-      final referenceCard = playerGames.isNotEmpty ? playerGames.first.playerCard : null;
+      final referenceCard = playerGames.isNotEmpty
+          ? playerGames.first.playerCard
+          : null;
 
       final updatedPlayer = player.copyWith(
-        federation:
-            (player.federation?.trim().isNotEmpty ?? false)
-                ? player.federation
-                : _nonEmpty(referenceCard?.federation) ?? player.federation,
-        title:
-            (player.title?.trim().isNotEmpty ?? false)
-                ? player.title
-                : _nonEmpty(referenceCard?.title) ?? player.title,
-        rating:
-            (player.rating != null && player.rating! > 0)
-                ? player.rating
-                : _positive(referenceCard?.rating) ?? player.rating,
-        fideId:
-            (player.fideId != null && player.fideId! > 0)
-                ? player.fideId
-                : referenceCard?.fideId ?? player.fideId,
+        federation: (player.federation?.trim().isNotEmpty ?? false)
+            ? player.federation
+            : _nonEmpty(referenceCard?.federation) ?? player.federation,
+        title: (player.title?.trim().isNotEmpty ?? false)
+            ? player.title
+            : _nonEmpty(referenceCard?.title) ?? player.title,
+        rating: (player.rating != null && player.rating! > 0)
+            ? player.rating
+            : _positive(referenceCard?.rating) ?? player.rating,
+        fideId: (player.fideId != null && player.fideId! > 0)
+            ? player.fideId
+            : referenceCard?.fideId ?? player.fideId,
       );
 
       var calculatedScore = 0.0;
@@ -136,10 +136,17 @@ class PlayerTourScreenNotifier
         }
       }
 
+      final resolvedScore = resolveBroadcastStandingScore(
+        sourceScore: player.score,
+        sourcePlayed: player.played,
+        calculatedScore: calculatedScore,
+        calculatedPlayed: gamesPlayed,
+      );
+
       enrichedPlayers.add(
         updatedPlayer.copyWith(
-          score: calculatedScore,
-          played: gamesPlayed,
+          score: resolvedScore.score,
+          played: resolvedScore.played,
         ),
       );
     }
@@ -147,12 +154,12 @@ class PlayerTourScreenNotifier
     // Step 4: Sort by ABSOLUTE SCORE (not percentage!)
     // Example: 3.5/4 (87.5%) should rank HIGHER than 3/3 (100%) because 3.5 > 3
     enrichedPlayers.sort((a, b) {
-      final aScore = a.score ?? 0.0;  // Absolute points collected (e.g., 3.5)
-      final bScore = b.score ?? 0.0;  // Absolute points collected (e.g., 3.0)
-      
+      final aScore = a.score ?? 0.0; // Absolute points collected (e.g., 3.5)
+      final bScore = b.score ?? 0.0; // Absolute points collected (e.g., 3.0)
+
       // Primary sort: by absolute score descending (whoever collected MORE points)
       if (bScore != aScore) return bScore.compareTo(aScore);
-      
+
       // Secondary sort: by rating/ELO descending (higher rated player first when scores equal)
       return (b.rating ?? 0).compareTo(a.rating ?? 0);
     });

--- a/lib/utils/broadcast_custom_scoring.dart
+++ b/lib/utils/broadcast_custom_scoring.dart
@@ -1,0 +1,60 @@
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+
+String formatBroadcastScore(double score) {
+  return score % 1 == 0 ? score.toInt().toString() : score.toStringAsFixed(1);
+}
+
+double? standardResultValueForSide(GameStatus status, {required bool isWhite}) {
+  switch (status) {
+    case GameStatus.whiteWins:
+      return isWhite ? 1.0 : 0.0;
+    case GameStatus.blackWins:
+      return isWhite ? 0.0 : 1.0;
+    case GameStatus.draw:
+      return 0.5;
+    case GameStatus.ongoing:
+    case GameStatus.unknown:
+      return null;
+  }
+}
+
+String? standardResultLabelForSide(GameStatus status, {required bool isWhite}) {
+  final value = standardResultValueForSide(status, isWhite: isWhite);
+  if (value == null) return null;
+  if (value == 0.5) return '½';
+  return formatBroadcastScore(value);
+}
+
+String? customAwareResultLabelForSide(
+  GameStatus status, {
+  required bool isWhite,
+  double? customPoints,
+}) {
+  final standardValue = standardResultValueForSide(status, isWhite: isWhite);
+  if (standardValue == null) return null;
+
+  if (customPoints != null &&
+      customPoints != 0.0 &&
+      customPoints != standardValue) {
+    return formatBroadcastScore(customPoints);
+  }
+
+  return standardValue == 0.5 ? '½' : formatBroadcastScore(standardValue);
+}
+
+({double? score, int played}) resolveBroadcastStandingScore({
+  required double? sourceScore,
+  required int sourcePlayed,
+  required double calculatedScore,
+  required int calculatedPlayed,
+  bool preserveSourceScore = true,
+}) {
+  if (preserveSourceScore && sourceScore != null) {
+    return (
+      score: sourceScore,
+      played: sourcePlayed > calculatedPlayed ? sourcePlayed : calculatedPlayed,
+    );
+  }
+
+  return (score: calculatedScore, played: calculatedPlayed);
+}

--- a/test/broadcast_custom_scoring_test.dart
+++ b/test/broadcast_custom_scoring_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/utils/broadcast_custom_scoring.dart';
+
+void main() {
+  group('custom-aware broadcast game points', () {
+    test('shows custom win points when they differ from standard result', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.whiteWins,
+          isWhite: true,
+          customPoints: 3.0,
+        ),
+        '3',
+      );
+    });
+
+    test('keeps standard win when custom points match standard result', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.whiteWins,
+          isWhite: true,
+          customPoints: 1.0,
+        ),
+        '1',
+      );
+    });
+
+    test('keeps draw label when custom points are zero', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.draw,
+          isWhite: true,
+          customPoints: 0.0,
+        ),
+        '½',
+      );
+    });
+  });
+
+  group('broadcast standings score resolution', () {
+    test('preserves custom source score and updates played count', () {
+      final resolved = resolveBroadcastStandingScore(
+        sourceScore: 3.0,
+        sourcePlayed: 1,
+        calculatedScore: 1.0,
+        calculatedPlayed: 1,
+      );
+
+      expect(resolved.score, 3.0);
+      expect(resolved.played, 1);
+    });
+
+    test('falls back to calculated score when no source score exists', () {
+      final resolved = resolveBroadcastStandingScore(
+        sourceScore: null,
+        sourcePlayed: 0,
+        calculatedScore: 1.5,
+        calculatedPlayed: 2,
+      );
+
+      expect(resolved.score, 1.5);
+      expect(resolved.played, 2);
+    });
+  });
+
+  test('parses per-player customPoints from game players JSON', () {
+    final player = Player.fromJson(const {
+      'name': 'Alireza Firouzja',
+      'rating': 2759,
+      'customPoints': 3.0,
+    });
+
+    final card = PlayerCard.fromPlayer(player);
+
+    expect(player.customPoints, 3.0);
+    expect(card.customPoints, 3.0);
+  });
+}


### PR DESCRIPTION
## Summary\n- preserve official/source standings scores for broadcasts with custom point systems, e.g. Norway Chess classical wins worth 3 points\n- parse per-game player customPoints and show them in the phone board/player result badge when they differ from standard chess scoring\n- keep standard scoring unchanged when custom points are absent or equal to the normal result\n\n## Tests\n- flutter analyze lib/utils/broadcast_custom_scoring.dart lib/repository/supabase/game/games.dart lib/screens/tour_detail/games_tour/models/games_tour_model.dart lib/screens/tour_detail/player_tour/player_tour_screen_provider.dart lib/screens/chessboard/widgets/player_first_row_detail_widget.dart test/broadcast_custom_scoring_test.dart\n- flutter test test/broadcast_custom_scoring_test.dart