### PR TITLE
Fix grouped round-start notification dedupe metadata

### DIFF
--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -1136,13 +1136,19 @@ function isCombinedTour(tour: TourRow | null): boolean {
   return /(^|[^a-z0-9])combined([^a-z0-9]|$)/.test(label);
 }
 
+function normalizeRoundName(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase().replace(/\s+/g, " ") ?? "";
+  return normalized || null;
+}
+
 function groupedRoundStartCollapseKey(
   context: { round: RoundRow | null; groupBroadcastId: string | null },
 ): string | null {
   const startsAt = context.round?.starts_at;
   const groupId = context.groupBroadcastId;
-  if (!startsAt || !groupId) return null;
-  return `round_started:${groupId}:${startsAt}`;
+  const roundName = normalizeRoundName(context.round?.name);
+  if (!startsAt || !groupId || !roundName) return null;
+  return `round_started:${groupId}:${roundName}:${startsAt}`;
 }
 
 function buildRoundStartedNotificationData(
@@ -1152,6 +1158,8 @@ function buildRoundStartedNotificationData(
   return {
     type: "round_started",
     round_id: roundId,
+    round_name: context.round?.name ?? null,
+    starts_at: context.round?.starts_at ?? null,
     group_broadcast_id: context.groupBroadcastId ?? null,
     grouped_round_start_key: groupedRoundStartCollapseKey(context),
   };
@@ -1163,7 +1171,9 @@ async function hasSentGroupedRoundStart(
 ): Promise<boolean> {
   const startsAt = context.round?.starts_at;
   const groupId = context.groupBroadcastId;
-  if (!startsAt || !groupId) return false;
+  const roundName = normalizeRoundName(context.round?.name);
+  const groupedKey = groupedRoundStartCollapseKey(context);
+  if (!startsAt || !groupId || !roundName) return false;
 
   const itemCreatedAt = new Date(item.created_at).getTime();
   const minCreatedAt = new Date(itemCreatedAt - 60 * 60 * 1000).toISOString();
@@ -1181,7 +1191,16 @@ async function hasSentGroupedRoundStart(
   if (error) return false;
 
   return ((data ?? []) as Array<{ payload?: Record<string, unknown> | null }>)
-    .some((row) => sameInstant(row.payload?.starts_at, startsAt));
+    .some((row) => {
+      const payload = row.payload ?? {};
+      if (groupedKey && payload.grouped_round_start_key === groupedKey) {
+        return true;
+      }
+      return sameInstant(payload.starts_at, startsAt) &&
+        normalizeRoundName(
+          typeof payload.round_name === "string" ? payload.round_name : null,
+        ) === roundName;
+    });
 }
 
 function sameInstant(a: unknown, b: string): boolean {

--- a/supabase/migrations/20260528203125_grouped_round_start_round_name_dedupe.sql
+++ b/supabase/migrations/20260528203125_grouped_round_start_round_name_dedupe.sql
@@ -1,0 +1,49 @@
+-- Follow-up to grouped round-start notification dedupe.
+-- The visible dedupe identity is group_broadcast_id + round name + exact start
+-- instant, matching the Edge Function collapse key. This keeps Open/Women/
+-- Combined copies of the same visible round to one push, without collapsing
+-- distinct named rounds that happen to share a grouped event start timestamp.
+
+CREATE OR REPLACE FUNCTION public.queue_round_start_notifications()
+RETURNS void AS $$
+DECLARE
+  now_ts TIMESTAMPTZ := now();
+BEGIN
+  INSERT INTO public.notification_outbox (
+    event_type,
+    round_id,
+    tour_id,
+    group_broadcast_id,
+    payload,
+    dedupe_key
+  )
+  SELECT
+    'round_started',
+    r.id,
+    r.tour_id,
+    t.group_broadcast_id,
+    jsonb_build_object(
+      'round_name', r.name,
+      'starts_at', r.starts_at
+    ),
+    CASE
+      WHEN t.group_broadcast_id IS NOT NULL AND nullif(btrim(r.name), '') IS NOT NULL THEN
+        'round_started:' ||
+        t.group_broadcast_id::text || ':' ||
+        lower(regexp_replace(btrim(r.name), '\s+', ' ', 'g')) || ':' ||
+        EXTRACT(EPOCH FROM r.starts_at)::bigint::text
+      WHEN t.group_broadcast_id IS NOT NULL THEN
+        'round_started:' ||
+        t.group_broadcast_id::text || ':' ||
+        EXTRACT(EPOCH FROM r.starts_at)::bigint::text
+      ELSE
+        'round_started:' || r.id::text
+    END
+  FROM public.rounds r
+  JOIN public.tours t ON t.id = r.tour_id
+  WHERE r.starts_at IS NOT NULL
+    AND r.starts_at <= now_ts
+    AND r.starts_at >= now_ts - interval '10 minutes'
+  ON CONFLICT (dedupe_key) DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;

--- a/test_notification_dispatch_dedupe.py
+++ b/test_notification_dispatch_dedupe.py
@@ -5,6 +5,9 @@ EDGE_FUNCTION = Path("supabase/functions/onesignal-dispatch/index.ts")
 ROUND_START_DEDUPE_MIGRATION = Path(
     "supabase/migrations/20260527232342_grouped_round_start_exact_time_dedupe.sql"
 )
+ROUND_START_ROUND_NAME_DEDUPE_MIGRATION = Path(
+    "supabase/migrations/20260528203125_grouped_round_start_round_name_dedupe.sql"
+)
 
 
 def _source() -> str:
@@ -42,12 +45,15 @@ def test_game_and_round_notifications_have_device_collapse_id() -> None:
     assert 'round:${type ?? "update"}:${roundId}' in source
 
 
-def test_round_started_uses_grouped_exact_start_collapse_id() -> None:
+def test_round_started_uses_grouped_round_name_exact_start_collapse_id() -> None:
     source = _source()
 
     assert "function groupedRoundStartCollapseKey" in source
-    assert "round_started:${groupId}:${startsAt}" in source
+    assert "const roundName = normalizeRoundName(context.round?.name)" in source
+    assert "round_started:${groupId}:${roundName}:${startsAt}" in source
     assert "grouped_round_start_key: groupedRoundStartCollapseKey(context)" in source
+    assert "round_name: context.round?.name ?? null" in source
+    assert "starts_at: context.round?.starts_at ?? null" in source
     assert "typeof groupedRoundStartKey" in source
 
 
@@ -59,7 +65,9 @@ def test_dispatcher_skips_duplicate_grouped_round_starts() -> None:
     assert '.eq("event_type", "round_started")' in source
     assert '.eq("group_broadcast_id", groupId)' in source
     assert '.eq("status", "sent")' in source
-    assert "sameInstant(row.payload?.starts_at, startsAt)" in source
+    assert "payload.grouped_round_start_key === groupedKey" in source
+    assert "sameInstant(payload.starts_at, startsAt)" in source
+    assert "normalizeRoundName(" in source
 
 
 def test_combined_tours_do_not_send_round_result_notifications() -> None:
@@ -75,6 +83,18 @@ def test_round_start_queue_dedupe_is_exact_group_start_time_not_two_hour_bucket(
 
     assert "CREATE OR REPLACE FUNCTION public.queue_round_start_notifications()" in migration
     assert "t.group_broadcast_id::text" in migration
+    assert "EXTRACT(EPOCH FROM r.starts_at)::bigint::text" in migration
+    assert "'round_started:' || r.id::text" in migration
+    assert "/ 7200" not in migration
+
+
+def test_round_start_queue_dedupe_followup_includes_visible_round_name() -> None:
+    migration = ROUND_START_ROUND_NAME_DEDUPE_MIGRATION.read_text(encoding="utf-8")
+
+    assert "CREATE OR REPLACE FUNCTION public.queue_round_start_notifications()" in migration
+    assert "nullif(btrim(r.name), '') IS NOT NULL" in migration
+    assert "lower(regexp_replace(btrim(r.name), '\\s+', ' ', 'g'))" in migration
+    assert "t.group_broadcast_id::text || ':' ||" in migration
     assert "EXTRACT(EPOCH FROM r.starts_at)::bigint::text" in migration
     assert "'round_started:' || r.id::text" in migration
     assert "/ 7200" not in migration


### PR DESCRIPTION
## Summary
- Follow-up to PR #186 / Berkay local notification dedupe work; this is additive and does not replace the existing dispatcher changes.
- Includes `round_name` and `starts_at` in round-start notification data, so the existing sent-row duplicate check has the metadata it compares.
- Tightens grouped round-start collapse/dedupe identity to `group_broadcast_id + normalized round_name + exact starts_at`, matching the requested visible round identity and avoiding accidental collapse of distinct named rounds.
- Adds a Supabase migration that updates `queue_round_start_notifications()` to use the same grouped visible-round dedupe key shape.
- Extends focused regression coverage for the follow-up behavior.

## Why
PR #186 / Berkay's local follow-up already added the main notification dedupe pieces on `dev`, but the dispatcher compared prior sent rows by `payload.starts_at` while sent round-start notification data did not include `starts_at`. This follow-up makes that duplicate check deterministic and aligned with the visible-event rule: one visible grouped round-start notification = one push.

## Validation
- `pytest -q test_notification_dispatch_dedupe.py` — 8 passed
- `python3 -m py_compile test_notification_dispatch_dedupe.py`
- `git diff --check HEAD~1 HEAD`
- `npm --cache /tmp/npm-cache exec --yes --package=esbuild esbuild -- supabase/functions/onesignal-dispatch/index.ts --bundle --platform=neutral --format=esm '--external:jsr:*' '--external:npm:*' --outfile=/tmp/onesignal-dispatch-followup-check.js`

## Notes
- Base: `dev`, because the PR #186/Berkay notification dedupe pieces are already present on `origin/dev` and not on `origin/main`.
- Scope is intentionally narrow: no notification wording/UI/preference changes, no unrelated push categories, no production data mutation.
