### PR TITLE
fix: keep pinned games in board order

### DIFF
--- a/lib/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart
@@ -6,6 +6,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_mode
 import 'package:chessever2/repository/local_storage/tournament/games/pin_games_local_storage.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/utils/game_display_sort.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/knockout_tournament_state_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
@@ -59,62 +60,13 @@ class _GamesProcessingArgs {
 
 // Top-level worker function for isolate
 List<GamesTourModel> _processGamesWorker(_GamesProcessingArgs args) {
-  // 1. Pre-parse numbers to avoid repeated regex operations during sort
-  final gameInfo = <String, (int, int)>{};
-  
-  // Helper to extract numbers (copied here to be accessible in isolate)
-  int extractRound(String roundSlug) {
-    final match = RegExp(r'round-?(\d+)', caseSensitive: false).firstMatch(roundSlug) ??
-                  RegExp(r'(\d+)').firstMatch(roundSlug);
-    return int.tryParse(match?.group(1) ?? '0') ?? 0;
-  }
-
-  int extractGame(String roundSlug) {
-    final match = RegExp(r'game-?(\d+)', caseSensitive: false).firstMatch(roundSlug);
-    return int.tryParse(match?.group(1) ?? '0') ?? 0;
-  }
-
-  for (final game in args.games) {
-    gameInfo[game.id] = (
-      extractRound(game.roundSlug),
-      extractGame(game.roundSlug),
-    );
-  }
-
-  // 2. Sort games
-  final sortedGames = List<Games>.from(args.games);
-  sortedGames.sort((a, b) {
-    // FIRST PRIORITY: Pinned games (only in non-search mode)
-    if (!args.isSearchMode) {
-      final aPinned = args.pinnedIds.contains(a.id);
-      final bPinned = args.pinnedIds.contains(b.id);
-      if (aPinned && !bPinned) return -1;
-      if (!aPinned && bPinned) return 1;
-
-      // If both are pinned, preserve pin order
-      if (aPinned && bPinned) {
-        final aIndex = args.pinnedIds.indexOf(a.id);
-        final bIndex = args.pinnedIds.indexOf(b.id);
-        if (aIndex != bIndex) return aIndex.compareTo(bIndex);
-      }
-    }
-
-    final (roundA, gameA) = gameInfo[a.id] ?? (0, 0);
-    final (roundB, gameB) = gameInfo[b.id] ?? (0, 0);
-
-    // Second, sort by round number DESCENDING
-    if (roundA != roundB) return roundB.compareTo(roundA);
-
-    // Within same round, sort by game number DESCENDING
-    if (gameA != gameB) return gameB.compareTo(gameA);
-
-    // Finally, sort by board number ASCENDING
-    final aBoard = a.boardNr, bBoard = b.boardNr;
-    if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
-    if (aBoard != null) return -1;
-    if (bBoard != null) return 1;
-    return 0;
-  });
+  // Sort games. Pinned games stay promoted, but pinned peers keep board order
+  // instead of the order in which the pin/auto-pin was created.
+  final sortedGames = sortGamesForEventDisplay(
+    args.games,
+    pinnedIds: args.pinnedIds,
+    prioritizePins: !args.isSearchMode,
+  );
 
   // 3. Map to models (heavy PGN parsing happens here inside fromGame)
   final models = <GamesTourModel>[];
@@ -576,39 +528,10 @@ class GamesTourScreenProvider
   ) {
     if (games.isEmpty) return const <Games>[];
 
-    final gameInfo = <String, (int, int)>{};
-    for (final game in games) {
-      gameInfo[game.id] = (
-        _extractRoundNumber(game.roundSlug),
-        _extractGameNumber(game.roundSlug),
-      );
-    }
-
-    final sortedGames = List<Games>.from(games);
-    sortedGames.sort((a, b) {
-      final aPinned = pinnedIds.contains(a.id);
-      final bPinned = pinnedIds.contains(b.id);
-      if (aPinned && !bPinned) return -1;
-      if (!aPinned && bPinned) return 1;
-
-      if (aPinned && bPinned) {
-        final aIndex = pinnedIds.indexOf(a.id);
-        final bIndex = pinnedIds.indexOf(b.id);
-        if (aIndex != bIndex) return aIndex.compareTo(bIndex);
-      }
-
-      final (roundA, gameA) = gameInfo[a.id] ?? (0, 0);
-      final (roundB, gameB) = gameInfo[b.id] ?? (0, 0);
-
-      if (roundA != roundB) return roundB.compareTo(roundA);
-      if (gameA != gameB) return gameB.compareTo(gameA);
-
-      final aBoard = a.boardNr, bBoard = b.boardNr;
-      if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
-      if (aBoard != null) return -1;
-      if (bBoard != null) return 1;
-      return 0;
-    });
+    final sortedGames = sortGamesForEventDisplay(
+      games,
+      pinnedIds: pinnedIds,
+    );
 
     return sortedGames;
   }

--- a/lib/screens/tour_detail/games_tour/utils/game_display_sort.dart
+++ b/lib/screens/tour_detail/games_tour/utils/game_display_sort.dart
@@ -1,0 +1,100 @@
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+
+/// Returns games in the same display order used by event game lists.
+///
+/// Pinned games are promoted ahead of unpinned games, but pinned games still
+/// use the event's board/round ordering instead of the order in which they
+/// were pinned or auto-pinned.
+List<Games> sortGamesForEventDisplay(
+  List<Games> games, {
+  required List<String> pinnedIds,
+  bool prioritizePins = true,
+}) {
+  if (games.isEmpty) return const <Games>[];
+
+  final gameInfo = <String, (int, int)>{};
+  for (final game in games) {
+    gameInfo[game.id] = (
+      extractRoundNumberFromSlug(game.roundSlug),
+      extractGameNumberFromSlug(game.roundSlug),
+    );
+  }
+
+  final sortedGames = List<Games>.from(games);
+  sortedGames.sort((a, b) {
+    if (prioritizePins) {
+      final aPinned = pinnedIds.contains(a.id);
+      final bPinned = pinnedIds.contains(b.id);
+      if (aPinned != bPinned) return aPinned ? -1 : 1;
+    }
+
+    final (roundA, gameA) = gameInfo[a.id] ?? (0, 0);
+    final (roundB, gameB) = gameInfo[b.id] ?? (0, 0);
+
+    // Current/live rounds are rendered first by the existing event UI.
+    if (roundA != roundB) return roundB.compareTo(roundA);
+
+    // Preserve existing match/game ordering inside a round when available.
+    if (gameA != gameB) return gameB.compareTo(gameA);
+
+    // Board order is the stable canonical order inside the pinned and
+    // unpinned groups. Missing board numbers go after numbered boards.
+    final aBoard = a.boardNr, bBoard = b.boardNr;
+    if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
+    if (aBoard != null) return -1;
+    if (bBoard != null) return 1;
+    return 0;
+  });
+
+  return sortedGames;
+}
+
+/// Same ordering as [sortGamesForEventDisplay], for already mapped card models.
+List<GamesTourModel> sortGameModelsForEventDisplay(
+  List<GamesTourModel> games, {
+  required List<String> pinnedIds,
+  bool prioritizePins = true,
+}) {
+  if (games.isEmpty) return const <GamesTourModel>[];
+
+  final sortedGames = List<GamesTourModel>.from(games);
+  sortedGames.sort((a, b) {
+    if (prioritizePins) {
+      final aPinned = pinnedIds.contains(a.gameId);
+      final bPinned = pinnedIds.contains(b.gameId);
+      if (aPinned != bPinned) return aPinned ? -1 : 1;
+    }
+
+    final roundA = extractRoundNumberFromSlug(a.roundSlug ?? '');
+    final roundB = extractRoundNumberFromSlug(b.roundSlug ?? '');
+    if (roundA != roundB) return roundB.compareTo(roundA);
+
+    final gameA = extractGameNumberFromSlug(a.roundSlug ?? '');
+    final gameB = extractGameNumberFromSlug(b.roundSlug ?? '');
+    if (gameA != gameB) return gameB.compareTo(gameA);
+
+    final aBoard = a.boardNr, bBoard = b.boardNr;
+    if (aBoard != null && bBoard != null) return aBoard.compareTo(bBoard);
+    if (aBoard != null) return -1;
+    if (bBoard != null) return 1;
+    return 0;
+  });
+
+  return sortedGames;
+}
+
+int extractRoundNumberFromSlug(String roundSlug) {
+  final match =
+      RegExp(r'round-?(\d+)', caseSensitive: false).firstMatch(roundSlug) ??
+      RegExp(r'(\d+)').firstMatch(roundSlug);
+  return int.tryParse(match?.group(1) ?? '0') ?? 0;
+}
+
+int extractGameNumberFromSlug(String roundSlug) {
+  final match = RegExp(
+    r'game-?(\d+)',
+    caseSensitive: false,
+  ).firstMatch(roundSlug);
+  return int.tryParse(match?.group(1) ?? '0') ?? 0;
+}

--- a/lib/screens/tour_detail/games_tour/widgets/games_tour_content_body.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/games_tour_content_body.dart
@@ -6,6 +6,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_mode
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/knockout_tournament_state_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/utils/game_display_sort.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/utils/knockout_match_detector.dart';
 import 'package:chessever2/screens/group_event/widget/tour_loading_widget.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
@@ -164,14 +165,13 @@ class GamesTourContentBody extends ConsumerWidget {
       if (pinnedGameIds.isNotEmpty) {
         for (final roundId in gamesByRound.keys) {
           final roundGames = gamesByRound[roundId]!;
-          roundGames.sort((a, b) {
-            final aPinned = pinnedGameIds.contains(a.gameId);
-            final bPinned = pinnedGameIds.contains(b.gameId);
-            if (aPinned != bPinned) {
-              return aPinned ? -1 : 1; // Pinned games first
-            }
-            return 0; // Keep original order for same pin status
-          });
+          final sortedRoundGames = sortGameModelsForEventDisplay(
+            roundGames,
+            pinnedIds: pinnedGameIds,
+          );
+          roundGames
+            ..clear()
+            ..addAll(sortedRoundGames);
         }
       }
     } else if (isRoundSlugDerivedStages) {
@@ -205,14 +205,13 @@ class GamesTourContentBody extends ConsumerWidget {
       if (pinnedGameIds.isNotEmpty) {
         for (final roundId in gamesByRound.keys) {
           final roundGames = gamesByRound[roundId]!;
-          roundGames.sort((a, b) {
-            final aPinned = pinnedGameIds.contains(a.gameId);
-            final bPinned = pinnedGameIds.contains(b.gameId);
-            if (aPinned != bPinned) {
-              return aPinned ? -1 : 1;
-            }
-            return 0;
-          });
+          final sortedRoundGames = sortGameModelsForEventDisplay(
+            roundGames,
+            pinnedIds: pinnedGameIds,
+          );
+          roundGames
+            ..clear()
+            ..addAll(sortedRoundGames);
         }
       }
     } else {

--- a/test/game_display_sort_test.dart
+++ b/test/game_display_sort_test.dart
@@ -1,0 +1,82 @@
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/utils/game_display_sort.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('sortGamesForEventDisplay', () {
+    test(
+      'promotes pinned games while ordering pinned peers by board number',
+      () {
+        final games = [
+          _game('board20', boardNr: 20),
+          _game('board1', boardNr: 1),
+          _game('board10', boardNr: 10),
+          _game('board3', boardNr: 3),
+        ];
+
+        final sorted = sortGamesForEventDisplay(
+          games,
+          pinnedIds: ['board20', 'board10', 'board3'],
+        );
+
+        expect(sorted.map((game) => game.id), [
+          'board3',
+          'board10',
+          'board20',
+          'board1',
+        ]);
+      },
+    );
+
+    test('keeps non-pinned games in board order after pinned games', () {
+      final games = [
+        _game('board30', boardNr: 30),
+        _game('board2', boardNr: 2),
+        _game('board20', boardNr: 20),
+        _game('board10', boardNr: 10),
+      ];
+
+      final sorted = sortGamesForEventDisplay(games, pinnedIds: ['board20']);
+
+      expect(sorted.map((game) => game.id), [
+        'board20',
+        'board2',
+        'board10',
+        'board30',
+      ]);
+    });
+
+    test('places missing board numbers after numbered games in each group', () {
+      final games = [
+        _game('pinnedMissing'),
+        _game('unpinnedMissing'),
+        _game('pinned10', boardNr: 10),
+        _game('unpinned5', boardNr: 5),
+      ];
+
+      final sorted = sortGamesForEventDisplay(
+        games,
+        pinnedIds: ['pinnedMissing', 'pinned10'],
+      );
+
+      expect(sorted.map((game) => game.id), [
+        'pinned10',
+        'pinnedMissing',
+        'unpinned5',
+        'unpinnedMissing',
+      ]);
+    });
+  });
+}
+
+Games _game(String id, {int? boardNr}) {
+  return Games(
+    id: id,
+    roundId: 'round-3',
+    roundSlug: 'round-3',
+    tourId: 'tour',
+    tourSlug: 'tour-slug',
+    boardNr: boardNr,
+    status: '*',
+  );
+}


### PR DESCRIPTION
## Summary
- keep pinned/auto-pinned event games promoted ahead of non-pinned games while ordering pinned peers by board number
- reuse the same ordering helper for normal event lists, filtered views, and knockout round sections
- add focused regression coverage for pinned board-order sorting and missing-board fallback behavior

## Test Plan
- `git diff --check`
- `flutter test test/game_display_sort_test.dart`
- `flutter analyze lib/screens/tour_detail/games_tour/utils/game_display_sort.dart test/game_display_sort_test.dart`
- `flutter analyze lib/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart lib/screens/tour_detail/games_tour/widgets/games_tour_content_body.dart lib/screens/tour_detail/games_tour/utils/game_display_sort.dart test/game_display_sort_test.dart` *(reports pre-existing issues in `games_tour_content_body.dart`: unnecessary non-null assertion and existing `print` calls; new helper/test are clean)*

## Acceptance
- pinned games stay above non-pinned games
- within the pinned group, Board 10 appears before Board 20 regardless of pin/auto-pin creation order
- non-pinned games continue below in board order
