### PR TITLE
Fix one-day event date labels

### DIFF
--- a/lib/screens/calendar/calendar_event_detail_screen.dart
+++ b/lib/screens/calendar/calendar_event_detail_screen.dart
@@ -5,10 +5,10 @@ import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/png_asset.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/svg_asset.dart';
+import 'package:chessever2/utils/time_utils.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
 import 'package:country_flags/country_flags.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class CalendarEventDetailScreen extends StatelessWidget {
@@ -17,17 +17,8 @@ class CalendarEventDetailScreen extends StatelessWidget {
   final CalendarEvent event;
 
   String _formatDateRange() {
-    final dateFormat = DateFormat('MMM d, yyyy');
-    if (event.startDate == null && event.endDate == null) {
-      return 'TBA';
-    }
-    if (event.startDate != null && event.endDate != null) {
-      return '${dateFormat.format(event.startDate!)} - ${dateFormat.format(event.endDate!)}';
-    }
-    if (event.startDate != null) {
-      return dateFormat.format(event.startDate!);
-    }
-    return dateFormat.format(event.endDate!);
+    final formatted = TimeUtils.formatDateRange(event.startDate, event.endDate);
+    return formatted.isEmpty ? 'TBA' : formatted;
   }
 
   String _extractDomain() {

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -10,6 +10,14 @@ class TimeUtils {
     final localEnd = toLocal(end);
 
     if (localStart != null && localEnd != null) {
+      final isSameCalendarDay =
+          localStart.year == localEnd.year &&
+          localStart.month == localEnd.month &&
+          localStart.day == localEnd.day;
+      if (isSameCalendarDay) {
+        return DateFormat('MMM d, yyyy').format(localStart);
+      }
+
       if (localStart.month == localEnd.month &&
           localStart.year == localEnd.year) {
         return "${DateFormat('MMM d').format(localStart)} - ${DateFormat('d, yyyy').format(localEnd)}";

--- a/test/time_utils_test.dart
+++ b/test/time_utils_test.dart
@@ -1,0 +1,23 @@
+import 'package:chessever2/utils/time_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TimeUtils.formatDateRange', () {
+    test(
+      'shows a single date when start and end are the same calendar day',
+      () {
+        final start = DateTime(2026, 5, 23, 9);
+        final end = DateTime(2026, 5, 23, 18);
+
+        expect(TimeUtils.formatDateRange(start, end), 'May 23, 2026');
+      },
+    );
+
+    test('keeps a compact range for multi-day events in the same month', () {
+      final start = DateTime(2026, 5, 23);
+      final end = DateTime(2026, 5, 25);
+
+      expect(TimeUtils.formatDateRange(start, end), 'May 23 - 25, 2026');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- show one-day event dates as a single date instead of duplicated ranges like `May 23 - 23, 2026`
- route calendar event detail date formatting through the shared event date formatter so detail/list behavior stays consistent
- add focused coverage for one-day and same-month multi-day event ranges

## Tests
- `git diff --check`
- `flutter test test/time_utils_test.dart`
- `flutter analyze lib/utils/time_utils.dart lib/screens/calendar/calendar_event_detail_screen.dart test/time_utils_test.dart`
