### PR TITLE
Fix Norway Chess scoring display

### DIFF
--- a/lib/repository/supabase/game/games.dart
+++ b/lib/repository/supabase/game/games.dart
@@ -266,6 +266,7 @@ class Player {
   final String fed;
   final int clock;
   final String team;
+  final double? customPoints;
 
   Player({
     required this.name,
@@ -275,6 +276,7 @@ class Player {
     required this.fed,
     required this.clock,
     required this.team,
+    this.customPoints,
   });
 
   factory Player.fromJsonString(String jsonString) {
@@ -297,6 +299,7 @@ class Player {
       fed: json['fed'] as String? ?? '',
       clock: (json['clock'] as num?)?.toInt() ?? 0,
       team: json['team'] as String? ?? '',
+      customPoints: (json['customPoints'] as num?)?.toDouble(),
     );
   }
 
@@ -309,6 +312,7 @@ class Player {
       'fed': fed,
       'clock': clock,
       'team': team,
+      if (customPoints != null) 'customPoints': customPoints,
     };
   }
 }

--- a/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
+++ b/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
@@ -16,6 +16,7 @@ import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provide
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/broadcast_custom_scoring.dart';
 import 'package:chessever2/utils/chess_title_utils.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
 import 'package:chessever2/utils/pgn_clock_utils.dart';
@@ -649,11 +650,12 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
                                     isWhitePlayer) ||
                                 (status == GameStatus.blackWins &&
                                     !isWhitePlayer);
-                            final label = isDraw
-                                ? '½'
-                                : isWin
-                                    ? '1'
-                                    : '0';
+                            final label =
+                                boardResultLabelForSide(
+                                  effectiveGameModel,
+                                  isWhite: isWhitePlayer,
+                                ) ??
+                                '';
                             final resultColor =
                                 isWin
                                     ? kPrimaryColor

--- a/lib/screens/standings/score_card_screen.dart
+++ b/lib/screens/standings/score_card_screen.dart
@@ -15,6 +15,7 @@ import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_pr
 import 'package:chessever2/screens/player_profile/widgets/performance_stats_row.dart';
 import 'package:chessever2/services/fide_photo_service.dart';
 import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/broadcast_custom_scoring.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
 import 'package:chessever2/utils/png_asset.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -526,9 +527,8 @@ class ScoreCardScreen extends ConsumerWidget {
           if (playerRating > 0) {
             final tc = game.timeControl;
             final fideK = tc != null ? playerRatings?.getK(tc) : null;
-            final fidePlayerRating = tc != null
-                ? playerRatings?.getRating(tc)?.toDouble()
-                : null;
+            final fidePlayerRating =
+                tc != null ? playerRatings?.getRating(tc)?.toDouble() : null;
             final ratingChange = _calculateFideRatingChange(
               playerRating,
               opponentRating,
@@ -724,7 +724,9 @@ class ScoreCardScreen extends ConsumerWidget {
                           Icon(
                             Icons.info_outline,
                             size: 40.ic,
-                            color: context.colors.textPrimary.withValues(alpha: 0.5),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.5,
+                            ),
                           ),
                           SizedBox(height: 12.h),
                           Text(
@@ -732,7 +734,9 @@ class ScoreCardScreen extends ConsumerWidget {
                                 ? 'No games in this tournament'
                                 : 'No games available',
                             style: AppTypography.textSmMedium.copyWith(
-                              color: context.colors.textPrimary.withValues(alpha: 0.7),
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.7,
+                              ),
                             ),
                           ),
                           SizedBox(height: 6.h),
@@ -742,7 +746,9 @@ class ScoreCardScreen extends ConsumerWidget {
                                 : 'Games will appear once they are played',
                             textAlign: TextAlign.center,
                             style: AppTypography.textXsRegular.copyWith(
-                              color: context.colors.textPrimary.withValues(alpha: 0.5),
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.5,
+                              ),
                             ),
                           ),
                         ],
@@ -779,9 +785,10 @@ class ScoreCardScreen extends ConsumerWidget {
                         final tc = game.timeControl;
                         final fideK =
                             tc != null ? playerRatings?.getK(tc) : null;
-                        final fidePlayerRating = tc != null
-                            ? playerRatings?.getRating(tc)?.toDouble()
-                            : null;
+                        final fidePlayerRating =
+                            tc != null
+                                ? playerRatings?.getRating(tc)?.toDouble()
+                                : null;
                         ratingChange = _calculateFideRatingChange(
                           playerRating,
                           opponentRating,
@@ -863,18 +870,19 @@ class ScoreCardScreen extends ConsumerWidget {
   }
 
   String _getPlayerResult(GamesTourModel game, bool isWhite) {
-    switch (game.gameStatus) {
-      case GameStatus.whiteWins:
-        return isWhite ? '1' : '0';
-      case GameStatus.blackWins:
-        return isWhite ? '0' : '1';
-      case GameStatus.draw:
-        return '½';
-      case GameStatus.ongoing:
-        return '–';
-      case GameStatus.unknown:
-        return '-';
+    if (isArmageddonGame(game)) {
+      return customAwareResultLabelForSide(
+            game.gameStatus,
+            isWhite: isWhite,
+            customPoints:
+                isWhite
+                    ? game.whitePlayer.customPoints
+                    : game.blackPlayer.customPoints,
+          ) ??
+          '-';
     }
+
+    return boardResultLabelForSide(game, isWhite: isWhite) ?? '-';
   }
 
   String? _buildRoundLabel(GamesTourModel game) {
@@ -1081,14 +1089,20 @@ class _PlayerHeaderRow extends StatelessWidget {
                   ),
                 TextSpan(
                   text: name,
-                  style: AppTypography.textMdBold.copyWith(color: context.colors.textPrimary),
+                  style: AppTypography.textMdBold.copyWith(
+                    color: context.colors.textPrimary,
+                  ),
                 ),
               ],
             ),
           ),
         ),
         if (hasTournamentContext)
-          Icon(Icons.keyboard_arrow_down, color: context.colors.textPrimaryMuted, size: 20.ic),
+          Icon(
+            Icons.keyboard_arrow_down,
+            color: context.colors.textPrimaryMuted,
+            size: 20.ic,
+          ),
       ],
     );
   }
@@ -1437,7 +1451,7 @@ class _RatingDisplay extends ConsumerWidget {
                   () => Skeletonizer(
                     enabled: true,
                     ignoreContainers: true,
-                    effect:  ShimmerEffect(
+                    effect: ShimmerEffect(
                       baseColor: context.colors.surfaceRecessed,
                       highlightColor: context.colors.divider,
                     ),
@@ -1503,12 +1517,18 @@ class _PlayerSelectionSheet extends ConsumerWidget {
             children: [
               Text(
                 'Select Player',
-                style: AppTypography.textMdBold.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textMdBold.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
               const Spacer(),
               GestureDetector(
                 onTap: () => Navigator.pop(context),
-                child: Icon(Icons.close, color: context.colors.textPrimaryMuted, size: 20.ic),
+                child: Icon(
+                  Icons.close,
+                  color: context.colors.textPrimaryMuted,
+                  size: 20.ic,
+                ),
               ),
             ],
           ),
@@ -1543,7 +1563,8 @@ class _PlayerSelectionSheet extends ConsumerWidget {
                     horizontal: 16.sp,
                     vertical: 10.h,
                   ),
-                  color: isSelected ? context.colors.surface : Colors.transparent,
+                  color:
+                      isSelected ? context.colors.surface : Colors.transparent,
                   child: Row(
                     children: [
                       // Country flag
@@ -1566,7 +1587,10 @@ class _PlayerSelectionSheet extends ConsumerWidget {
                         child: Text(
                           '${player.title != null && player.title!.isNotEmpty ? '${player.title} ' : ''}${player.name}',
                           style: AppTypography.textSmMedium.copyWith(
-                            color: isSelected ? kGreenColor : context.colors.textPrimary,
+                            color:
+                                isSelected
+                                    ? kGreenColor
+                                    : context.colors.textPrimary,
                           ),
                           overflow: TextOverflow.ellipsis,
                         ),

--- a/lib/screens/tour_detail/games_tour/models/games_tour_model.dart
+++ b/lib/screens/tour_detail/games_tour/models/games_tour_model.dart
@@ -638,6 +638,7 @@ class PlayerCard {
   final int? fideId;
   final String? team;
   final String? gamebasePlayerId;
+  final double? customPoints;
 
   PlayerCard({
     required this.name,
@@ -648,6 +649,7 @@ class PlayerCard {
     required this.team,
     this.fideId,
     this.gamebasePlayerId,
+    this.customPoints,
   });
 
   factory PlayerCard.fromPlayer(Player player) {
@@ -664,6 +666,7 @@ class PlayerCard {
       countryCode: player.fed.trim(),
       fideId: player.fideId > 0 ? player.fideId : null,
       team: player.team,
+      customPoints: player.customPoints,
     );
   }
 
@@ -676,6 +679,7 @@ class PlayerCard {
     int? fideId,
     String? team,
     String? gamebasePlayerId,
+    double? customPoints,
   }) {
     return PlayerCard(
       name: name ?? this.name,
@@ -686,6 +690,7 @@ class PlayerCard {
       fideId: fideId ?? this.fideId,
       team: team ?? this.team,
       gamebasePlayerId: gamebasePlayerId ?? this.gamebasePlayerId,
+      customPoints: customPoints ?? this.customPoints,
     );
   }
 
@@ -704,7 +709,8 @@ class PlayerCard {
         other.countryCode == countryCode &&
         other.fideId == fideId &&
         other.team == team &&
-        other.gamebasePlayerId == gamebasePlayerId;
+        other.gamebasePlayerId == gamebasePlayerId &&
+        other.customPoints == customPoints;
   }
 
   @override
@@ -718,6 +724,7 @@ class PlayerCard {
       fideId,
       team,
       gamebasePlayerId,
+      customPoints,
     );
   }
 }

--- a/lib/utils/broadcast_custom_scoring.dart
+++ b/lib/utils/broadcast_custom_scoring.dart
@@ -1,0 +1,83 @@
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+
+String formatBroadcastScore(double score) {
+  return score % 1 == 0 ? score.toInt().toString() : score.toStringAsFixed(1);
+}
+
+double? standardResultValueForSide(GameStatus status, {required bool isWhite}) {
+  switch (status) {
+    case GameStatus.whiteWins:
+      return isWhite ? 1.0 : 0.0;
+    case GameStatus.blackWins:
+      return isWhite ? 0.0 : 1.0;
+    case GameStatus.draw:
+      return 0.5;
+    case GameStatus.ongoing:
+    case GameStatus.unknown:
+      return null;
+  }
+}
+
+String? standardResultLabelForSide(GameStatus status, {required bool isWhite}) {
+  final value = standardResultValueForSide(status, isWhite: isWhite);
+  if (value == null) return null;
+  if (value == 0.5) return '½';
+  return formatBroadcastScore(value);
+}
+
+String? customAwareResultLabelForSide(
+  GameStatus status, {
+  required bool isWhite,
+  double? customPoints,
+}) {
+  final standardValue = standardResultValueForSide(status, isWhite: isWhite);
+  if (standardValue == null) return null;
+
+  if (customPoints != null &&
+      customPoints != 0.0 &&
+      customPoints != standardValue) {
+    return formatBroadcastScore(customPoints);
+  }
+
+  return standardValue == 0.5 ? '½' : formatBroadcastScore(standardValue);
+}
+
+bool isArmageddonGame(GamesTourModel game) {
+  return _containsArmageddon(game.roundSlug) ||
+      _containsArmageddon(game.roundId) ||
+      _containsArmageddon(game.tourSlug);
+}
+
+bool _containsArmageddon(String? value) {
+  return value?.toLowerCase().contains('armageddon') ?? false;
+}
+
+String? boardResultLabelForSide(GamesTourModel game, {required bool isWhite}) {
+  if (isArmageddonGame(game)) {
+    return standardResultLabelForSide(game.gameStatus, isWhite: isWhite);
+  }
+
+  return customAwareResultLabelForSide(
+    game.gameStatus,
+    isWhite: isWhite,
+    customPoints:
+        isWhite ? game.whitePlayer.customPoints : game.blackPlayer.customPoints,
+  );
+}
+
+({double? score, int played}) resolveBroadcastStandingScore({
+  required double? sourceScore,
+  required int sourcePlayed,
+  required double calculatedScore,
+  required int calculatedPlayed,
+  bool preserveSourceScore = true,
+}) {
+  if (preserveSourceScore && sourceScore != null) {
+    return (
+      score: sourceScore,
+      played: sourcePlayed > calculatedPlayed ? sourcePlayed : calculatedPlayed,
+    );
+  }
+
+  return (score: calculatedScore, played: calculatedPlayed);
+}

--- a/test/broadcast_custom_scoring_test.dart
+++ b/test/broadcast_custom_scoring_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/utils/broadcast_custom_scoring.dart';
+
+void main() {
+  group('custom-aware broadcast game points', () {
+    test('shows custom win points when they differ from standard result', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.whiteWins,
+          isWhite: true,
+          customPoints: 3.0,
+        ),
+        '3',
+      );
+    });
+
+    test('keeps standard win when custom points match standard result', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.whiteWins,
+          isWhite: true,
+          customPoints: 1.0,
+        ),
+        '1',
+      );
+    });
+
+    test('keeps draw label when custom points are zero', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.draw,
+          isWhite: true,
+          customPoints: 0.0,
+        ),
+        '½',
+      );
+    });
+  });
+
+  group('Norway board and player-card scoring', () {
+    test('board view shows classical custom win as 3-0', () {
+      final game = _game(
+        status: GameStatus.whiteWins,
+        whiteCustomPoints: 3.0,
+        blackCustomPoints: 0.0,
+      );
+
+      expect(boardResultLabelForSide(game, isWhite: true), '3');
+      expect(boardResultLabelForSide(game, isWhite: false), '0');
+    });
+
+    test('board view shows classical draw custom points as 1-1', () {
+      final game = _game(
+        status: GameStatus.draw,
+        whiteCustomPoints: 1.0,
+        blackCustomPoints: 1.0,
+      );
+
+      expect(boardResultLabelForSide(game, isWhite: true), '1');
+      expect(boardResultLabelForSide(game, isWhite: false), '1');
+    });
+
+    test('board view keeps Armageddon simple as 1-0', () {
+      final game = _game(
+        status: GameStatus.whiteWins,
+        roundSlug: 'round-4-armageddon',
+        whiteCustomPoints: 0.5,
+        blackCustomPoints: 0.0,
+      );
+
+      expect(boardResultLabelForSide(game, isWhite: true), '1');
+      expect(boardResultLabelForSide(game, isWhite: false), '0');
+    });
+
+    test('player card can show Armageddon bonus as 0.5', () {
+      expect(
+        customAwareResultLabelForSide(
+          GameStatus.whiteWins,
+          isWhite: true,
+          customPoints: 0.5,
+        ),
+        '0.5',
+      );
+    });
+  });
+
+  group('broadcast standings score resolution', () {
+    test('preserves custom source score and updates played count', () {
+      final resolved = resolveBroadcastStandingScore(
+        sourceScore: 3.0,
+        sourcePlayed: 1,
+        calculatedScore: 1.0,
+        calculatedPlayed: 1,
+      );
+
+      expect(resolved.score, 3.0);
+      expect(resolved.played, 1);
+    });
+
+    test('falls back to calculated score when no source score exists', () {
+      final resolved = resolveBroadcastStandingScore(
+        sourceScore: null,
+        sourcePlayed: 0,
+        calculatedScore: 1.5,
+        calculatedPlayed: 2,
+      );
+
+      expect(resolved.score, 1.5);
+      expect(resolved.played, 2);
+    });
+  });
+
+  test('parses per-player customPoints from game players JSON', () {
+    final player = Player.fromJson(const {
+      'name': 'Alireza Firouzja',
+      'rating': 2759,
+      'customPoints': 3.0,
+    });
+
+    final card = PlayerCard.fromPlayer(player);
+
+    expect(player.customPoints, 3.0);
+    expect(card.customPoints, 3.0);
+  });
+}
+
+GamesTourModel _game({
+  required GameStatus status,
+  String roundSlug = 'round-4',
+  double? whiteCustomPoints,
+  double? blackCustomPoints,
+}) {
+  return GamesTourModel(
+    gameId: 'game-1',
+    source: GameSource.supabase,
+    whitePlayer: PlayerCard(
+      name: 'Carlsen, Magnus',
+      federation: 'NOR',
+      title: 'GM',
+      rating: 2840,
+      countryCode: 'NOR',
+      team: '',
+      customPoints: whiteCustomPoints,
+    ),
+    blackPlayer: PlayerCard(
+      name: 'Gukesh D',
+      federation: 'IND',
+      title: 'GM',
+      rating: 2732,
+      countryCode: 'IND',
+      team: '',
+      customPoints: blackCustomPoints,
+    ),
+    whiteTimeDisplay: '--:--',
+    blackTimeDisplay: '--:--',
+    whiteClockCentiseconds: 0,
+    blackClockCentiseconds: 0,
+    gameStatus: status,
+    roundId: roundSlug,
+    roundSlug: roundSlug,
+    tourId: 'norway-chess',
+    tourSlug: 'norway-chess-2026',
+  );
+}


### PR DESCRIPTION
## Summary\n- preserve per-player custom broadcast points from game player JSON into player cards\n- show Norway classical custom points on board rows (3-0 wins, 1-1 draws)\n- keep Armageddon board rows simple as 1-0, while player scorecards can show the 0.5 bonus\n- preserve official source standings scores instead of recalculating custom broadcasts as standard chess points\n\n## Verification\n- dart format lib/utils/broadcast_custom_scoring.dart lib/screens/chessboard/widgets/player_first_row_detail_widget.dart lib/screens/standings/score_card_screen.dart test/broadcast_custom_scoring_test.dart\n- flutter test test/broadcast_custom_scoring_test.dart\n- flutter analyze lib/utils/broadcast_custom_scoring.dart lib/screens/chessboard/widgets/player_first_row_detail_widget.dart lib/screens/standings/score_card_screen.dart test/broadcast_custom_scoring_test.dart