### PR TITLE
feat: add event no-spoilers mode

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -30,6 +30,7 @@ import 'package:chessever2/screens/chessboard/widgets/smooth_sheet_config.dart';
 import 'package:chessever2/screens/chessboard/widgets/save_analysis_sheet.dart';
 import 'package:chessever2/screens/group_event/providers/countryman_games_tour_screen_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart';
 import 'package:chessever2/utils/app_typography.dart';
@@ -74,7 +75,6 @@ import 'package:chessever2/screens/library/utils/gamebase_game_to_games_tour_mod
 import 'package:chessever2/utils/chess_title_utils.dart';
 import 'package:showcaseview/showcaseview.dart';
 import 'package:chessever2/repository/local_storage/local_storage_repository.dart';
-import 'package:flutter/foundation.dart';
 import 'package:chessever2/services/lichess_move_annotations_service.dart';
 import 'package:chessever2/services/live_updates_service.dart';
 import 'package:chessever2/providers/auth_state_provider.dart';
@@ -5651,9 +5651,14 @@ class _TabletBoardWithSidebar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // PERF: Use .select() to only rebuild when showEngineGauge changes
-    final showEngineGauge = ref.watch(
+    final engineGaugeEnabled = ref.watch(
       engineSettingsProviderNew.select((s) => s.valueOrNull?.showEngineGauge ?? true),
     );
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(game.tourId).select((state) => state.enabled),
+    );
+    final showEngineGauge =
+        engineGaugeEnabled && !(noSpoilersEnabled && game.gameStatus.isFinished);
 
     final effectiveEvalWidth = showEngineGauge ? evalBarWidth : 0.0;
 
@@ -5727,9 +5732,14 @@ class _BoardWithSidebar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // PERF: Use .select() to only rebuild when showEngineGauge changes
-    final showEngineGauge = ref.watch(
+    final engineGaugeEnabled = ref.watch(
       engineSettingsProviderNew.select((s) => s.valueOrNull?.showEngineGauge ?? true),
     );
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(game.tourId).select((state) => state.enabled),
+    );
+    final showEngineGauge =
+        engineGaugeEnabled && !(noSpoilersEnabled && game.gameStatus.isFinished);
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -5861,6 +5871,12 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard> {
                        gameStatus != GameStatus.unknown;
     final shouldShowEffect = isGameOver && isAtEnd;
 
+    if (shouldShowEffect && !_wasAtEnd) {
+      ref
+          .read(eventNoSpoilersRevealedGamesProvider.notifier)
+          .reveal(widget.game.gameId);
+    }
+
     // When navigating TO the final position, delay showing the effect for animation
     if (shouldShowEffect && !_wasAtEnd) {
       _showDelayedGameEndingEffect = false;
@@ -5927,8 +5943,23 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard> {
     final isGameOver = gameStatus != GameStatus.ongoing &&
                        gameStatus != GameStatus.unknown;
 
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(widget.game.tourId).select((state) => state.enabled),
+    );
+    final spoilersRevealedForGame = ref.watch(
+      eventNoSpoilersRevealedGamesProvider.select(
+        (gameIds) => gameIds.contains(widget.game.gameId),
+      ),
+    );
+    final canShowFinishedSpoilers =
+        !noSpoilersEnabled || !isGameOver || spoilersRevealedForGame;
+
     // Use delayed flag to allow move animation to complete first
-    final showGameEndingEffect = isGameOver && isAtEnd && _showDelayedGameEndingEffect;
+    final showGameEndingEffect =
+        isGameOver &&
+        isAtEnd &&
+        _showDelayedGameEndingEffect &&
+        canShowFinishedSpoilers;
 
     // Calculate square highlights and annotations for game ending
     final gameEndingData = showGameEndingEffect

--- a/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
+++ b/lib/screens/chessboard/widgets/chess_board_from_fen_new.dart
@@ -6,6 +6,7 @@ import 'package:chessever2/screens/chessboard/widgets/evaluation_bar_widget.dart
 import 'package:chessever2/screens/chessboard/widgets/player_first_row_detail_widget.dart';
 import 'package:chessever2/screens/chessboard/widgets/share_game_card_overlay.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -242,7 +243,15 @@ class ChessBoardFromFENNew extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showEvalBar = _shouldShowEvalBar(ref) && gamesTourModel.hasStarted;
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(gamesTourModel.tourId).select(
+        (state) => state.enabled,
+      ),
+    );
+    final hideFinishedSpoilers =
+        noSpoilersEnabled && gamesTourModel.gameStatus.isFinished;
+    final showEvalBar =
+        _shouldShowEvalBar(ref) && gamesTourModel.hasStarted && !hideFinishedSpoilers;
     final sideBarWidth = showEvalBar ? 20.w : 0.w;
 
     return Padding(
@@ -462,7 +471,15 @@ class GridChessBoardFromFENNew extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showEvalBar = _shouldShowEvalBar(ref) && gamesTourModel.hasStarted;
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(gamesTourModel.tourId).select(
+        (state) => state.enabled,
+      ),
+    );
+    final hideFinishedSpoilers =
+        noSpoilersEnabled && gamesTourModel.gameStatus.isFinished;
+    final showEvalBar =
+        _shouldShowEvalBar(ref) && gamesTourModel.hasStarted && !hideFinishedSpoilers;
     final sideBarWidth = showEvalBar ? 10.w : 0.w;
 
     // On phone, use the original fixed calculation for 2-column grid
@@ -663,7 +680,15 @@ class _ChessBoardContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showEvalBar = _shouldShowEvalBar(ref) && gamesTourModel.hasStarted;
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(gamesTourModel.tourId).select(
+        (state) => state.enabled,
+      ),
+    );
+    final hideFinishedSpoilers =
+        noSpoilersEnabled && gamesTourModel.gameStatus.isFinished;
+    final showEvalBar =
+        _shouldShowEvalBar(ref) && gamesTourModel.hasStarted && !hideFinishedSpoilers;
     final sideBarWidth = showEvalBar ? 20.w : 0.w;
 
     return SizedBox(
@@ -742,7 +767,7 @@ class _PlayerRow extends StatelessWidget {
   }
 }
 
-class _ChessBoardWithEvaluation extends StatelessWidget {
+class _ChessBoardWithEvaluation extends ConsumerWidget {
   const _ChessBoardWithEvaluation({
     required this.gamesTourModel,
     required this.lastMove,
@@ -762,9 +787,18 @@ class _ChessBoardWithEvaluation extends StatelessWidget {
   final bool showCoordinates;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(gamesTourModel.tourId).select(
+        (state) => state.enabled,
+      ),
+    );
+    final hideFinishedSpoilers =
+        noSpoilersEnabled && gamesTourModel.gameStatus.isFinished;
+
     // Get effective game status for ended games
-    final gameStatus = gamesTourModel.gameStatus;
+    final gameStatus =
+        hideFinishedSpoilers ? GameStatus.ongoing : gamesTourModel.gameStatus;
     final resolvedFen = _resolveFen(gamesTourModel.fen);
 
     if (!showEvalBar || !gamesTourModel.hasStarted) {

--- a/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
+++ b/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
@@ -1,11 +1,11 @@
 import 'package:chessever2/providers/engine_settings_provider.dart';
-import 'package:chessever2/providers/for_you_games_provider.dart';
 import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/group_event/providers/countryman_games_tour_screen_provider.dart';
 import 'package:chessever2/screens/standings/player_standing_model.dart';
 import 'package:chessever2/screens/standings/score_card_screen.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart';
 import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -20,7 +20,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:chessever2/utils/svg_asset.dart';
-import 'dart:ui';
 
 enum PlayerView { listView, gridView, boardView }
 
@@ -46,6 +45,21 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final noSpoilersEnabled = ref.watch(
+      eventNoSpoilersProvider(gamesTourModel.tourId).select(
+        (state) => state.enabled,
+      ),
+    );
+    final spoilersRevealedForGame = ref.watch(
+      eventNoSpoilersRevealedGamesProvider.select(
+        (gameIds) => gameIds.contains(gamesTourModel.gameId),
+      ),
+    );
+    final revealSpoilers =
+        !noSpoilersEnabled ||
+        !gamesTourModel.gameStatus.isFinished ||
+        spoilersRevealedForGame;
+
     final playerCard = useMemoized(() {
       return isWhitePlayer
           ? gamesTourModel.whitePlayer
@@ -248,9 +262,9 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
           (settings?.showEngineGauge ?? true);
 
       // We only show the gauge area if:
-      // 1. The game is finished (to show 1, 0, or 1/2)
+      // 1. The finished-game result is allowed to be shown
       // 2. The game is ongoing AND started AND gauge is enabled in settings
-      final isFinished = gamesTourModel.gameStatus.isFinished;
+      final isFinished = gamesTourModel.gameStatus.isFinished && revealSpoilers;
       final effectivelyShowingEvalBar =
           showEvalBarInSettings &&
           gamesTourModel.hasStarted &&
@@ -260,7 +274,7 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
         return playerView == PlayerView.gridView ? 10.w : 20.w;
       }
       return 0.0;
-    }, [ref.watch(engineSettingsProviderNew), gamesTourModel, playerView]);
+    }, [ref.watch(engineSettingsProviderNew), gamesTourModel, playerView, revealSpoilers]);
 
     // Clock padding - add small horizontal padding to prevent flickering and provide stability
     final clockPadding = playerView == PlayerView.gridView ? 4.w : 6.w;
@@ -357,7 +371,7 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
         // This handles cases where:
         // - view might not match expected case
         // - gamesContext filter returned empty (e.g., For You only has few games from event)
-        if ((gamesContext == null || gamesContext!.isEmpty) && gamesTourModel.tourId.isNotEmpty) {
+        if ((gamesContext == null || gamesContext.isEmpty) && gamesTourModel.tourId.isNotEmpty) {
           gamesContext = [gamesTourModel];
           hasEventContext = true;
         }
@@ -378,7 +392,7 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
           // Game result score - centered in eval bar width
           SizedBox(
             width: engineGaugeWidth,
-            child: gamesTourModel.gameStatus.isFinished
+            child: gamesTourModel.gameStatus.isFinished && revealSpoilers
                 ? Center(
                     child: Text(
                       gamesTourModel.gameStatus == GameStatus.whiteWins

--- a/lib/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart
@@ -1,0 +1,85 @@
+import 'package:chessever2/repository/sqlite/app_database.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class EventNoSpoilersState {
+  const EventNoSpoilersState({this.enabled = false, this.isLoading = true});
+
+  final bool enabled;
+  final bool isLoading;
+
+  EventNoSpoilersState copyWith({bool? enabled, bool? isLoading}) {
+    return EventNoSpoilersState(
+      enabled: enabled ?? this.enabled,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+}
+
+final eventNoSpoilersProvider = StateNotifierProvider.family<
+  EventNoSpoilersController,
+  EventNoSpoilersState,
+  String
+>((ref, tourId) {
+  return EventNoSpoilersController(ref: ref, tourId: tourId);
+});
+
+final eventNoSpoilersRevealedGamesProvider =
+    StateNotifierProvider<EventNoSpoilersRevealedGamesController, Set<String>>(
+      (ref) => EventNoSpoilersRevealedGamesController(),
+    );
+
+class EventNoSpoilersRevealedGamesController
+    extends StateNotifier<Set<String>> {
+  EventNoSpoilersRevealedGamesController() : super(<String>{});
+
+  void reveal(String gameId) {
+    if (gameId.isEmpty || state.contains(gameId)) return;
+    state = {...state, gameId};
+  }
+
+  void hide(String gameId) {
+    if (gameId.isEmpty || !state.contains(gameId)) return;
+    state = state.where((id) => id != gameId).toSet();
+  }
+}
+
+class EventNoSpoilersController extends StateNotifier<EventNoSpoilersState> {
+  EventNoSpoilersController({required this.ref, required this.tourId})
+    : super(const EventNoSpoilersState()) {
+    load();
+  }
+
+  final Ref ref;
+  final String tourId;
+
+  String get _key => 'event_no_spoilers_$tourId';
+
+  Future<void> load() async {
+    if (tourId.isEmpty) {
+      state = const EventNoSpoilersState(enabled: false, isLoading: false);
+      return;
+    }
+
+    try {
+      final db = ref.read(appDatabaseProvider);
+      final enabled = await db.getBool(_key) ?? false;
+      state = EventNoSpoilersState(enabled: enabled, isLoading: false);
+    } catch (_) {
+      state = const EventNoSpoilersState(enabled: false, isLoading: false);
+    }
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    state = state.copyWith(enabled: enabled, isLoading: false);
+    if (tourId.isEmpty) return;
+
+    try {
+      final db = ref.read(appDatabaseProvider);
+      await db.setBool(_key, enabled);
+    } catch (_) {
+      // Local preference persistence failure should not block the UI toggle.
+    }
+  }
+
+  Future<void> toggle() => setEnabled(!state.enabled);
+}

--- a/lib/screens/tour_detail/games_tour/widgets/game_card.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card.dart
@@ -1,6 +1,7 @@
 import 'package:chessever2/providers/engine_settings_provider.dart';
 import 'package:chessever2/providers/live_game_subscription_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/widgets/chess_progress_bar.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/widgets/games_tour_content_provider.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -282,8 +283,17 @@ class _CenterContent extends ConsumerWidget {
       ),
     );
 
-    // If game is not ongoing, show result text
+    final hideSpoilers = ref.watch(
+      eventNoSpoilersProvider(matchWithComparison.game.tourId).select(
+        (state) => state.enabled,
+      ),
+    );
+
+    // If game is not ongoing, show result text unless this event is spoiler-free.
     if (effectiveStatus != GameStatus.ongoing) {
+      if (hideSpoilers && matchWithComparison.game.gameStatus.isFinished) {
+        return const SizedBox.shrink();
+      }
       return Center(
         child: StatusText(status: _displayTextSupporter(matchWithComparison)),
       );

--- a/lib/screens/tour_detail/games_tour/widgets/games_app_bar_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/games_app_bar_widget.dart
@@ -4,6 +4,7 @@ import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_list_view_mode_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_provider.dart';
@@ -31,6 +32,7 @@ import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provi
 enum MenuAction {
   unpinAll,
   showHideFinishedGames,
+  noSpoilers,
   collapseAllRounds,
   expandAllRounds,
 }
@@ -271,6 +273,11 @@ class _GamesAppBarWidgetState extends ConsumerState<GamesAppBarWidget>
                 .autoPinDisabled;
 
         final gamesTourScreen = ref.watch(gamesTourScreenProvider.notifier);
+        final noSpoilersEnabled = ref.watch(
+          eventNoSpoilersProvider(tourData.aboutTourModel.id).select(
+            (state) => state.enabled,
+          ),
+        );
 
         return GestureDetector(
           behavior: HitTestBehavior.translucent,
@@ -518,6 +525,52 @@ class _GamesAppBarWidgetState extends ConsumerState<GamesAppBarWidget>
                                           color: kDividerColor,
                                         ),
                                       ],
+
+                                      PopupMenuItem<MenuAction>(
+                                        value: MenuAction.noSpoilers,
+                                        onTap: () {
+                                          unawaited(
+                                            ref
+                                                .read(
+                                                  eventNoSpoilersProvider(
+                                                    tourData.aboutTourModel.id,
+                                                  ).notifier,
+                                                )
+                                                .toggle(),
+                                          );
+                                        },
+                                        child: SizedBox(
+                                          width: 200,
+                                          child: Row(
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.spaceBetween,
+                                            children: [
+                                              Text(
+                                                noSpoilersEnabled
+                                                    ? "Disable No Spoilers"
+                                                    : "No Spoilers",
+                                                style: AppTypography
+                                                    .textXsMedium
+                                                    .copyWith(
+                                                      color: kWhiteColor,
+                                                    ),
+                                              ),
+                                              Icon(
+                                                noSpoilersEnabled
+                                                    ? Icons.visibility_off
+                                                    : Icons.visibility,
+                                                color: kWhiteColor,
+                                                size: 16.sp,
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      ),
+                                      PopupMenuDivider(
+                                        height: 1.h,
+                                        thickness: 0.5.w,
+                                        color: kDividerColor,
+                                      ),
 
                                       if (roundIds.isNotEmpty) ...[
                                         PopupMenuItem<MenuAction>(


### PR DESCRIPTION
## Summary
- Add a per-event `No Spoilers` toggle in the event `⋮` menu, persisted locally by event id.
- Hide finished-game result text/score markers in event cards and player rows while no-spoilers is enabled.
- Hide finished-game eval bars and suppress final board-ending animation until the user navigates to the final position from an earlier move.

## Test Plan
- `dart format lib/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart`
- `git diff --check`
- `flutter analyze lib/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart` ✅
- `flutter analyze lib/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart lib/screens/tour_detail/games_tour/widgets/games_app_bar_widget.dart lib/screens/tour_detail/games_tour/widgets/game_card.dart lib/screens/chessboard/widgets/chess_board_from_fen_new.dart lib/screens/chessboard/widgets/player_first_row_detail_widget.dart lib/screens/chessboard/chess_board_screen_new.dart` ⚠️ reports existing warnings/infos in large touched files; no new compile errors.

## Notes
- Synced/rebased against `origin/main` before opening.
- Scope is intentionally local to event surfaces, not a global Settings toggle.
