### PR TITLE
Add phone board coordinates toggle

### DIFF
--- a/lib/providers/board_settings_provider_new.dart
+++ b/lib/providers/board_settings_provider_new.dart
@@ -32,6 +32,7 @@ class BoardSettingsNew {
     this.pieceStyleIndex = 0, // Now used for chessground PieceSet
     this.gamesListViewModeIndex = 0,
     this.useFigurine = false, // Use chess piece symbols (♔♕♖♗♘) instead of letters
+    this.enableCoordinates = true, // Show board edge coordinates (A-H, 1-8)
   });
 
   /// DEPRECATED: Kept for backwards compatibility migration only
@@ -47,6 +48,8 @@ class BoardSettingsNew {
   final int gamesListViewModeIndex;
   /// Use figurine notation (chess piece symbols) instead of letters (K, Q, R, B, N)
   final bool useFigurine;
+  /// Show board edge coordinates (A-H files and 1-8 ranks)
+  final bool enableCoordinates;
 
   /// Get the current piece set from chessground
   PieceSet get pieceSet => getPieceSetByIndex(pieceStyleIndex);
@@ -114,6 +117,7 @@ class BoardSettingsNew {
     int? pieceStyleIndex,
     int? gamesListViewModeIndex,
     bool? useFigurine,
+    bool? enableCoordinates,
   }) {
     return BoardSettingsNew(
       boardColorIndex: boardColorIndex ?? this.boardColorIndex,
@@ -124,6 +128,7 @@ class BoardSettingsNew {
       pieceStyleIndex: pieceStyleIndex ?? this.pieceStyleIndex,
       gamesListViewModeIndex: gamesListViewModeIndex ?? this.gamesListViewModeIndex,
       useFigurine: useFigurine ?? this.useFigurine,
+      enableCoordinates: enableCoordinates ?? this.enableCoordinates,
     );
   }
 }
@@ -195,6 +200,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         pieceStyleIndex: model.pieceStyleIndex,
         gamesListViewModeIndex: model.gamesListViewModeIndex,
         useFigurine: model.useFigurine,
+        enableCoordinates: model.enableCoordinates,
       );
 
       // Cache locally
@@ -305,6 +311,15 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
     await _persist(newSettings);
   }
 
+  /// Toggle board edge coordinates (A-H, 1-8)
+  Future<void> toggleCoordinates(bool value) async {
+    final currentState = state.valueOrNull ?? const BoardSettingsNew();
+    final newSettings = currentState.copyWith(enableCoordinates: value);
+    debugPrint('🔲 BoardSettings: Board coordinates ${value ? 'enabled' : 'disabled'}');
+    state = AsyncValue.data(newSettings);
+    await _persist(newSettings);
+  }
+
   /// Refresh settings from Supabase
   Future<void> refresh() async {
     state = const AsyncValue.loading();
@@ -362,6 +377,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
           'piece_style_index': settings.pieceStyleIndex,
           'games_list_view_mode_index': settings.gamesListViewModeIndex,
           'use_figurine': settings.useFigurine,
+          'enable_coordinates': settings.enableCoordinates,
           'updated_at': DateTime.now().toUtc().toIso8601String(),
         },
         onConflict: 'user_id', // Specify conflict column
@@ -385,6 +401,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         'pieceStyleIndex': settings.pieceStyleIndex,
         'gamesListViewModeIndex': settings.gamesListViewModeIndex,
         'useFigurine': settings.useFigurine,
+        'enableCoordinates': settings.enableCoordinates,
       });
       await db.setString(_cacheKey, json);
       debugPrint('[BoardSettings] Cached settings locally');
@@ -422,6 +439,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         pieceStyleIndex: map['pieceStyleIndex'] as int? ?? 0,
         gamesListViewModeIndex: map['gamesListViewModeIndex'] as int? ?? 0,
         useFigurine: map['useFigurine'] as bool? ?? false,
+        enableCoordinates: map['enableCoordinates'] as bool? ?? true,
       );
       debugPrint('[BoardSettings] Loaded settings from cache');
       return settings;

--- a/lib/repository/board_settings/models/board_settings_model.dart
+++ b/lib/repository/board_settings/models/board_settings_model.dart
@@ -14,6 +14,7 @@ class BoardSettingsModel with BoardSettingsModelMappable {
   final int pieceStyleIndex; // Index into chessground's PieceSet
   final int gamesListViewModeIndex; // 0=gamesCard, 1=chessBoardGrid, 2=chessBoard
   final bool useFigurine; // Use chess piece symbols (♔♕♖♗♘) instead of letters
+  final bool enableCoordinates; // Show board edge coordinates (A-H, 1-8)
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -28,6 +29,7 @@ class BoardSettingsModel with BoardSettingsModelMappable {
     required this.pieceStyleIndex,
     required this.gamesListViewModeIndex,
     required this.useFigurine,
+    required this.enableCoordinates,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -46,6 +48,7 @@ class BoardSettingsModel with BoardSettingsModelMappable {
       pieceStyleIndex: json['piece_style_index'] as int? ?? 0,
       gamesListViewModeIndex: json['games_list_view_mode_index'] as int? ?? 1, // Default to chessBoardGrid
       useFigurine: json['use_figurine'] as bool? ?? false,
+      enableCoordinates: json['enable_coordinates'] as bool? ?? true,
       createdAt: DateTime.parse(json['created_at'] as String),
       updatedAt: DateTime.parse(json['updated_at'] as String),
     );
@@ -64,6 +67,7 @@ class BoardSettingsModel with BoardSettingsModelMappable {
       'piece_style_index': pieceStyleIndex,
       'games_list_view_mode_index': gamesListViewModeIndex,
       'use_figurine': useFigurine,
+      'enable_coordinates': enableCoordinates,
       'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),
     };
@@ -81,6 +85,7 @@ class BoardSettingsModel with BoardSettingsModelMappable {
       'piece_style_index': pieceStyleIndex,
       'games_list_view_mode_index': gamesListViewModeIndex,
       'use_figurine': useFigurine,
+      'enable_coordinates': enableCoordinates,
     };
   }
 
@@ -97,6 +102,7 @@ class BoardSettingsModel with BoardSettingsModelMappable {
       pieceStyleIndex: 0, // cburnett (default)
       gamesListViewModeIndex: 1, // chessBoardGrid view (default)
       useFigurine: false, // Use letters by default
+      enableCoordinates: true, // Show board coordinates by default
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     );

--- a/lib/repository/board_settings/models/board_settings_model.mapper.dart
+++ b/lib/repository/board_settings/models/board_settings_model.mapper.dart
@@ -69,6 +69,11 @@ class BoardSettingsModelMapper extends ClassMapperBase<BoardSettingsModel> {
     'useFigurine',
     _$useFigurine,
   );
+  static bool _$enableCoordinates(BoardSettingsModel v) => v.enableCoordinates;
+  static const Field<BoardSettingsModel, bool> _f$enableCoordinates = Field(
+    'enableCoordinates',
+    _$enableCoordinates,
+  );
   static DateTime _$createdAt(BoardSettingsModel v) => v.createdAt;
   static const Field<BoardSettingsModel, DateTime> _f$createdAt = Field(
     'createdAt',
@@ -92,6 +97,7 @@ class BoardSettingsModelMapper extends ClassMapperBase<BoardSettingsModel> {
     #pieceStyleIndex: _f$pieceStyleIndex,
     #gamesListViewModeIndex: _f$gamesListViewModeIndex,
     #useFigurine: _f$useFigurine,
+    #enableCoordinates: _f$enableCoordinates,
     #createdAt: _f$createdAt,
     #updatedAt: _f$updatedAt,
   };
@@ -108,6 +114,7 @@ class BoardSettingsModelMapper extends ClassMapperBase<BoardSettingsModel> {
       pieceStyleIndex: data.dec(_f$pieceStyleIndex),
       gamesListViewModeIndex: data.dec(_f$gamesListViewModeIndex),
       useFigurine: data.dec(_f$useFigurine),
+      enableCoordinates: data.dec(_f$enableCoordinates),
       createdAt: data.dec(_f$createdAt),
       updatedAt: data.dec(_f$updatedAt),
     );
@@ -195,6 +202,7 @@ abstract class BoardSettingsModelCopyWith<
     int? pieceStyleIndex,
     int? gamesListViewModeIndex,
     bool? useFigurine,
+    bool? enableCoordinates,
     DateTime? createdAt,
     DateTime? updatedAt,
   });
@@ -223,6 +231,7 @@ class _BoardSettingsModelCopyWithImpl<$R, $Out>
     int? pieceStyleIndex,
     int? gamesListViewModeIndex,
     bool? useFigurine,
+    bool? enableCoordinates,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) => $apply(
@@ -238,6 +247,7 @@ class _BoardSettingsModelCopyWithImpl<$R, $Out>
       if (gamesListViewModeIndex != null)
         #gamesListViewModeIndex: gamesListViewModeIndex,
       if (useFigurine != null) #useFigurine: useFigurine,
+      if (enableCoordinates != null) #enableCoordinates: enableCoordinates,
       if (createdAt != null) #createdAt: createdAt,
       if (updatedAt != null) #updatedAt: updatedAt,
     }),
@@ -260,6 +270,7 @@ class _BoardSettingsModelCopyWithImpl<$R, $Out>
       or: $value.gamesListViewModeIndex,
     ),
     useFigurine: data.get(#useFigurine, or: $value.useFigurine),
+    enableCoordinates: data.get(#enableCoordinates, or: $value.enableCoordinates),
     createdAt: data.get(#createdAt, or: $value.createdAt),
     updatedAt: data.get(#updatedAt, or: $value.updatedAt),
   );

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -5920,6 +5920,11 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard> {
     final showPvArrows = ref.watch(
       engineSettingsProviderNew.select((s) => s.valueOrNull?.showPvArrows ?? true),
     );
+    final enableCoordinates = ref.watch(
+      boardSettingsProviderNew.select(
+        (s) => s.valueOrNull?.enableCoordinates ?? true,
+      ),
+    );
 
     // Check if game has ended and we're at the final position
     final gameStatus = widget.game.gameStatus;
@@ -5955,7 +5960,7 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard> {
     final chessboard = Chessboard(
       size: widget.size,
       settings: ChessboardSettings(
-        enableCoordinates: true,
+        enableCoordinates: enableCoordinates,
         animationDuration: const Duration(milliseconds: 200),
         dragFeedbackScale: 1,
         dragTargetKind: DragTargetKind.none,

--- a/lib/screens/chessboard/chess_board_settings_page.dart
+++ b/lib/screens/chessboard/chess_board_settings_page.dart
@@ -518,6 +518,73 @@ class _ChessBoardSettingsPageState extends ConsumerState<ChessBoardSettingsPage>
         ),
         SizedBox(height: 18.h),
 
+        // Board Coordinates Toggle
+        _SettingCard(
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Text(
+                          'Board Coordinates',
+                          style: AppTypography.textMdMedium.copyWith(
+                            color: kWhiteColor,
+                            fontSize: 13.f,
+                          ),
+                        ),
+                        SizedBox(width: 8.w),
+                        Container(
+                          padding: EdgeInsets.symmetric(horizontal: 8.sp, vertical: 2.sp),
+                          decoration: BoxDecoration(
+                            color: kPrimaryColor.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(6.br),
+                            border: Border.all(color: kPrimaryColor.withValues(alpha: 0.3)),
+                          ),
+                          child: Text(
+                            'A-H 1-8',
+                            style: AppTypography.textSmMedium.copyWith(
+                              color: kPrimaryColor,
+                              fontSize: 11.f,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 4.h),
+                    Text(
+                      'Show A-H and 1-8 labels around the board.',
+                      style: AppTypography.textSmRegular.copyWith(
+                        color: kWhiteColor70,
+                        fontSize: 11.f,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch.adaptive(
+                value: boardSettings.enableCoordinates,
+                thumbColor: WidgetStateProperty.resolveWith(
+                  (states) => states.contains(WidgetState.selected)
+                      ? kPrimaryColor
+                      : kWhiteColor.withValues(alpha: 0.6),
+                ),
+                trackColor: WidgetStateProperty.resolveWith(
+                  (states) => states.contains(WidgetState.selected)
+                      ? kPrimaryColor.withValues(alpha: 0.35)
+                      : kDividerColor.withValues(alpha: 0.5),
+                ),
+                onChanged: (value) {
+                  _trackPersist(boardNotifier.toggleCoordinates(value));
+                },
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 18.h),
+
         // Figurine Notation Toggle
         _SettingCard(
           child: Row(

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -862,7 +862,7 @@ class _ChessBoardWidget extends ConsumerWidget {
         child: Chessboard.fixed(
           size: boardSize,
           settings: ChessboardSettings(
-            enableCoordinates: showCoordinates,
+            enableCoordinates: showCoordinates && boardSettings.enableCoordinates,
             // Use theme colors from settings with our custom app colors
             colorScheme: boardSettings.colorScheme,
             // Use piece set from settings

--- a/lib/screens/gamebase/gamebase_explorer_screen.dart
+++ b/lib/screens/gamebase/gamebase_explorer_screen.dart
@@ -168,7 +168,7 @@ class _GamebaseChessBoard extends ConsumerWidget {
           child: Chessboard.fixed(
             size: boardSize,
             settings: ChessboardSettings(
-              enableCoordinates: true,
+              enableCoordinates: boardSettings.enableCoordinates,
               // Use theme colors from settings with our custom app colors
               colorScheme: boardSettings.colorScheme,
               // Use piece set from settings

--- a/supabase/migrations/20260526172400_add_enable_coordinates_to_user_engine_settings.sql
+++ b/supabase/migrations/20260526172400_add_enable_coordinates_to_user_engine_settings.sql
@@ -1,0 +1,3 @@
+-- Allow users to hide/show board edge coordinates (A-H, 1-8).
+ALTER TABLE public.user_engine_settings
+ADD COLUMN IF NOT EXISTS enable_coordinates BOOLEAN NOT NULL DEFAULT true;

--- a/test/board_settings_coordinates_test.dart
+++ b/test/board_settings_coordinates_test.dart
@@ -1,0 +1,50 @@
+import 'package:chessever2/providers/board_settings_provider_new.dart';
+import 'package:chessever2/repository/board_settings/models/board_settings_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BoardSettingsNew coordinates', () {
+    test('defaults to showing board coordinates', () {
+      const settings = BoardSettingsNew();
+
+      expect(settings.enableCoordinates, isTrue);
+    });
+
+    test('copyWith can hide and restore board coordinates', () {
+      const settings = BoardSettingsNew();
+
+      expect(
+        settings.copyWith(enableCoordinates: false).enableCoordinates,
+        isFalse,
+      );
+      expect(
+        settings
+            .copyWith(enableCoordinates: false)
+            .copyWith(enableCoordinates: true)
+            .enableCoordinates,
+        isTrue,
+      );
+    });
+  });
+
+  group('BoardSettingsModel coordinates', () {
+    test('fromSupabase falls back to showing coordinates for older rows', () {
+      final model = BoardSettingsModel.fromSupabase({
+        'id': 'settings-1',
+        'user_id': 'user-1',
+        'created_at': '2026-05-26T00:00:00.000Z',
+        'updated_at': '2026-05-26T00:00:00.000Z',
+      });
+
+      expect(model.enableCoordinates, isTrue);
+    });
+
+    test('serializes enable_coordinates for Supabase upserts', () {
+      final model = BoardSettingsModel.defaultSettings(
+        'user-1',
+      ).copyWith(enableCoordinates: false);
+
+      expect(model.toSupabaseUpsert('user-1')['enable_coordinates'], isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a Board Coordinates toggle to phone Board Settings near the existing bottom settings
- persist the setting through BoardSettingsNew, local cache, and Supabase `user_engine_settings.enable_coordinates`
- apply the preference to the main phone board, gamebase board preview, and event/list board cards while keeping share/export overlays coordinate-free

## Tests
- `flutter test --no-pub test/board_settings_coordinates_test.dart`
- `flutter analyze --no-pub lib/providers/board_settings_provider_new.dart lib/repository/board_settings/models/board_settings_model.dart lib/repository/board_settings/models/board_settings_model.mapper.dart lib/screens/chessboard/chess_board_settings_page.dart lib/screens/gamebase/gamebase_explorer_screen.dart test/board_settings_coordinates_test.dart`
- `git diff --check`

Note: a broader focused analyze that includes legacy large board widgets still reports pre-existing warnings in `chess_board_screen_new.dart` and `chess_board_from_fen_new.dart`; the new coordinates/model/settings subset is clean.