### PR TITLE
feat: scroll active bottom tab to top

### DIFF
--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -7,6 +7,7 @@ import 'package:chessever2/screens/calendar/calendar_event_detail_screen.dart';
 import 'package:chessever2/screens/calendar/provider/calendar_screen_provider.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/group_event/providers/sorting_all_event_provider.dart';
+import 'package:chessever2/screens/home/widget/bottom_nav_bar.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/services/analytics/analytics_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -49,14 +50,25 @@ class CalendarScreen extends ConsumerStatefulWidget {
 class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   final TextEditingController searchController = TextEditingController();
   final focusNode = FocusNode();
+  final ScrollController _scrollController = ScrollController();
   Timer? _searchAnalyticsTimer;
 
   @override
   void dispose() {
     searchController.dispose();
     focusNode.dispose();
+    _scrollController.dispose();
     _searchAnalyticsTimer?.cancel();
     super.dispose();
+  }
+
+  void _scrollToTop() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   @override
@@ -67,6 +79,15 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     final searchQuery = ref.watch(calendarSearchQueryProvider);
     final isListMode =
         filterMode != CalendarFilterMode.all || searchQuery.trim().isNotEmpty;
+
+    ref.listen<BottomNavBarReTapRequest>(bottomNavBarReTapRequestProvider, (
+      previous,
+      next,
+    ) {
+      if (next.item == BottomNavBarItem.calendar) {
+        _scrollToTop();
+      }
+    });
 
     return Scaffold(
       body: Column(
@@ -326,6 +347,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                       displacement: 60.h,
                       strokeWidth: 3.w,
                       child: GridView.builder(
+                        controller: _scrollController,
                         padding: EdgeInsets.symmetric(horizontal: 16.sp),
                         physics: const AlwaysScrollableScrollPhysics(
                           parent: BouncingScrollPhysics(),
@@ -401,6 +423,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
 
                     return SkeletonWidget(
                       child: GridView.builder(
+                        controller: _scrollController,
                         padding: EdgeInsets.symmetric(horizontal: 16.sp),
                         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                           crossAxisCount: crossAxisCount,
@@ -465,14 +488,15 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
       });
       sortedEvents = flattenedEvents;
     } else {
-      sortedEvents = ref.read(tournamentSortingServiceProvider).sortCalendarEvents(
-        flattenedEvents,
-        prioritizeFavorites: false,
-      );
+      sortedEvents = ref
+          .read(tournamentSortingServiceProvider)
+          .sortCalendarEvents(flattenedEvents, prioritizeFavorites: false);
     }
 
     final isTablet = ResponsiveHelper.isTablet;
-    final crossAxisCount = ResponsiveHelper.getGridCrossAxisCount(phoneCount: 1);
+    final crossAxisCount = ResponsiveHelper.getGridCrossAxisCount(
+      phoneCount: 1,
+    );
     final horizontalPadding = ResponsiveHelper.adaptive(
       phone: 16.sp,
       tablet: 24.sp,
@@ -490,6 +514,7 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
       child:
           sortedEvents.isEmpty
               ? ListView(
+                controller: _scrollController,
                 physics: const AlwaysScrollableScrollPhysics(
                   parent: BouncingScrollPhysics(),
                 ),
@@ -510,51 +535,53 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
               )
               // Use grid layout for tablets, list for phones
               : isTablet && crossAxisCount > 1
-                  ? GridView.builder(
-                      physics: const AlwaysScrollableScrollPhysics(
-                        parent: BouncingScrollPhysics(),
-                      ),
-                      padding: EdgeInsets.symmetric(
-                        horizontal: horizontalPadding,
-                        vertical: 12.h,
-                      ),
-                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: crossAxisCount,
-                        crossAxisSpacing: 16.sp,
-                        mainAxisSpacing: 16.sp,
-                        childAspectRatio: ResponsiveHelper.isLandscape ? 2.2 : 1.8,
-                      ),
-                      itemCount: sortedEvents.length,
-                      itemBuilder: (context, index) {
-                        final event = sortedEvents[index];
-                        return EventCard(
-                          tourEventCardModel: event,
-                          heroTagSuffix: 'calendar-list-$index',
-                          onTap: () => _onEventTap(event),
-                        );
-                      },
-                    )
-                  : ListView.builder(
-                      physics: const AlwaysScrollableScrollPhysics(
-                        parent: BouncingScrollPhysics(),
-                      ),
-                      padding: EdgeInsets.symmetric(
-                        horizontal: horizontalPadding,
-                        vertical: 12.h,
-                      ),
-                      itemCount: sortedEvents.length,
-                      itemBuilder: (context, index) {
-                        final event = sortedEvents[index];
-                        return Padding(
-                          padding: EdgeInsets.only(bottom: 12.h),
-                          child: EventCard(
-                            tourEventCardModel: event,
-                            heroTagSuffix: 'calendar-list-$index',
-                            onTap: () => _onEventTap(event),
-                          ),
-                        );
-                      },
+              ? GridView.builder(
+                controller: _scrollController,
+                physics: const AlwaysScrollableScrollPhysics(
+                  parent: BouncingScrollPhysics(),
+                ),
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: 12.h,
+                ),
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: crossAxisCount,
+                  crossAxisSpacing: 16.sp,
+                  mainAxisSpacing: 16.sp,
+                  childAspectRatio: ResponsiveHelper.isLandscape ? 2.2 : 1.8,
+                ),
+                itemCount: sortedEvents.length,
+                itemBuilder: (context, index) {
+                  final event = sortedEvents[index];
+                  return EventCard(
+                    tourEventCardModel: event,
+                    heroTagSuffix: 'calendar-list-$index',
+                    onTap: () => _onEventTap(event),
+                  );
+                },
+              )
+              : ListView.builder(
+                controller: _scrollController,
+                physics: const AlwaysScrollableScrollPhysics(
+                  parent: BouncingScrollPhysics(),
+                ),
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: 12.h,
+                ),
+                itemCount: sortedEvents.length,
+                itemBuilder: (context, index) {
+                  final event = sortedEvents[index];
+                  return Padding(
+                    padding: EdgeInsets.only(bottom: 12.h),
+                    child: EventCard(
+                      tourEventCardModel: event,
+                      heroTagSuffix: 'calendar-list-$index',
+                      onTap: () => _onEventTap(event),
                     ),
+                  );
+                },
+              ),
     );
   }
 
@@ -808,7 +835,8 @@ class _QuickFilterButtons extends ConsumerWidget {
         }
 
         // Otherwise, calculate potential favorite events from current year data
-        final favoriteEventIds = favoriteEventIdsAsync.valueOrNull ?? <String>{};
+        final favoriteEventIds =
+            favoriteEventIdsAsync.valueOrNull ?? <String>{};
 
         // Count unique events in the current data that are in our favorites set
         final matchingEventIds = <String>{};

--- a/lib/screens/group_event/group_event_screen.dart
+++ b/lib/screens/group_event/group_event_screen.dart
@@ -10,6 +10,7 @@ import 'package:chessever2/screens/group_event/widget/filter_popup/group_event_f
 import 'package:chessever2/screens/group_event/widget/for_you_games_widget.dart';
 import 'package:chessever2/screens/group_event/widget/search_results_widget.dart';
 import 'package:chessever2/screens/home/home_screen_provider.dart';
+import 'package:chessever2/screens/home/widget/bottom_nav_bar.dart';
 import 'package:chessever2/screens/group_event/providers/group_event_screen_provider.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/group_event/providers/sorting_all_event_provider.dart';
@@ -141,15 +142,42 @@ class GroupEventScreen extends HookConsumerWidget {
             searchController.clear();
           }
           if (next == GroupEventCategory.forYou) {
-            unawaited(
-              ref.read(forYouEventsProvider.notifier).refreshIfStale(),
-            );
+            unawaited(ref.read(forYouEventsProvider.notifier).refreshIfStale());
           }
           FocusScope.of(context).unfocus();
           // ignore: unused_result
           ref.refresh(groupEventScreenProvider);
         }
       });
+    });
+
+    void scrollActiveEventsTabToTop() {
+      final ScrollController target;
+      if (selectedTourEvent == GroupEventCategory.forYou) {
+        target = forYouScrollController;
+      } else if (selectedTourEvent == GroupEventCategory.past) {
+        target = pastScrollController;
+      } else if (selectedTourEvent == GroupEventCategory.current) {
+        target = currentScrollController;
+      } else {
+        target = searchScrollController;
+      }
+
+      if (!target.hasClients) return;
+      target.animateTo(
+        0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
+      );
+    }
+
+    ref.listen<BottomNavBarReTapRequest>(bottomNavBarReTapRequestProvider, (
+      previous,
+      next,
+    ) {
+      if (next.item == BottomNavBarItem.tournaments) {
+        scrollActiveEventsTabToTop();
+      }
     });
 
     void onScroll() {
@@ -246,13 +274,14 @@ class GroupEventScreen extends HookConsumerWidget {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                            builder: (_) => PlayerProfileScreen(
-                              fideId: player.fideId,
-                              playerName: player.name,
-                              title: player.title,
-                              federation: player.fed,
-                              rating: player.rating,
-                            ),
+                            builder:
+                                (_) => PlayerProfileScreen(
+                                  fideId: player.fideId,
+                                  playerName: player.name,
+                                  title: player.title,
+                                  federation: player.fed,
+                                  rating: player.rating,
+                                ),
                           ),
                         );
                       },

--- a/lib/screens/home/widget/bottom_nav_bar.dart
+++ b/lib/screens/home/widget/bottom_nav_bar.dart
@@ -10,6 +10,33 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 enum BottomNavBarItem { tournaments, calendar, library }
 
+class BottomNavBarReTapRequest {
+  const BottomNavBarReTapRequest({required this.item, required this.sequence});
+
+  final BottomNavBarItem item;
+  final int sequence;
+}
+
+class BottomNavBarReTapRequestNotifier
+    extends StateNotifier<BottomNavBarReTapRequest> {
+  BottomNavBarReTapRequestNotifier()
+    : super(
+        const BottomNavBarReTapRequest(
+          item: BottomNavBarItem.tournaments,
+          sequence: 0,
+        ),
+      );
+
+  void request(BottomNavBarItem item) {
+    state = BottomNavBarReTapRequest(item: item, sequence: state.sequence + 1);
+  }
+}
+
+final bottomNavBarReTapRequestProvider = StateNotifierProvider<
+  BottomNavBarReTapRequestNotifier,
+  BottomNavBarReTapRequest
+>((ref) => BottomNavBarReTapRequestNotifier());
+
 final Map<BottomNavBarItem, String> bottomNavBarIcons = {
   BottomNavBarItem.tournaments: SvgAsset.tournamentIcon,
   BottomNavBarItem.calendar: SvgAsset.calendarIcon,
@@ -56,17 +83,19 @@ class BottomNavBar extends ConsumerWidget {
             onTap: () {
               final previous = ref.read(selectedBottomNavBarItemProvider);
               final next = BottomNavBarItem.values[index];
-              if (previous == next) return;
+              if (previous == next) {
+                ref
+                    .read(bottomNavBarReTapRequestProvider.notifier)
+                    .request(next);
+                return;
+              }
 
               ref.read(selectedBottomNavBarItemProvider.notifier).state = next;
 
               unawaited(
                 AnalyticsService.instance.trackEvent(
                   'Bottom Nav Changed',
-                  properties: {
-                    'previous_tab': previous.name,
-                    'tab': next.name,
-                  },
+                  properties: {'previous_tab': previous.name, 'tab': next.name},
                 ),
               );
             },

--- a/lib/screens/library/library_screen.dart
+++ b/lib/screens/library/library_screen.dart
@@ -21,6 +21,7 @@ import 'package:chessever2/screens/library/widgets/folder_card.dart';
 import 'package:chessever2/screens/library/widgets/library_search_bar.dart';
 import 'package:chessever2/screens/library/widgets/library_search_results_view.dart';
 import 'package:chessever2/screens/library/library_player_profile_screen.dart';
+import 'package:chessever2/screens/home/widget/bottom_nav_bar.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
@@ -44,6 +45,7 @@ class LibraryScreen extends ConsumerStatefulWidget {
 class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
+  final ScrollController _scrollController = ScrollController();
   String _searchQuery = '';
   bool _isSearchFocused = false;
 
@@ -69,7 +71,17 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     _searchFocusNode.removeListener(_onSearchFocusChange);
     _searchFocusNode.dispose();
     _searchController.dispose();
+    _scrollController.dispose();
     super.dispose();
+  }
+
+  void _scrollToTop() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
+    );
   }
 
   // Filter method - commented out as filter button is not ready yet
@@ -169,6 +181,15 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<BottomNavBarReTapRequest>(bottomNavBarReTapRequestProvider, (
+      previous,
+      next,
+    ) {
+      if (next.item == BottomNavBarItem.library) {
+        _scrollToTop();
+      }
+    });
+
     return ScreenWrapper(
       child: Center(
         child: ConstrainedBox(
@@ -225,12 +246,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                   opacity: opacity,
                   child: SizedBox(
                     width: buttonWidth,
-                    child: buttonWidth > 1
-                        ? _FilterButton(
-                            isActive: filtersActive,
-                            onTap: _openFilters,
-                          )
-                        : const SizedBox.shrink(),
+                    child:
+                        buttonWidth > 1
+                            ? _FilterButton(
+                              isActive: filtersActive,
+                              onTap: _openFilters,
+                            )
+                            : const SizedBox.shrink(),
                   ),
                 ),
 
@@ -241,12 +263,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                 opacity: opacity,
                 child: SizedBox(
                   width: buttonWidth,
-                  child: buttonWidth > 1
-                      ? _SquareIconButton(
-                          icon: Icons.grid_on_rounded,
-                          onTap: _navigateToEmptyBoard,
-                        )
-                      : const SizedBox.shrink(),
+                  child:
+                      buttonWidth > 1
+                          ? _SquareIconButton(
+                            icon: Icons.grid_on_rounded,
+                            onTap: _navigateToEmptyBoard,
+                          )
+                          : const SizedBox.shrink(),
                 ),
               ),
               // Add folder button gap
@@ -256,13 +279,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                 opacity: opacity,
                 child: SizedBox(
                   width: buttonWidth,
-                  child: buttonWidth > 1
-                      ? _SquareIconButton(
-                          icon: Icons.add,
-                          onTap: _handleCreateFolder,
-                          isPrimary: true,
-                        )
-                      : const SizedBox.shrink(),
+                  child:
+                      buttonWidth > 1
+                          ? _SquareIconButton(
+                            icon: Icons.add,
+                            onTap: _handleCreateFolder,
+                            isPrimary: true,
+                          )
+                          : const SizedBox.shrink(),
                 ),
               ),
             ],
@@ -437,8 +461,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               results: results,
               databaseGamesAsync: databaseGamesAsync,
               viewMode: viewMode,
+              scrollController: _scrollController,
               onFolderTap: (folder) async {
-                final shouldFocusSearch = await Navigator.of(context).push<bool>(
+                final shouldFocusSearch = await Navigator.of(
+                  context,
+                ).push<bool>(
                   MaterialPageRoute(
                     builder: (_) => FolderContentsScreen(folder: folder),
                   ),
@@ -500,9 +527,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       children: [
         // Subtle background decoration - only when folders exist
         if (hasFolders)
-          const Positioned.fill(
-            child: _LibraryBackgroundDecoration(),
-          ),
+          const Positioned.fill(child: _LibraryBackgroundDecoration()),
         // Main content
         RefreshIndicator(
           onRefresh: () async {
@@ -512,6 +537,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
           color: kWhiteColor,
           backgroundColor: kBlack2Color,
           child: CustomScrollView(
+            controller: _scrollController,
             physics: const AlwaysScrollableScrollPhysics(
               parent: BouncingScrollPhysics(),
             ),
@@ -550,7 +576,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     if (ResponsiveHelper.isTablet) {
       final crossAxisCount = ResponsiveHelper.tabletGridColumns.clamp(2, 3);
       return SliverPadding(
-        padding: EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: 8.h),
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontalPadding,
+          vertical: 8.h,
+        ),
         sliver: SliverGrid(
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: crossAxisCount,
@@ -564,9 +593,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               isExpanded: true,
               onTap: () async {
                 HapticFeedback.mediumImpact();
-                final shouldFocusSearch = await Navigator.of(context).push<bool>(
+                final shouldFocusSearch = await Navigator.of(
+                  context,
+                ).push<bool>(
                   MaterialPageRoute(
-                    builder: (_) => FolderContentsScreen(folder: filteredFolders[index]),
+                    builder:
+                        (_) => FolderContentsScreen(
+                          folder: filteredFolders[index],
+                        ),
                   ),
                 );
                 if (shouldFocusSearch == true && mounted) {
@@ -582,7 +616,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
 
     // Phone layout: single column list
     return SliverPadding(
-      padding: EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: 8.h),
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalPadding,
+        vertical: 8.h,
+      ),
       sliver: SliverList(
         delegate: SliverChildBuilderDelegate(
           (context, index) => Padding(
@@ -592,9 +629,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               isExpanded: true,
               onTap: () async {
                 HapticFeedback.mediumImpact();
-                final shouldFocusSearch = await Navigator.of(context).push<bool>(
+                final shouldFocusSearch = await Navigator.of(
+                  context,
+                ).push<bool>(
                   MaterialPageRoute(
-                    builder: (_) => FolderContentsScreen(folder: filteredFolders[index]),
+                    builder:
+                        (_) => FolderContentsScreen(
+                          folder: filteredFolders[index],
+                        ),
                   ),
                 );
                 if (shouldFocusSearch == true && mounted) {
@@ -746,10 +788,7 @@ class _FilterButton extends StatelessWidget {
   final bool isActive;
   final VoidCallback onTap;
 
-  const _FilterButton({
-    required this.isActive,
-    required this.onTap,
-  });
+  const _FilterButton({required this.isActive, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -764,9 +803,10 @@ class _FilterButton extends StatelessWidget {
           color: const Color(0xFF09090B), // Zinc 950
           borderRadius: BorderRadius.circular(10.br),
           border: Border.all(
-            color: isActive
-                ? const Color(0xFF52525B) // Zinc 600 when active
-                : const Color(0xFF27272A), // Zinc 800
+            color:
+                isActive
+                    ? const Color(0xFF52525B) // Zinc 600 when active
+                    : const Color(0xFF27272A), // Zinc 800
           ),
         ),
         child: Center(
@@ -926,8 +966,7 @@ class _LibraryEmptyStateContent extends StatelessWidget {
             isLight
                 ? const Color(0xFF3F3F46).withValues(alpha: opacity * 0.6)
                 : const Color(0xFF27272A).withValues(alpha: opacity * 0.8),
-        borderRadius:
-            _getCornerRadius(row, col, gridSize, 6.br),
+        borderRadius: _getCornerRadius(row, col, gridSize, 6.br),
       ),
     );
   }

--- a/lib/screens/library/widgets/library_search_results_view.dart
+++ b/lib/screens/library/widgets/library_search_results_view.dart
@@ -31,6 +31,7 @@ class LibrarySearchResultsView extends ConsumerStatefulWidget {
   final Function(GamebasePlayer) onPlayerFilter;
   final Function(SavedAnalysis) onAnalysisTap;
   final Function(GamesTourModel) onGameTap;
+  final ScrollController? scrollController;
 
   const LibrarySearchResultsView({
     super.key,
@@ -42,25 +43,33 @@ class LibrarySearchResultsView extends ConsumerStatefulWidget {
     required this.onPlayerFilter,
     required this.onAnalysisTap,
     required this.onGameTap,
+    this.scrollController,
   });
 
   @override
-  ConsumerState<LibrarySearchResultsView> createState() => _LibrarySearchResultsViewState();
+  ConsumerState<LibrarySearchResultsView> createState() =>
+      _LibrarySearchResultsViewState();
 }
 
-class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsView> {
-  final ScrollController _scrollController = ScrollController();
+class _LibrarySearchResultsViewState
+    extends ConsumerState<LibrarySearchResultsView> {
+  late final ScrollController _scrollController;
+  late final bool _ownsScrollController;
 
   @override
   void initState() {
     super.initState();
+    _scrollController = widget.scrollController ?? ScrollController();
+    _ownsScrollController = widget.scrollController == null;
     _scrollController.addListener(_onScroll);
   }
 
   @override
   void dispose() {
     _scrollController.removeListener(_onScroll);
-    _scrollController.dispose();
+    if (_ownsScrollController) {
+      _scrollController.dispose();
+    }
     super.dispose();
   }
 
@@ -91,7 +100,9 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
     final data = row['data'];
     final mdRaw = data is Map ? (data['md'] ?? data['metadata']) : null;
     final md =
-        mdRaw is Map ? Map<String, dynamic>.from(mdRaw) : const <String, dynamic>{};
+        mdRaw is Map
+            ? Map<String, dynamic>.from(mdRaw)
+            : const <String, dynamic>{};
 
     // Headers fallback
     final whiteName =
@@ -146,7 +157,8 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
         (md['ECO'] as String?)?.trim().isNotEmpty == true
             ? md['ECO'].toString()
             : (row['eco']?.toString() ?? row['ECO']?.toString());
-    final formatCode = (eco != null && eco.isNotEmpty) ? eco : (timeControl ?? '');
+    final formatCode =
+        (eco != null && eco.isNotEmpty) ? eco : (timeControl ?? '');
 
     int parseRating(dynamic value) {
       if (value is int) return value;
@@ -229,7 +241,8 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
 
   @override
   Widget build(BuildContext context) {
-    final fallbackGameModels = widget.results.games.map(_mapToGameModel).toList();
+    final fallbackGameModels =
+        widget.results.games.map(_mapToGameModel).toList();
 
     // Watch the paginated provider for database games
     final paginationState = ref.watch(gamebaseDatabaseGamesPaginatedProvider);
@@ -241,8 +254,7 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
           error: (_, __) => true,
           orElse: () => false,
         ) ??
-        paginationState.games.isNotEmpty ||
-        fallbackGameModels.isNotEmpty;
+        paginationState.games.isNotEmpty || fallbackGameModels.isNotEmpty;
 
     final hasAnyResults =
         widget.results.folders.isNotEmpty ||
@@ -290,9 +302,10 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
         if (widget.results.players.isNotEmpty) ...[
           _SectionHeader(
             title: 'Players',
-            count: widget.results.playerTotalCount > 0
-                ? widget.results.playerTotalCount
-                : widget.results.players.length,
+            count:
+                widget.results.playerTotalCount > 0
+                    ? widget.results.playerTotalCount
+                    : widget.results.players.length,
           ),
           ListView.separated(
             shrinkWrap: true,
@@ -350,18 +363,22 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
     required GamesListViewMode viewMode,
   }) {
     // Use paginated games if available, otherwise fall back to legacy
-    final games = paginationState.games.isNotEmpty
-        ? paginationState.games
-        : (databaseGamesAsync?.valueOrNull ?? fallbackGames);
+    final games =
+        paginationState.games.isNotEmpty
+            ? paginationState.games
+            : (databaseGamesAsync?.valueOrNull ?? fallbackGames);
 
-    if (games.isEmpty && !paginationState.isLoading && databaseGamesAsync == null) {
+    if (games.isEmpty &&
+        !paginationState.isLoading &&
+        databaseGamesAsync == null) {
       return const [];
     }
 
     return [
       _SectionHeader(
         title: 'Database Games',
-        count: paginationState.totalCount > 0 ? paginationState.totalCount : null,
+        count:
+            paginationState.totalCount > 0 ? paginationState.totalCount : null,
       ),
       if (games.isEmpty && paginationState.isLoading)
         Padding(
@@ -379,11 +396,7 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
           ),
         )
       else
-        _buildGamesList(
-          context: context,
-          games: games,
-          viewMode: viewMode,
-        ),
+        _buildGamesList(context: context, games: games, viewMode: viewMode),
 
       // Load more indicator
       if (paginationState.hasMore && games.isNotEmpty) ...[
@@ -391,9 +404,10 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
         _LoadMoreButton(
           isLoading: paginationState.isLoading,
           onTap: _loadMoreGames,
-          remainingCount: paginationState.totalCount > 0
-              ? paginationState.totalCount - games.length
-              : null,
+          remainingCount:
+              paginationState.totalCount > 0
+                  ? paginationState.totalCount - games.length
+                  : null,
         ),
       ],
 
@@ -428,7 +442,8 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
     if (isGrid) {
       // Grid mode: dynamic columns based on device/orientation
       // Tablet landscape: 4 columns, Tablet portrait: 2 columns, Phone: 2 columns
-      final int gridColumns = ResponsiveHelper.isTablet && ResponsiveHelper.isLandscape ? 4 : 2;
+      final int gridColumns =
+          ResponsiveHelper.isTablet && ResponsiveHelper.isLandscape ? 4 : 2;
       final items = <Widget>[];
 
       for (int i = 0; i < games.length; i += gridColumns) {
@@ -448,13 +463,14 @@ class _LibrarySearchResultsViewState extends ConsumerState<LibrarySearchResultsV
                 for (int j = 0; j < gridColumns; j++) ...[
                   if (j > 0) SizedBox(width: 12.sp),
                   Expanded(
-                    child: j < rowGames.length
-                        ? _LibraryGridGame(
-                            game: rowGames[j],
-                            gameIndex: i + j,
-                            allGames: games,
-                          )
-                        : const SizedBox.shrink(),
+                    child:
+                        j < rowGames.length
+                            ? _LibraryGridGame(
+                              game: rowGames[j],
+                              gameIndex: i + j,
+                              allGames: games,
+                            )
+                            : const SizedBox.shrink(),
                   ),
                 ],
               ],
@@ -521,18 +537,19 @@ class _LoadMoreButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: isLoading ? null : () {
-        HapticFeedbackService.light();
-        onTap();
-      },
+      onTap:
+          isLoading
+              ? null
+              : () {
+                HapticFeedbackService.light();
+                onTap();
+              },
       child: Container(
         padding: EdgeInsets.symmetric(vertical: 14.h, horizontal: 20.w),
         decoration: BoxDecoration(
           color: const Color(0xFF18181B),
           borderRadius: BorderRadius.circular(12.br),
-          border: Border.all(
-            color: const Color(0xFF27272A),
-          ),
+          border: Border.all(color: const Color(0xFF27272A)),
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -552,8 +569,8 @@ class _LoadMoreButton extends StatelessWidget {
               isLoading
                   ? 'Loading...'
                   : remainingCount != null
-                      ? 'Load more ($remainingCount remaining)'
-                      : 'Load more games',
+                  ? 'Load more ($remainingCount remaining)'
+                  : 'Load more games',
               style: AppTypography.textSmMedium.copyWith(
                 color: kWhiteColor.withValues(alpha: 0.9),
               ),
@@ -592,14 +609,15 @@ class _LibraryGridGame extends ConsumerWidget {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => ChessBoardScreenNew(
-              games: allGames,
-              currentIndex: gameIndex,
-              hideEventInfo: true,
-              showGamebaseButton: false,
-              disableGamebaseOverlayByDefault: true,
-              showClock: false,
-            ),
+            builder:
+                (_) => ChessBoardScreenNew(
+                  games: allGames,
+                  currentIndex: gameIndex,
+                  hideEventInfo: true,
+                  showGamebaseButton: false,
+                  disableGamebaseOverlayByDefault: true,
+                  showClock: false,
+                ),
           ),
         );
       },
@@ -636,14 +654,15 @@ class _LibraryBoardGame extends ConsumerWidget {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => ChessBoardScreenNew(
-              games: allGames,
-              currentIndex: gameIndex,
-              hideEventInfo: true,
-              showGamebaseButton: false,
-              disableGamebaseOverlayByDefault: true,
-              showClock: false,
-            ),
+            builder:
+                (_) => ChessBoardScreenNew(
+                  games: allGames,
+                  currentIndex: gameIndex,
+                  hideEventInfo: true,
+                  showGamebaseButton: false,
+                  disableGamebaseOverlayByDefault: true,
+                  showClock: false,
+                ),
           ),
         );
       },

--- a/test/bottom_nav_bar_retap_test.dart
+++ b/test/bottom_nav_bar_retap_test.dart
@@ -1,0 +1,27 @@
+import 'package:chessever2/screens/home/widget/bottom_nav_bar.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test(
+    'bottom nav re-tap requests advance sequence for repeated same tab taps',
+    () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(
+        bottomNavBarReTapRequestProvider.notifier,
+      );
+
+      notifier.request(BottomNavBarItem.tournaments);
+      final first = container.read(bottomNavBarReTapRequestProvider);
+
+      notifier.request(BottomNavBarItem.tournaments);
+      final second = container.read(bottomNavBarReTapRequestProvider);
+
+      expect(first.item, BottomNavBarItem.tournaments);
+      expect(second.item, BottomNavBarItem.tournaments);
+      expect(second.sequence, first.sequence + 1);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Re-tapping the already-selected bottom navigation tab now emits a scroll-to-top request instead of doing nothing.
- Events scrolls the currently visible For You / Current / Past / Search list to the top without changing the selected subtab.
- Calendar and Library listen for their active-tab re-tap and scroll their current root list to the top, including Library search results.

## Test Plan
- `dart format --set-exit-if-changed lib/screens/home/widget/bottom_nav_bar.dart lib/screens/group_event/group_event_screen.dart lib/screens/calendar/calendar_screen.dart lib/screens/library/library_screen.dart lib/screens/library/widgets/library_search_results_view.dart test/bottom_nav_bar_retap_test.dart`
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/screens/home/widget/bottom_nav_bar.dart lib/screens/group_event/group_event_screen.dart lib/screens/calendar/calendar_screen.dart lib/screens/library/library_screen.dart lib/screens/library/widgets/library_search_results_view.dart test/bottom_nav_bar_retap_test.dart` *(passes with existing non-fatal warnings/infos in touched files)*
- `flutter test test/bottom_nav_bar_retap_test.dart`

## Notes for reviewer
- Pull-to-refresh behavior is untouched; this only animates the active scroll controller to offset 0.
- Switching to a different bottom tab keeps the existing navigation analytics behavior.
- Re-tapping Events preserves the active Events subtab and only scrolls that visible list.

Review requested: @devberkay
