### PR TITLE
Fix phone event refresh missing later rounds

### DIFF
--- a/lib/repository/supabase/game/game_repository.dart
+++ b/lib/repository/supabase/game/game_repository.dart
@@ -65,6 +65,16 @@ const String _gameListSelectColumns = '''
           tours!games_tour_id_fkey(group_broadcasts!tours_group_broadcast_id_fkey(time_control))
         ''';
 
+const int _tourGamesFetchPageSize = 1000;
+
+@visibleForTesting
+bool shouldFetchAnotherTourGamesPage(
+  int fetchedCount, {
+  int pageSize = _tourGamesFetchPageSize,
+}) {
+  return fetchedCount == pageSize;
+}
+
 class GameRepository extends BaseRepository {
   List<int> _parseFideIds(List<String> fideIds) {
     return fideIds.map((id) => int.tryParse(id)).whereType<int>().toList();
@@ -96,20 +106,45 @@ class GameRepository extends BaseRepository {
     int offset = 0,
   }) async {
     return handleApiCall(() async {
-      var query = supabase
-          .from('games')
-          .select(_gameListSelectColumns)
-          .eq('tour_id', tourId)
-          .order('id', ascending: true);
+      final jsonList = <String>[];
+      var pageOffset = offset;
+      var remaining = limit;
 
-      if (limit != null) {
-        query = query.range(offset, offset + limit - 1);
+      while (true) {
+        final pageSize =
+            remaining == null || remaining > _tourGamesFetchPageSize
+                ? _tourGamesFetchPageSize
+                : remaining;
+        if (pageSize <= 0) {
+          break;
+        }
+
+        final response = await supabase
+            .from('games')
+            .select(_gameListSelectColumns)
+            .eq('tour_id', tourId)
+            .order('id', ascending: true)
+            .range(pageOffset, pageOffset + pageSize - 1);
+
+        final responseList = response as List;
+        jsonList.addAll(responseList.map((item) => json.encode(item)));
+
+        if (!shouldFetchAnotherTourGamesPage(
+          responseList.length,
+          pageSize: pageSize,
+        )) {
+          break;
+        }
+
+        if (remaining != null) {
+          remaining -= responseList.length;
+          if (remaining <= 0) {
+            break;
+          }
+        }
+
+        pageOffset += responseList.length;
       }
-
-      final response = await query;
-
-      final jsonList =
-          (response as List).map((item) => json.encode(item)).toList();
 
       final games = await compute(_decodeGamesInIsolate, jsonList);
 

--- a/test/game_repository_tour_games_pagination_test.dart
+++ b/test/game_repository_tour_games_pagination_test.dart
@@ -1,0 +1,20 @@
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldFetchAnotherTourGamesPage', () {
+    test('continues when Supabase returns a full page', () {
+      expect(shouldFetchAnotherTourGamesPage(1000), isTrue);
+    });
+
+    test('stops when Supabase returns a partial page', () {
+      expect(shouldFetchAnotherTourGamesPage(999), isFalse);
+      expect(shouldFetchAnotherTourGamesPage(0), isFalse);
+    });
+
+    test('honors smaller explicit requested page sizes', () {
+      expect(shouldFetchAnotherTourGamesPage(25, pageSize: 25), isTrue);
+      expect(shouldFetchAnotherTourGamesPage(24, pageSize: 25), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fetch tournament games by tour id in explicit 1000-row pages instead of relying on the default Supabase/PostgREST page.
- Preserve existing limit/offset behavior for callers that request a bounded page.
- Add a focused pagination continuation test.

## Why
Large live broadcasts such as Titled Tuesday can exceed the default 1000-row response. The phone app then keeps refreshing/reopening the event with only the first page of games, so later live rounds do not appear even though desktop can show them.

## Tests
- `git diff --check`
- `flutter test test/game_repository_tour_games_pagination_test.dart`
- `flutter analyze lib/repository/supabase/game/game_repository.dart test/game_repository_tour_games_pagination_test.dart` *(fails on pre-existing warnings/infos in game_repository.dart: avoid_print, unnecessary_null_comparison/type_check, unused_element; no new issue from the changed pagination helper/path observed)*
