### PR TITLE
Split phone Library folders and databases

### DIFF
--- a/lib/repository/library/library_repository.dart
+++ b/lib/repository/library/library_repository.dart
@@ -47,13 +47,14 @@ class LibraryRepository extends BaseRepository {
     return response != null ? LibraryFolder.fromSupabase(response) : null;
   });
 
-  /// Create a new folder
+  /// Create a new folder or database node.
   Future<LibraryFolder> createFolder({
     required String name,
     String? color,
     String? icon,
     int? orderIndex,
     String? parentId,
+    String nodeType = LibraryFolder.nodeTypeFolder,
   }) => handleApiCall(() async {
     final userId = supabase.auth.currentUser?.id;
     if (userId == null) throw Exception('User not authenticated');
@@ -69,6 +70,7 @@ class LibraryRepository extends BaseRepository {
       icon: icon ?? 'folder',
       orderIndex: nextOrder,
       parentId: parentId,
+      nodeType: nodeType,
       createdAt: DateTime.now(),
       updatedAt: DateTime.now(),
     );
@@ -83,8 +85,8 @@ class LibraryRepository extends BaseRepository {
     return LibraryFolder.fromSupabase(response);
   });
 
-  /// Ensure the user has the default "My Database" structure.
-  /// Creates a root "My Database" folder and a child "My Subdatabase" folder.
+  /// Ensure the user has a default organizational folder and database.
+  /// Folders organize databases; only databases contain games.
   Future<void> ensureDefaultFolders() async {
     final userId = supabase.auth.currentUser?.id;
     if (userId == null) return;
@@ -98,10 +100,12 @@ class LibraryRepository extends BaseRepository {
 
     if ((existing as List).isNotEmpty) return;
 
-    // Create root folder
-    final rootFolder = await createFolder(name: 'My Database');
-    // Create child folder inside it
-    await createFolder(name: 'My Subdatabase', parentId: rootFolder.id);
+    final rootFolder = await createFolder(name: 'My Folder');
+    await createFolder(
+      name: 'My Database',
+      parentId: rootFolder.id,
+      nodeType: LibraryFolder.nodeTypeDatabase,
+    );
   }
 
   /// Update a folder
@@ -558,16 +562,15 @@ class LibraryRepository extends BaseRepository {
   /// let the user squeak past the free-tier cap (we hit exactly that bug:
   /// users were adding an 11th game without the paywall firing because the
   /// stream had not yet emitted the freshly-inserted row).
-  Future<int> getTotalAnalysisCountForCurrentUser() =>
-      handleApiCall(() async {
-        final userId = supabase.auth.currentUser?.id;
-        if (userId == null) throw Exception('User not authenticated');
+  Future<int> getTotalAnalysisCountForCurrentUser() => handleApiCall(() async {
+    final userId = supabase.auth.currentUser?.id;
+    if (userId == null) throw Exception('User not authenticated');
 
-        return supabase
-            .from('user_saved_analyses')
-            .count(CountOption.exact)
-            .eq('user_id', userId);
-      });
+    return supabase
+        .from('user_saved_analyses')
+        .count(CountOption.exact)
+        .eq('user_id', userId);
+  });
 
   /// Count of analyses saved **directly** in [folderId], not counting
   /// sub-folders. Used by the tree PGN export so every folder level gets

--- a/lib/repository/library/models/library_folder.dart
+++ b/lib/repository/library/models/library_folder.dart
@@ -4,6 +4,9 @@ part 'library_folder.mapper.dart';
 
 @MappableClass()
 class LibraryFolder with LibraryFolderMappable {
+  static const nodeTypeFolder = 'folder';
+  static const nodeTypeDatabase = 'database';
+
   final String id;
   final String userId;
   final String name;
@@ -15,6 +18,7 @@ class LibraryFolder with LibraryFolderMappable {
   final String? shareToken;
   final String? ownerDisplayName;
   final String? parentId;
+  final String nodeType;
 
   /// Client-side only — true when this folder was fetched via subscription.
   /// Not stored in DB; set by the provider layer.
@@ -32,6 +36,7 @@ class LibraryFolder with LibraryFolderMappable {
     this.shareToken,
     this.ownerDisplayName,
     this.parentId,
+    this.nodeType = nodeTypeDatabase,
     this.isSubscribed = false,
   });
 
@@ -48,6 +53,7 @@ class LibraryFolder with LibraryFolderMappable {
       updatedAt: DateTime.parse(json['updated_at'] as String),
       shareToken: json['share_token'] as String?,
       parentId: json['parent_id'] as String?,
+      nodeType: json['node_type'] as String? ?? nodeTypeDatabase,
     );
   }
 
@@ -60,6 +66,7 @@ class LibraryFolder with LibraryFolderMappable {
       'icon': icon,
       'order_index': orderIndex,
       'parent_id': parentId,
+      'node_type': nodeType,
     };
   }
 
@@ -75,6 +82,10 @@ class LibraryFolder with LibraryFolderMappable {
       'created_at': createdAt.toIso8601String(),
       'updated_at': updatedAt.toIso8601String(),
       'parent_id': parentId,
+      'node_type': nodeType,
     };
   }
+
+  bool get isDatabase => nodeType == nodeTypeDatabase;
+  bool get isFolder => nodeType == nodeTypeFolder;
 }

--- a/lib/repository/library/models/library_folder.mapper.dart
+++ b/lib/repository/library/models/library_folder.mapper.dart
@@ -67,6 +67,13 @@ class LibraryFolderMapper extends ClassMapperBase<LibraryFolder> {
     _$parentId,
     opt: true,
   );
+  static String _$nodeType(LibraryFolder v) => v.nodeType;
+  static const Field<LibraryFolder, String> _f$nodeType = Field(
+    'nodeType',
+    _$nodeType,
+    opt: true,
+    def: LibraryFolder.nodeTypeDatabase,
+  );
   static bool _$isSubscribed(LibraryFolder v) => v.isSubscribed;
   static const Field<LibraryFolder, bool> _f$isSubscribed = Field(
     'isSubscribed',
@@ -88,6 +95,7 @@ class LibraryFolderMapper extends ClassMapperBase<LibraryFolder> {
     #shareToken: _f$shareToken,
     #ownerDisplayName: _f$ownerDisplayName,
     #parentId: _f$parentId,
+    #nodeType: _f$nodeType,
     #isSubscribed: _f$isSubscribed,
   };
 
@@ -104,6 +112,7 @@ class LibraryFolderMapper extends ClassMapperBase<LibraryFolder> {
       shareToken: data.dec(_f$shareToken),
       ownerDisplayName: data.dec(_f$ownerDisplayName),
       parentId: data.dec(_f$parentId),
+      nodeType: data.dec(_f$nodeType),
       isSubscribed: data.dec(_f$isSubscribed),
     );
   }
@@ -182,6 +191,7 @@ abstract class LibraryFolderCopyWith<$R, $In extends LibraryFolder, $Out>
     String? shareToken,
     String? ownerDisplayName,
     String? parentId,
+    String? nodeType,
     bool? isSubscribed,
   });
   LibraryFolderCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
@@ -208,6 +218,7 @@ class _LibraryFolderCopyWithImpl<$R, $Out>
     Object? shareToken = $none,
     Object? ownerDisplayName = $none,
     Object? parentId = $none,
+    String? nodeType,
     bool? isSubscribed,
   }) => $apply(
     FieldCopyWithData({
@@ -222,6 +233,7 @@ class _LibraryFolderCopyWithImpl<$R, $Out>
       if (shareToken != $none) #shareToken: shareToken,
       if (ownerDisplayName != $none) #ownerDisplayName: ownerDisplayName,
       if (parentId != $none) #parentId: parentId,
+      if (nodeType != null) #nodeType: nodeType,
       if (isSubscribed != null) #isSubscribed: isSubscribed,
     }),
   );
@@ -238,6 +250,7 @@ class _LibraryFolderCopyWithImpl<$R, $Out>
     shareToken: data.get(#shareToken, or: $value.shareToken),
     ownerDisplayName: data.get(#ownerDisplayName, or: $value.ownerDisplayName),
     parentId: data.get(#parentId, or: $value.parentId),
+    nodeType: data.get(#nodeType, or: $value.nodeType),
     isSubscribed: data.get(#isSubscribed, or: $value.isSubscribed),
   );
 

--- a/lib/screens/chessboard/widgets/save_analysis_sheet.dart
+++ b/lib/screens/chessboard/widgets/save_analysis_sheet.dart
@@ -97,7 +97,11 @@ class _SaveAnalysisSheet extends ConsumerWidget {
         isContentScrollAware: true,
       ),
       child: PagedSheet(
-        decoration: ChessSheetDecoration.dark(context, alpha: 0.97, borderRadius: 28.sp),
+        decoration: ChessSheetDecoration.dark(
+          context,
+          alpha: 0.97,
+          borderRadius: 28.sp,
+        ),
         shrinkChildToAvoidDynamicOverlap: true,
         navigator: navigator,
       ),
@@ -325,6 +329,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           name: newFolderName,
           color:
               '#${_selectedFolderColor.toARGB32().toRadixString(16).substring(2)}',
+          nodeType: LibraryFolder.nodeTypeDatabase,
         );
         targetFolderId = newFolder.id;
       }
@@ -483,7 +488,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 SizedBox(width: 12.w),
                 Expanded(
                   child: Text(
-                    _isEditMode ? 'Game updated' : 'Analysis saved successfully',
+                    _isEditMode
+                        ? 'Game updated'
+                        : 'Analysis saved successfully',
                     style: AppTypography.textSmMedium.copyWith(
                       color: context.colors.textPrimary,
                     ),
@@ -664,9 +671,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                   ),
                 ),
                 child: Icon(
-                  _isEditMode
-                      ? Icons.edit_rounded
-                      : Icons.bookmark_add_rounded,
+                  _isEditMode ? Icons.edit_rounded : Icons.bookmark_add_rounded,
                   color: kPrimaryColor,
                   size: 22.sp,
                 ),
@@ -689,7 +694,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                           ? 'Update title, folder & metadata'
                           : 'Keep your variations & comments',
                       style: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.textPrimary.withValues(alpha: 0.5),
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.5,
+                        ),
                       ),
                     ),
                   ],
@@ -718,7 +725,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
               decoration: BoxDecoration(
                 color: context.colors.textPrimary.withValues(alpha: 0.04),
                 borderRadius: BorderRadius.circular(12.br),
-                border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.08)),
+                border: Border.all(
+                  color: context.colors.textPrimary.withValues(alpha: 0.08),
+                ),
               ),
               child: Row(
                 children: [
@@ -732,7 +741,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                     child: Text(
                       'Game Details',
                       style: AppTypography.textSmMedium.copyWith(
-                        color: context.colors.textPrimary.withValues(alpha: 0.9),
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.9,
+                        ),
                       ),
                     ),
                   ),
@@ -875,12 +886,16 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
       decoration: BoxDecoration(
         color: context.colors.textPrimary.withValues(alpha: 0.03),
         borderRadius: BorderRadius.circular(8.br),
-        border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.06)),
+        border: Border.all(
+          color: context.colors.textPrimary.withValues(alpha: 0.06),
+        ),
       ),
       child: TextField(
         controller: controller,
         enabled: !_isSaving,
-        style: AppTypography.textSmRegular.copyWith(color: context.colors.textPrimary),
+        style: AppTypography.textSmRegular.copyWith(
+          color: context.colors.textPrimary,
+        ),
         decoration: InputDecoration(
           hintText: hint,
           hintStyle: AppTypography.textXsRegular.copyWith(
@@ -914,7 +929,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           decoration: BoxDecoration(
             color: context.colors.textPrimary.withValues(alpha: 0.03),
             borderRadius: BorderRadius.circular(10.br),
-            border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.06)),
+            border: Border.all(
+              color: context.colors.textPrimary.withValues(alpha: 0.06),
+            ),
           ),
           child:
               isResult
@@ -957,7 +974,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
             Icons.arrow_drop_down,
             color: context.colors.textPrimary.withValues(alpha: 0.4),
           ),
-          style: AppTypography.textSmRegular.copyWith(color: context.colors.textPrimary),
+          style: AppTypography.textSmRegular.copyWith(
+            color: context.colors.textPrimary,
+          ),
           onChanged:
               _isSaving
                   ? null
@@ -1072,13 +1091,17 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                     color:
                         _isCreatingNewFolder
                             ? kPrimaryColor.withValues(alpha: 0.15)
-                            : context.colors.textPrimary.withValues(alpha: 0.05),
+                            : context.colors.textPrimary.withValues(
+                              alpha: 0.05,
+                            ),
                     borderRadius: BorderRadius.circular(20.br),
                     border: Border.all(
                       color:
                           _isCreatingNewFolder
                               ? kPrimaryColor.withValues(alpha: 0.4)
-                              : context.colors.textPrimary.withValues(alpha: 0.1),
+                              : context.colors.textPrimary.withValues(
+                                alpha: 0.1,
+                              ),
                       width: 1,
                     ),
                   ),
@@ -1093,7 +1116,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                         color:
                             _isCreatingNewFolder
                                 ? kPrimaryColor
-                                : context.colors.textPrimary.withValues(alpha: 0.6),
+                                : context.colors.textPrimary.withValues(
+                                  alpha: 0.6,
+                                ),
                       ),
                       SizedBox(width: 6.w),
                       Text(
@@ -1102,7 +1127,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                           color:
                               _isCreatingNewFolder
                                   ? kPrimaryColor
-                                  : context.colors.textPrimary.withValues(alpha: 0.6),
+                                  : context.colors.textPrimary.withValues(
+                                    alpha: 0.6,
+                                  ),
                         ),
                       ),
                     ],
@@ -1160,7 +1187,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
             focusNode: _newFolderNameFocusNode,
             enabled: !_isSaving,
             maxLength: 50,
-            style: AppTypography.textMdRegular.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textMdRegular.copyWith(
+              color: context.colors.textPrimary,
+            ),
             decoration: InputDecoration(
               hintText: 'Folder name',
               hintStyle: AppTypography.textMdRegular.copyWith(
@@ -1354,7 +1383,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
         decoration: BoxDecoration(
           color: context.colors.textPrimary.withValues(alpha: 0.03),
           borderRadius: BorderRadius.circular(16.br),
-          border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.06)),
+          border: Border.all(
+            color: context.colors.textPrimary.withValues(alpha: 0.06),
+          ),
         ),
         child: Column(
           children: [
@@ -1424,7 +1455,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
       decoration: BoxDecoration(
         color: context.colors.textPrimary.withValues(alpha: 0.03),
         borderRadius: BorderRadius.circular(16.br),
-        border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.06)),
+        border: Border.all(
+          color: context.colors.textPrimary.withValues(alpha: 0.06),
+        ),
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(16.br),
@@ -1436,7 +1469,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 final folder = entry.value;
                 final isSelected = _selectedFolder?.id == folder.id;
                 final isLast = index == folders.length - 1;
-                final isSubdatabase = folder.parentId != null;
+                final isChildNode = folder.parentId != null;
 
                 return Column(
                   children: [
@@ -1455,9 +1488,11 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                       Container(
                         height: 1,
                         margin: EdgeInsets.only(
-                          left: isSubdatabase ? 80.w : 56.w,
+                          left: isChildNode ? 80.w : 56.w,
                         ),
-                        color: context.colors.textPrimary.withValues(alpha: 0.05),
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.05,
+                        ),
                       ),
                   ],
                 );
@@ -1474,7 +1509,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
       decoration: BoxDecoration(
         color: context.colors.textPrimary.withValues(alpha: 0.03),
         borderRadius: BorderRadius.circular(16.br),
-        border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.06)),
+        border: Border.all(
+          color: context.colors.textPrimary.withValues(alpha: 0.06),
+        ),
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -1606,7 +1643,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 decoration: BoxDecoration(
                   color: context.colors.textPrimary.withValues(alpha: 0.05),
                   borderRadius: BorderRadius.circular(14.br),
-                  border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.1)),
+                  border: Border.all(
+                    color: context.colors.textPrimary.withValues(alpha: 0.1),
+                  ),
                 ),
                 child: Center(
                   child: Text(
@@ -1650,7 +1689,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                         color:
                             canSave
                                 ? null
-                                : context.colors.textPrimary.withValues(alpha: 0.08),
+                                : context.colors.textPrimary.withValues(
+                                  alpha: 0.08,
+                                ),
                         borderRadius: BorderRadius.circular(14.br),
                         boxShadow:
                             canSave
@@ -1686,9 +1727,8 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                                       color:
                                           canSave
                                               ? context.colors.textPrimary
-                                              : context.colors.textPrimary.withValues(
-                                                alpha: 0.3,
-                                              ),
+                                              : context.colors.textPrimary
+                                                  .withValues(alpha: 0.3),
                                       size: 18.sp,
                                     ),
                                     SizedBox(width: 8.w),
@@ -1704,9 +1744,8 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                                         color:
                                             canSave
                                                 ? context.colors.textPrimary
-                                                : context.colors.textPrimary.withValues(
-                                                  alpha: 0.3,
-                                                ),
+                                                : context.colors.textPrimary
+                                                    .withValues(alpha: 0.3),
                                         letterSpacing: 0.3,
                                       ),
                                     ),
@@ -1757,7 +1796,7 @@ class _FolderListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final folderColor = _parseColorString(folder.color);
-    final isSubdatabase = folder.parentId != null;
+    final isChildNode = folder.parentId != null;
     final countAsync = ref.watch(folderAnalysisCountProvider(folder.id));
 
     return GestureDetector(
@@ -1769,7 +1808,7 @@ class _FolderListItem extends ConsumerWidget {
           final animValue = value.clamp(0.0, 1.0).toDouble();
           return Container(
             padding: EdgeInsets.only(
-              left: 14.w + (isSubdatabase ? 24.w : 0),
+              left: 14.w + (isChildNode ? 24.w : 0),
               right: 14.w,
               top: 12.h,
               bottom: 12.h,
@@ -1783,7 +1822,7 @@ class _FolderListItem extends ConsumerWidget {
             ),
             child: Row(
               children: [
-                if (isSubdatabase) ...[
+                if (isChildNode) ...[
                   Icon(
                     Icons.subdirectory_arrow_right_rounded,
                     size: 16.sp,
@@ -1823,8 +1862,9 @@ class _FolderListItem extends ConsumerWidget {
                       Text(
                         folder.name,
                         style: AppTypography.textSmMedium.copyWith(
-                          color:
-                              context.colors.textPrimary.withValues(alpha: 0.9),
+                          color: context.colors.textPrimary.withValues(
+                            alpha: 0.9,
+                          ),
                         ),
                         overflow: TextOverflow.ellipsis,
                         maxLines: 1,
@@ -1857,13 +1897,17 @@ class _FolderListItem extends ConsumerWidget {
                     color:
                         isSelected
                             ? kPrimaryColor
-                            : context.colors.textPrimary.withValues(alpha: 0.05),
+                            : context.colors.textPrimary.withValues(
+                              alpha: 0.05,
+                            ),
                     shape: BoxShape.circle,
                     border: Border.all(
                       color:
                           isSelected
                               ? kPrimaryColor
-                              : context.colors.textPrimary.withValues(alpha: 0.15),
+                              : context.colors.textPrimary.withValues(
+                                alpha: 0.15,
+                              ),
                       width: 2,
                     ),
                   ),
@@ -1890,5 +1934,7 @@ final _foldersProvider = FutureProvider.autoDispose<List<LibraryFolder>>((
   ref,
 ) async {
   final repository = ref.watch(libraryRepositoryProvider);
-  return repository.getFolders();
+  return repository.getFolders().then(
+    (folders) => folders.where((folder) => folder.isDatabase).toList(),
+  );
 });

--- a/lib/screens/gamebase/widgets/position_games_sheet.dart
+++ b/lib/screens/gamebase/widgets/position_games_sheet.dart
@@ -17,6 +17,117 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../providers/gamebase_explorer_state.dart';
 import '../providers/gamebase_providers.dart';
 
+typedef GamebaseSortChanged =
+    void Function(GamebaseSortField field, GamebaseSortDirection direction);
+
+Future<void> showGamebaseSortOptions({
+  required BuildContext context,
+  required GamebaseSortField sortBy,
+  required GamebaseSortDirection sortDirection,
+  required GamebaseSortChanged onChanged,
+}) {
+  return showModalBottomSheet(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder:
+        (ctx) => StatefulBuilder(
+          builder: (context, setModalState) {
+            final bottomPadding = MediaQuery.of(ctx).padding.bottom;
+            void handleTap(GamebaseSortField field) {
+              final nextDirection =
+                  sortBy == field
+                      ? (sortDirection == GamebaseSortDirection.desc
+                          ? GamebaseSortDirection.asc
+                          : GamebaseSortDirection.desc)
+                      : GamebaseSortDirection.desc;
+              setModalState(() {});
+              Navigator.pop(ctx);
+              onChanged(field, nextDirection);
+            }
+
+            return Container(
+              decoration: BoxDecoration(
+                color: context.colors.surfaceRecessed,
+                borderRadius: BorderRadius.vertical(
+                  top: Radius.circular(20.br),
+                ),
+              ),
+              padding: EdgeInsets.fromLTRB(
+                16.w,
+                24.h,
+                16.w,
+                bottomPadding + 16.h,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Sort Games',
+                        style: TextStyle(
+                          color: context.colors.textPrimary,
+                          fontSize: 18.f,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      InkWell(
+                        onTap: () => Navigator.pop(ctx),
+                        borderRadius: BorderRadius.circular(20.br),
+                        child: Container(
+                          padding: EdgeInsets.all(4.w),
+                          decoration: BoxDecoration(
+                            color: context.colors.surface,
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(
+                            Icons.close,
+                            color: Colors.grey,
+                            size: 20.sp,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 24.h),
+                  _SortOptionTile(
+                    title: 'Average Rating',
+                    isSelected: sortBy == GamebaseSortField.avgElo,
+                    sortDirection: sortDirection,
+                    onTap: () => handleTap(GamebaseSortField.avgElo),
+                  ),
+                  SizedBox(height: 8.h),
+                  _SortOptionTile(
+                    title: 'White Rating',
+                    isSelected: sortBy == GamebaseSortField.whiteElo,
+                    sortDirection: sortDirection,
+                    onTap: () => handleTap(GamebaseSortField.whiteElo),
+                  ),
+                  SizedBox(height: 8.h),
+                  _SortOptionTile(
+                    title: 'Black Rating',
+                    isSelected: sortBy == GamebaseSortField.blackElo,
+                    sortDirection: sortDirection,
+                    onTap: () => handleTap(GamebaseSortField.blackElo),
+                  ),
+                  SizedBox(height: 8.h),
+                  _SortOptionTile(
+                    title: 'Year / Date',
+                    isSelected: sortBy == GamebaseSortField.date,
+                    sortDirection: sortDirection,
+                    onTap: () => handleTap(GamebaseSortField.date),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+  );
+}
+
 class PositionGamesSheet extends ConsumerStatefulWidget {
   const PositionGamesSheet({
     super.key,
@@ -120,12 +231,14 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
   }
 
   Future<GamebaseSearchQueryResponse> _fetchFenPage(int pageNumber) {
-    final timeControlFilter = widget.filters.timeControls.isNotEmpty
-        ? widget.filters.timeControls.first
-        : null;
-    final playerIdFilter = widget.filters.playerIds.isNotEmpty
-        ? widget.filters.playerIds.first
-        : null;
+    final timeControlFilter =
+        widget.filters.timeControls.isNotEmpty
+            ? widget.filters.timeControls.first
+            : null;
+    final playerIdFilter =
+        widget.filters.playerIds.isNotEmpty
+            ? widget.filters.playerIds.first
+            : null;
     return ref
         .read(gamebaseRepositoryProvider)
         .getFenPositionGames(
@@ -169,11 +282,12 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
 
     final requestToken = ++_requestToken;
     try {
-      final response = widget.useFenEndpoint
-          ? await _fetchFenPage(_nextPageNumber)
-          : await ref.read(
-              positionGamesProvider(_buildQuery(_nextPageNumber)).future,
-            );
+      final response =
+          widget.useFenEndpoint
+              ? await _fetchFenPage(_nextPageNumber)
+              : await ref.read(
+                positionGamesProvider(_buildQuery(_nextPageNumber)).future,
+              );
       if (!mounted || requestToken != _requestToken) return;
 
       final mergedRows = List<Map<String, dynamic>>.from(_rows);
@@ -226,141 +340,18 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
   }
 
   void _showSortOptions() {
-    showModalBottomSheet(
+    showGamebaseSortOptions(
       context: context,
-      backgroundColor: Colors.transparent,
-      isScrollControlled: true,
-      builder:
-          (ctx) => StatefulBuilder(
-            builder: (context, setModalState) {
-              final bottomPadding = MediaQuery.of(ctx).padding.bottom;
-              return Container(
-                decoration: BoxDecoration(
-                  color: context.colors.surfaceRecessed,
-                  borderRadius: BorderRadius.vertical(
-                    top: Radius.circular(20.br),
-                  ),
-                ),
-                padding: EdgeInsets.fromLTRB(
-                  16.w,
-                  24.h,
-                  16.w,
-                  bottomPadding + 16.h,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Sort Games',
-                          style: TextStyle(
-                            color: context.colors.textPrimary,
-                            fontSize: 18.f,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        InkWell(
-                          onTap: () => Navigator.pop(ctx),
-                          borderRadius: BorderRadius.circular(20.br),
-                          child: Container(
-                            padding: EdgeInsets.all(4.w),
-                            decoration: BoxDecoration(
-                              color: context.colors.surface,
-                              shape: BoxShape.circle,
-                            ),
-                            child: Icon(
-                              Icons.close,
-                              color: Colors.grey,
-                              size: 20.sp,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    SizedBox(height: 24.h),
-                    _SortOptionTile(
-                      title: 'Average Rating',
-                      isSelected: _sortBy == GamebaseSortField.avgElo,
-                      sortDirection: _sortDirection,
-                      onTap: () {
-                        _handleSortTap(
-                          GamebaseSortField.avgElo,
-                          setModalState,
-                          ctx,
-                        );
-                      },
-                    ),
-                    SizedBox(height: 8.h),
-                    _SortOptionTile(
-                      title: 'White Rating',
-                      isSelected: _sortBy == GamebaseSortField.whiteElo,
-                      sortDirection: _sortDirection,
-                      onTap: () {
-                        _handleSortTap(
-                          GamebaseSortField.whiteElo,
-                          setModalState,
-                          ctx,
-                        );
-                      },
-                    ),
-                    SizedBox(height: 8.h),
-                    _SortOptionTile(
-                      title: 'Black Rating',
-                      isSelected: _sortBy == GamebaseSortField.blackElo,
-                      sortDirection: _sortDirection,
-                      onTap: () {
-                        _handleSortTap(
-                          GamebaseSortField.blackElo,
-                          setModalState,
-                          ctx,
-                        );
-                      },
-                    ),
-                    SizedBox(height: 8.h),
-                    _SortOptionTile(
-                      title: 'Year / Date',
-                      isSelected: _sortBy == GamebaseSortField.date,
-                      sortDirection: _sortDirection,
-                      onTap: () {
-                        _handleSortTap(
-                          GamebaseSortField.date,
-                          setModalState,
-                          ctx,
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              );
-            },
-          ),
+      sortBy: _sortBy,
+      sortDirection: _sortDirection,
+      onChanged: (field, direction) {
+        setState(() {
+          _sortBy = field;
+          _sortDirection = direction;
+        });
+        _fetchPage(reset: true);
+      },
     );
-  }
-
-  void _handleSortTap(
-    GamebaseSortField field,
-    StateSetter setModalState,
-    BuildContext ctx,
-  ) {
-    setModalState(() {
-      if (_sortBy == field) {
-        // Toggle direction
-        _sortDirection =
-            _sortDirection == GamebaseSortDirection.desc
-                ? GamebaseSortDirection.asc
-                : GamebaseSortDirection.desc;
-      } else {
-        // Switch field, default to desc
-        _sortBy = field;
-        _sortDirection = GamebaseSortDirection.desc;
-      }
-    });
-    setState(() {});
-    Navigator.pop(ctx);
-    _fetchPage(reset: true);
   }
 
   String get _countText {
@@ -606,7 +597,7 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
       context: context,
       barrierDismissible: false,
       builder:
-          (ctx) =>  Center(
+          (ctx) => Center(
             child: CircularProgressIndicator(color: context.colors.textPrimary),
           ),
     );
@@ -702,7 +693,10 @@ class _PositionGamesFooter extends StatelessWidget {
             SizedBox(width: 10.w),
             Text(
               'Loading more games...',
-              style: TextStyle(color: context.colors.textPrimaryMuted, fontSize: 12.f),
+              style: TextStyle(
+                color: context.colors.textPrimaryMuted,
+                fontSize: 12.f,
+              ),
             ),
           ],
         ),
@@ -736,7 +730,10 @@ class _PositionGamesFooter extends StatelessWidget {
         child: Center(
           child: Text(
             'Loaded all $totalCount games',
-            style: TextStyle(color: context.colors.textSecondary, fontSize: 12.f),
+            style: TextStyle(
+              color: context.colors.textSecondary,
+              fontSize: 12.f,
+            ),
           ),
         ),
       );
@@ -805,7 +802,11 @@ class _Header extends StatelessWidget {
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Icon(Icons.sort_rounded, color: context.colors.textPrimaryMuted, size: 15.sp),
+                    Icon(
+                      Icons.sort_rounded,
+                      color: context.colors.textPrimaryMuted,
+                      size: 15.sp,
+                    ),
                     SizedBox(width: 5.w),
                     Text(
                       'Sort',
@@ -822,7 +823,11 @@ class _Header extends StatelessWidget {
           ],
           IconButton(
             onPressed: () => Navigator.of(context).pop(),
-            icon: Icon(Icons.close, color: context.colors.textSecondary, size: 22.ic),
+            icon: Icon(
+              Icons.close,
+              color: context.colors.textSecondary,
+              size: 22.ic,
+            ),
             tooltip: 'Close',
           ),
         ],
@@ -889,7 +894,8 @@ class _SortOptionTile extends StatelessWidget {
               child: Text(
                 title,
                 style: AppTypography.textSmMedium.copyWith(
-                  color: isSelected ? kPrimaryColor : context.colors.textPrimary,
+                  color:
+                      isSelected ? kPrimaryColor : context.colors.textPrimary,
                   fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
                 ),
               ),

--- a/lib/screens/library/folder_contents_screen.dart
+++ b/lib/screens/library/folder_contents_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:io';
 
 import 'package:chessever2/e2e/e2e_ids.dart';
+import 'package:chessever2/repository/gamebase/search/gamebase_search_models.dart';
 import 'package:chessever2/repository/library/library_repository.dart';
 import 'package:chessever2/repository/library/models/library_folder.dart';
 import 'package:chessever2/repository/library/models/saved_analysis.dart';
 import 'package:chessever2/screens/library/pgn_import_preview_screen.dart';
+import 'package:chessever2/screens/gamebase/widgets/position_games_sheet.dart';
 import 'package:chessever2/screens/library/providers/book_games_paginated_provider.dart';
 import 'package:chessever2/screens/library/providers/library_folders_provider.dart';
 import 'package:chessever2/screens/library/utils/folder_pgn_exporter.dart';
@@ -45,6 +47,8 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   late final TextEditingController _searchController;
   late final BookPaginationKey _paginationKey;
   final Set<String> _removingIds = {};
+  GamebaseSortField _sortBy = GamebaseSortField.date;
+  GamebaseSortDirection _sortDirection = GamebaseSortDirection.desc;
   // Overrides widget.folder.name after an in-place rename so the header
   // reflects the new name without needing to pop/reopen.
   String? _overrideFolderName;
@@ -94,6 +98,22 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   void _clearSearch() {
     HapticFeedbackService.light();
     _searchController.clear();
+  }
+
+  void _showSortOptions() {
+    HapticFeedbackService.buttonPress();
+    showGamebaseSortOptions(
+      context: context,
+      sortBy: _sortBy,
+      sortDirection: _sortDirection,
+      onChanged: (field, direction) {
+        if (!mounted) return;
+        setState(() {
+          _sortBy = field;
+          _sortDirection = direction;
+        });
+      },
+    );
   }
 
   Future<void> _removeAnalysis(SavedAnalysis analysis) async {
@@ -679,56 +699,137 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   }
 
   Widget _buildSearchBar() {
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
-      child: Container(
-        height: 38.h,
-        decoration: BoxDecoration(
-          color: context.colors.textPrimary.withValues(alpha: 0.06),
-          borderRadius: BorderRadius.circular(10.br),
-        ),
-        child: Row(
-          children: [
-            SizedBox(width: 12.w),
-            Icon(
-              Icons.search_rounded,
-              size: 18.sp,
-              color: const Color(0xFFA1A1AA),
-            ),
-            SizedBox(width: 8.w),
-            Expanded(
-              child: TextField(
-                controller: _searchController,
-                style: AppTypography.textSmRegular.copyWith(
-                  color: context.colors.textPrimary,
-                ),
-                decoration: InputDecoration(
-                  hintText: 'Search games...',
-                  hintStyle: AppTypography.textSmRegular.copyWith(
-                    color: const Color(0xFFA1A1AA),
-                  ),
-                  border: InputBorder.none,
-                  contentPadding: EdgeInsets.zero,
-                  isDense: true,
-                ),
+    final searchField = Container(
+      height: 38.h,
+      decoration: BoxDecoration(
+        color: context.colors.textPrimary.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(10.br),
+      ),
+      child: Row(
+        children: [
+          SizedBox(width: 12.w),
+          Icon(
+            Icons.search_rounded,
+            size: 18.sp,
+            color: const Color(0xFFA1A1AA),
+          ),
+          SizedBox(width: 8.w),
+          Expanded(
+            child: TextField(
+              controller: _searchController,
+              style: AppTypography.textSmRegular.copyWith(
+                color: context.colors.textPrimary,
               ),
-            ),
-            if (_searchController.text.isNotEmpty) ...[
-              GestureDetector(
-                onTap: _clearSearch,
-                child: Icon(
-                  Icons.close,
-                  size: 20.sp,
+              decoration: InputDecoration(
+                hintText: 'Search games...',
+                hintStyle: AppTypography.textSmRegular.copyWith(
                   color: const Color(0xFFA1A1AA),
                 ),
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.zero,
+                isDense: true,
               ),
-              SizedBox(width: 8.w),
-            ],
+            ),
+          ),
+          if (_searchController.text.isNotEmpty) ...[
+            GestureDetector(
+              onTap: _clearSearch,
+              child: Icon(
+                Icons.close,
+                size: 20.sp,
+                color: const Color(0xFFA1A1AA),
+              ),
+            ),
             SizedBox(width: 8.w),
           ],
-        ),
+          SizedBox(width: 8.w),
+        ],
       ),
     );
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
+      child: Row(
+        children: [
+          Expanded(child: searchField),
+          if (_isDatabase) ...[
+            SizedBox(width: 8.w),
+            GestureDetector(
+              onTap: _showSortOptions,
+              child: Container(
+                width: 38.h,
+                height: 38.h,
+                decoration: BoxDecoration(
+                  color: context.colors.textPrimary.withValues(alpha: 0.06),
+                  borderRadius: BorderRadius.circular(10.br),
+                  border: Border.all(
+                    color: context.colors.textPrimary.withValues(alpha: 0.08),
+                  ),
+                ),
+                child: Icon(
+                  _sortDirection == GamebaseSortDirection.desc
+                      ? Icons.south_rounded
+                      : Icons.north_rounded,
+                  size: 18.sp,
+                  color: kPrimaryColor,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  int _ratingFromMetadata(SavedAnalysis analysis, String key) {
+    final value = analysis.chessGame.metadata[key];
+    if (value is num) return value.toInt();
+    final text = value?.toString() ?? '';
+    final digits = RegExp(r'\d+').firstMatch(text)?.group(0);
+    return int.tryParse(digits ?? '') ?? 0;
+  }
+
+  DateTime _gameDate(SavedAnalysis analysis) {
+    final raw = analysis.chessGame.metadata['Date']?.toString().trim() ?? '';
+    if (raw.isNotEmpty && raw != '????.??.??') {
+      final normalized = raw.replaceAll('.', '-').replaceAll('?', '01');
+      final parsed = DateTime.tryParse(normalized);
+      if (parsed != null) return parsed;
+    }
+    return analysis.createdAt;
+  }
+
+  int _sortValue(SavedAnalysis analysis, GamebaseSortField field) {
+    switch (field) {
+      case GamebaseSortField.whiteElo:
+        return _ratingFromMetadata(analysis, 'WhiteElo');
+      case GamebaseSortField.blackElo:
+        return _ratingFromMetadata(analysis, 'BlackElo');
+      case GamebaseSortField.avgElo:
+        final white = _ratingFromMetadata(analysis, 'WhiteElo');
+        final black = _ratingFromMetadata(analysis, 'BlackElo');
+        if (white > 0 && black > 0) return ((white + black) / 2).round();
+        return white > 0 ? white : black;
+      case GamebaseSortField.date:
+        return _gameDate(analysis).millisecondsSinceEpoch;
+    }
+  }
+
+  List<SavedAnalysis> _sortAnalyses(List<SavedAnalysis> analyses) {
+    final sorted = List<SavedAnalysis>.from(analyses);
+    sorted.sort((a, b) {
+      final comparison = _sortValue(
+        a,
+        _sortBy,
+      ).compareTo(_sortValue(b, _sortBy));
+      final directed =
+          _sortDirection == GamebaseSortDirection.asc
+              ? comparison
+              : -comparison;
+      if (directed != 0) return directed;
+      return b.createdAt.compareTo(a.createdAt);
+    });
+    return sorted;
   }
 
   Widget _buildSavedGames(
@@ -753,19 +854,20 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         data: (bookState) {
           final analyses =
               _isDatabase ? bookState.games : const <SavedAnalysis>[];
-          final filteredAnalyses =
-              analyses.where((analysis) {
-                if (query.isEmpty) return true;
-                final md = analysis.chessGame.metadata;
-                final title = analysis.title.toLowerCase();
-                final white = (md['White'] ?? '').toString().toLowerCase();
-                final black = (md['Black'] ?? '').toString().toLowerCase();
-                final event = (md['Event'] ?? '').toString().toLowerCase();
-                return title.contains(query) ||
-                    white.contains(query) ||
-                    black.contains(query) ||
-                    event.contains(query);
-              }).toList();
+          final filteredAnalyses = _sortAnalyses(
+            analyses.where((analysis) {
+              if (query.isEmpty) return true;
+              final md = analysis.chessGame.metadata;
+              final title = analysis.title.toLowerCase();
+              final white = (md['White'] ?? '').toString().toLowerCase();
+              final black = (md['Black'] ?? '').toString().toLowerCase();
+              final event = (md['Event'] ?? '').toString().toLowerCase();
+              return title.contains(query) ||
+                  white.contains(query) ||
+                  black.contains(query) ||
+                  event.contains(query);
+            }).toList(),
+          );
 
           // Filter child folders if query is present
           final filteredFolders =

--- a/lib/screens/library/folder_contents_screen.dart
+++ b/lib/screens/library/folder_contents_screen.dart
@@ -50,6 +50,8 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   String? _overrideFolderName;
 
   bool get _isSubscribed => widget.folder.isSubscribed;
+  bool get _isFolder => widget.folder.isFolder;
+  bool get _isDatabase => widget.folder.isDatabase;
 
   String get _currentFolderName => _overrideFolderName ?? widget.folder.name;
 
@@ -126,7 +128,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Removed from "${widget.folder.name}"',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -175,7 +179,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Failed to remove: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -186,21 +192,19 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
 
   Future<void> _handlePlusButton() async {
     HapticFeedbackService.light();
-    // Sub-databases can't nest further (2-layer hierarchy), so only offer
-    // "Create Sub-Database" on root folders.
-    final isRootFolder = widget.folder.parentId == null;
     final choice = await showAddToLibrarySheet(
       context,
       title: 'Add to "$_currentFolderName"',
-      showCreateDatabase: isRootFolder,
-      createDatabaseTitle: 'Create Sub-Database',
-      createDatabaseSubtitle: 'New empty sub-database under this one',
+      showCreateDatabase: _isFolder,
+      createDatabaseTitle: 'Create Folder or Database',
+      createDatabaseSubtitle: 'Organize another folder or game database here',
+      showImports: _isDatabase,
     );
     if (choice == null || !mounted) return;
 
     switch (choice) {
       case AddToLibraryChoice.createDatabase:
-        await _handleCreateSubfolder();
+        await _handleCreateChildNode();
       case AddToLibraryChoice.importPgn:
         await _handleImportPgnFromClipboard();
       case AddToLibraryChoice.pickPgnFile:
@@ -225,7 +229,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
           SnackBar(
             content: Text(
               'Could not open file picker: $e',
-              style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+              style: AppTypography.textSmMedium.copyWith(
+                color: context.colors.textPrimary,
+              ),
             ),
             backgroundColor: kRedColor.withValues(alpha: 0.9),
             behavior: SnackBarBehavior.floating,
@@ -259,7 +265,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Clipboard is empty. Copy a PGN first.',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -275,7 +283,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Clipboard does not contain a valid PGN',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor.withValues(alpha: 0.9),
           behavior: SnackBarBehavior.floating,
@@ -302,7 +312,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
     ref.invalidate(libraryFoldersStreamProvider);
   }
 
-  Future<void> _handleCreateSubfolder() async {
+  Future<void> _handleCreateChildNode() async {
     final data = await showCreateFolderDialog(
       context,
       initialParentId: widget.folder.id,
@@ -313,15 +323,21 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
     try {
       await ref
           .read(libraryRepositoryProvider)
-          .createFolder(name: data.name, parentId: data.parentId);
+          .createFolder(
+            name: data.name,
+            parentId: data.parentId,
+            nodeType: data.nodeType,
+          );
       ref.invalidate(libraryFoldersStreamProvider);
 
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Sub-database "${data.name}" created',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            '${data.nodeType == LibraryFolder.nodeTypeFolder ? 'Folder' : 'Database'} "${data.name}" created',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -332,8 +348,10 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Failed to create sub-database: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            'Failed to create item: $e',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -366,7 +384,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Renamed to "$name"',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -379,7 +399,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Failed to rename: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -392,7 +414,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
     HapticFeedbackService.medium();
 
     final repo = ref.read(libraryRepositoryProvider);
-    // Children are sub-databases directly under this folder. Empty for
+    // Children are child nodes directly under this folder. Empty for
     // leaf / sub-level folders, which cleanly degrades to a single-file
     // export via the tree helper.
     final childFolders = ref.read(
@@ -436,7 +458,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             error != null
                 ? 'Export failed: $error'
                 : 'Nothing to export in this database',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -451,9 +475,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
       for (final entry in files) {
         final file = File('${tempDir.path}/${entry.filename}');
         await file.writeAsString(entry.pgn);
-        xFiles.add(
-          XFile(file.path, mimeType: 'application/x-chess-pgn'),
-        );
+        xFiles.add(XFile(file.path, mimeType: 'application/x-chess-pgn'));
       }
 
       if (!mounted) return;
@@ -480,7 +502,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         SnackBar(
           content: Text(
             'Share failed: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -526,7 +550,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
 
     return Container(
       padding: EdgeInsets.only(top: topPadding + 8.h, bottom: 6.h),
-      decoration:  BoxDecoration(
+      decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
@@ -550,9 +574,10 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
       phone: 8.w,
       tablet: 16.w,
     );
-    final totalCount = bookAsync.valueOrNull?.totalCount;
+    final totalCount = _isDatabase ? bookAsync.valueOrNull?.totalCount : null;
 
-    final bool showExport = (bookAsync.valueOrNull?.totalCount ?? 0) > 0;
+    final bool showExport =
+        _isDatabase && (bookAsync.valueOrNull?.totalCount ?? 0) > 0;
     final bool showRename = !_isSubscribed;
     final bool showAdd = !_isSubscribed;
 
@@ -626,7 +651,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
           if (showRename)
             IconButton(
               onPressed: _handleRename,
-              tooltip: 'Rename Database',
+              tooltip: 'Rename',
               visualDensity: VisualDensity.compact,
               padding: EdgeInsets.symmetric(horizontal: 6.w),
               constraints: BoxConstraints(minWidth: 32.w, minHeight: 32.h),
@@ -674,7 +699,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             Expanded(
               child: TextField(
                 controller: _searchController,
-                style: AppTypography.textSmRegular.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textSmRegular.copyWith(
+                  color: context.colors.textPrimary,
+                ),
                 decoration: InputDecoration(
                   hintText: 'Search games...',
                   hintStyle: AppTypography.textSmRegular.copyWith(
@@ -708,7 +735,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
     AsyncValue<PaginatedBookState> bookAsync,
     String query,
   ) {
-    // Watch child folders (sub-databases)
+    // Watch child folders (child nodes)
     final childFolders = ref.watch(
       childLibraryFoldersProvider(widget.folder.id),
     );
@@ -724,7 +751,8 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
       backgroundColor: context.colors.surface,
       child: bookAsync.when(
         data: (bookState) {
-          final analyses = bookState.games;
+          final analyses =
+              _isDatabase ? bookState.games : const <SavedAnalysis>[];
           final filteredAnalyses =
               analyses.where((analysis) {
                 if (query.isEmpty) return true;
@@ -755,7 +783,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             return _buildEmptySearchState();
           }
 
-          // Total items = Subfolders + Games + Loading Tail
+          // Total items = child nodes + Games + Loading Tail
           final showLoadingTail = bookState.hasMore && query.isEmpty;
           final itemCount =
               filteredFolders.length +
@@ -767,7 +795,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
             itemCount: itemCount,
             itemBuilder: (context, index) {
-              // 1. Show Subfolders first
+              // 1. Show child nodes first
               if (index < filteredFolders.length) {
                 final folder = filteredFolders[index];
                 return Padding(
@@ -839,9 +867,12 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             },
           );
         },
-        loading: () => Center(
-          child: CircularProgressIndicator(color: context.colors.textPrimary),
-        ),
+        loading:
+            () => Center(
+              child: CircularProgressIndicator(
+                color: context.colors.textPrimary,
+              ),
+            ),
         error:
             (e, _) => Center(
               child: Text(
@@ -854,6 +885,7 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   }
 
   Widget _buildEmptySavedState() {
+    final isFolder = _isFolder;
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -865,13 +897,17 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
           ),
           SizedBox(height: 16.h),
           Text(
-            'This database is empty',
-            style: AppTypography.textMdMedium.copyWith(color: context.colors.textPrimary),
+            isFolder ? 'This folder is empty' : 'This database is empty',
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           if (!_isSubscribed) ...[
             SizedBox(height: 8.h),
             Text(
-              'Save your first game here!',
+              isFolder
+                  ? 'Create a folder or database here.'
+                  : 'Save your first game here!',
               style: AppTypography.textSmRegular.copyWith(
                 color: context.colors.textPrimary.withValues(alpha: 0.5),
               ),
@@ -895,7 +931,9 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
           SizedBox(height: 16.h),
           Text(
             'No matches found',
-            style: AppTypography.textMdMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           SizedBox(height: 8.h),
           Text(
@@ -1027,9 +1065,10 @@ class _ExportProgressDialogState extends State<_ExportProgressDialog> {
               borderRadius: BorderRadius.circular(4.br),
               child: LinearProgressIndicator(
                 value: progress.total > 0 ? progress.fraction : null,
-                backgroundColor: context.colors.textPrimary.withValues(alpha: 0.08),
-                valueColor:
-                    const AlwaysStoppedAnimation<Color>(kPrimaryColor),
+                backgroundColor: context.colors.textPrimary.withValues(
+                  alpha: 0.08,
+                ),
+                valueColor: const AlwaysStoppedAnimation<Color>(kPrimaryColor),
                 minHeight: 6.h,
               ),
             ),

--- a/lib/screens/library/library_screen.dart
+++ b/lib/screens/library/library_screen.dart
@@ -123,7 +123,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
           SnackBar(
             content: Text(
               'Could not open file picker: $e2',
-              style:  TextStyle(color: context.colors.textPrimary),
+              style: TextStyle(color: context.colors.textPrimary),
             ),
             backgroundColor: kRedColor.withValues(alpha: 0.9),
             behavior: SnackBarBehavior.floating,
@@ -194,7 +194,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
       final ownedBookCount =
-          folders.where((f) => !f.isSubscribed && f.id != kTwicBookId).length;
+          folders
+              .where(
+                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
+              )
+              .length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -211,6 +215,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       final newFolder = await repository.createFolder(
         name: data.name,
         parentId: data.parentId,
+        nodeType: data.nodeType,
       );
 
       // Force refresh folders provider to ensure immediate UI update
@@ -223,7 +228,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              'Database "${data.name}" created',
+              '${data.nodeType == LibraryFolder.nodeTypeFolder ? 'Folder' : 'Database'} "${data.name}" created',
               style: TextStyle(color: context.colors.textPrimary),
             ),
             backgroundColor: context.colors.surface.withValues(alpha: 0.95),
@@ -349,9 +354,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                                 // CSS: 36x36, bg #262626, radius 10px
                                 KeyedSubtree(
                                   key: e2eKey(E2eIds.libraryCreateFolderButton),
-                                  child: _PlusButton(
-                                    onTap: _handlePlusButton,
-                                  ),
+                                  child: _PlusButton(onTap: _handlePlusButton),
                                 ),
                               ],
                             )
@@ -735,7 +738,11 @@ class _PlusButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(10.br),
         ),
         child: Center(
-          child: Icon(Icons.add, size: 20.sp, color: context.colors.textPrimary),
+          child: Icon(
+            Icons.add,
+            size: 20.sp,
+            color: context.colors.textPrimary,
+          ),
         ),
       ),
     );
@@ -842,7 +849,8 @@ class _LibraryBackgroundDecoration extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
-        color: isLight ? context.colors.divider : context.colors.surfaceRecessed,
+        color:
+            isLight ? context.colors.divider : context.colors.surfaceRecessed,
         borderRadius: _getCornerRadius(row, col, gridSize, 6.br),
       ),
     );
@@ -936,4 +944,3 @@ class _LibraryFolderLoadingCard extends StatelessWidget {
     );
   }
 }
-

--- a/lib/screens/library/providers/library_folders_provider.dart
+++ b/lib/screens/library/providers/library_folders_provider.dart
@@ -73,8 +73,8 @@ final recentDatabasesProvider = Provider.autoDispose<List<LibraryFolder>>((
   ref,
 ) {
   final all = ref.watch(combinedLibraryFoldersProvider).valueOrNull ?? [];
-  // Exclude TWIC and sort by updatedAt desc
-  final owned = all.where((f) => f.id != kTwicBookId).toList();
+  // Exclude TWIC/folders and sort databases by updatedAt desc
+  final owned = all.where((f) => f.id != kTwicBookId && f.isDatabase).toList();
   owned.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
   return owned.take(3).toList();
 });

--- a/lib/screens/library/utils/folder_pgn_exporter.dart
+++ b/lib/screens/library/utils/folder_pgn_exporter.dart
@@ -13,7 +13,7 @@ const _kBrandSource = 'Chessever';
 typedef FolderExportProgress = void Function(int processed, int total);
 
 /// A single PGN file produced by [exportFolderTreeAsPgnFiles]. Each entry
-/// maps 1:1 to one folder in the tree — the root plus one per sub-database.
+/// maps 1:1 to one folder in the tree — the root plus one per child node.
 class FolderPgnFile {
   final String filename;
   final String pgn;
@@ -32,7 +32,7 @@ class FolderPgnFile {
 /// * `Source`: "Chessever"
 /// * `SourceURL`: direct link to the shared database (if [shareToken] is set)
 ///
-/// Only the folder's **direct** games are included — sub-database games are
+/// Only the folder's **direct** games are included — child node games are
 /// exported separately via [exportFolderTreeAsPgnFiles]. Games are streamed
 /// in pages and concatenated with blank lines between them. Progress updates
 /// are issued after each page via [onProgress].

--- a/lib/screens/library/widgets/add_to_folder_sheet.dart
+++ b/lib/screens/library/widgets/add_to_folder_sheet.dart
@@ -70,7 +70,11 @@ class _AddToFolderSheetShell extends ConsumerWidget {
         isContentScrollAware: true,
       ),
       child: PagedSheet(
-        decoration: ChessSheetDecoration.dark(context, alpha: 0.97, borderRadius: 28.sp),
+        decoration: ChessSheetDecoration.dark(
+          context,
+          alpha: 0.97,
+          borderRadius: 28.sp,
+        ),
         shrinkChildToAvoidDynamicOverlap: true,
         navigator: navigator,
       ),
@@ -201,7 +205,11 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
       final ownedBookCount =
-          folders.where((f) => !f.isSubscribed && f.id != kTwicBookId).length;
+          folders
+              .where(
+                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
+              )
+              .length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -217,17 +225,25 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
     try {
       final created = await ref
           .read(libraryRepositoryProvider)
-          .createFolder(name: data.name, parentId: data.parentId);
+          .createFolder(
+            name: data.name,
+            parentId: data.parentId,
+            nodeType: data.nodeType,
+          );
       ref.invalidate(libraryFoldersStreamProvider);
 
       if (!mounted) return;
-      setState(() => _selectedFolderIds.add(created.id));
+      if (created.isDatabase) {
+        setState(() => _selectedFolderIds.add(created.id));
+      }
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Database "${data.name}" created',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            '${data.nodeType == LibraryFolder.nodeTypeFolder ? 'Folder' : 'Database'} "${data.name}" created',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -238,8 +254,10 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Failed to create database: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            'Failed to create item: $e',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -289,7 +307,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
         SnackBar(
           content: Text(
             'Select at least one database',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -299,7 +319,10 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
     }
 
     // Pre-flight only counted 1 row; one game × N folders = N rows.
-    final allowed = await canSaveMoreGames(context, gamesToAdd: selected.length);
+    final allowed = await canSaveMoreGames(
+      context,
+      gamesToAdd: selected.length,
+    );
     if (!allowed || !mounted) return;
 
     setState(() => _isSaving = true);
@@ -349,7 +372,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
             successCount == 1
                 ? 'Added to 1 database'
                 : 'Added to $successCount databases',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -362,7 +387,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
         SnackBar(
           content: Text(
             'Failed to add game: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -380,7 +407,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
     final allFolders =
         ref.watch(combinedLibraryFoldersProvider).valueOrNull ?? [];
     final selectedFolders =
-        allFolders.where((f) => _selectedFolderIds.contains(f.id)).toList();
+        allFolders
+            .where((f) => _selectedFolderIds.contains(f.id) && f.isDatabase)
+            .toList();
 
     return Material(
       type: MaterialType.transparency,
@@ -394,7 +423,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
               padding: EdgeInsets.symmetric(horizontal: 20.w),
               child: Text(
                 'Add to Databases',
-                style: AppTypography.textLgBold.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textLgBold.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
             ),
 
@@ -416,7 +447,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
                           child: Text(
                             'No databases yet.',
                             style: AppTypography.textSmRegular.copyWith(
-                              color: context.colors.textPrimary.withValues(alpha: 0.5),
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.5,
+                              ),
                             ),
                             textAlign: TextAlign.center,
                           ),
@@ -489,13 +522,17 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
                     color:
                         isSelected
                             ? kPrimaryColor.withValues(alpha: 0.2)
-                            : context.colors.textPrimary.withValues(alpha: 0.05),
+                            : context.colors.textPrimary.withValues(
+                              alpha: 0.05,
+                            ),
                     borderRadius: BorderRadius.circular(20.br),
                     border: Border.all(
                       color:
                           isSelected
                               ? kPrimaryColor.withValues(alpha: 0.6)
-                              : context.colors.textPrimary.withValues(alpha: 0.1),
+                              : context.colors.textPrimary.withValues(
+                                alpha: 0.1,
+                              ),
                     ),
                   ),
                   child: Row(
@@ -506,7 +543,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
                         color:
                             isSelected
                                 ? kPrimaryColor
-                                : context.colors.textPrimary.withValues(alpha: 0.6),
+                                : context.colors.textPrimary.withValues(
+                                  alpha: 0.6,
+                                ),
                       ),
                       SizedBox(width: 6.w),
                       Text(
@@ -515,7 +554,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
                           color:
                               isSelected
                                   ? context.colors.textPrimary
-                                  : context.colors.textPrimary.withValues(alpha: 0.8),
+                                  : context.colors.textPrimary.withValues(
+                                    alpha: 0.8,
+                                  ),
                         ),
                       ),
                     ],
@@ -649,8 +690,8 @@ class _ExpandableFolderTile extends ConsumerWidget {
       children: [
         _FolderSelectionTile(
           folder: folder,
-          selected: isSelected,
-          onTap: onToggleSelect,
+          selected: folder.isDatabase && isSelected,
+          onTap: folder.isDatabase ? onToggleSelect : onToggleExpand,
           trailing:
               hasChildren
                   ? IconButton(
@@ -671,8 +712,10 @@ class _ExpandableFolderTile extends ConsumerWidget {
               padding: EdgeInsets.only(left: 24.w, bottom: 4.h),
               child: _FolderSelectionTile(
                 folder: child,
-                selected: selectedIds.contains(child.id),
-                onTap: () => onToggleChildSelect(child),
+                selected: child.isDatabase && selectedIds.contains(child.id),
+                onTap: () {
+                  if (child.isDatabase) onToggleChildSelect(child);
+                },
                 isSmall: true,
               ),
             ),
@@ -701,7 +744,7 @@ class _FolderSelectionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isSubdatabase = folder.parentId != null;
+    final isChildNode = folder.parentId != null;
 
     return GestureDetector(
       onTap: onTap,
@@ -725,7 +768,7 @@ class _FolderSelectionTile extends StatelessWidget {
         ),
         child: Row(
           children: [
-            if (isSubdatabase) ...[
+            if (isChildNode) ...[
               Icon(
                 Icons.subdirectory_arrow_right_rounded,
                 size: 16.sp,
@@ -737,7 +780,9 @@ class _FolderSelectionTile extends StatelessWidget {
               folder.parentId == null
                   ? Icons.folder_rounded
                   : Icons.folder_open_rounded,
-              color: context.colors.textPrimary.withValues(alpha: isSmall ? 0.6 : 1.0),
+              color: context.colors.textPrimary.withValues(
+                alpha: isSmall ? 0.6 : 1.0,
+              ),
               size: isSmall ? 20.sp : 24.sp,
             ),
             SizedBox(width: 12.w),
@@ -748,22 +793,25 @@ class _FolderSelectionTile extends StatelessWidget {
                         ? AppTypography.textSmMedium
                         : AppTypography.textSmMedium)
                     .copyWith(
-                      color: context.colors.textPrimary.withValues(alpha: isSmall ? 0.8 : 1.0),
+                      color: context.colors.textPrimary.withValues(
+                        alpha: isSmall ? 0.8 : 1.0,
+                      ),
                     ),
               ),
             ),
             if (trailing != null) trailing!,
             SizedBox(width: 8.w),
-            Icon(
-              selected
-                  ? Icons.check_circle_rounded
-                  : Icons.radio_button_unchecked_rounded,
-              color:
-                  selected
-                      ? kPrimaryColor
-                      : context.colors.textPrimary.withValues(alpha: 0.35),
-              size: isSmall ? 18.sp : 20.sp,
-            ),
+            if (folder.isDatabase)
+              Icon(
+                selected
+                    ? Icons.check_circle_rounded
+                    : Icons.radio_button_unchecked_rounded,
+                color:
+                    selected
+                        ? kPrimaryColor
+                        : context.colors.textPrimary.withValues(alpha: 0.35),
+                size: isSmall ? 18.sp : 20.sp,
+              ),
           ],
         ),
       ),

--- a/lib/screens/library/widgets/add_to_library_sheet.dart
+++ b/lib/screens/library/widgets/add_to_library_sheet.dart
@@ -6,18 +6,18 @@ import 'package:flutter/material.dart';
 
 enum AddToLibraryChoice { createDatabase, importPgn, pickPgnFile }
 
-/// Bottom sheet that offers the three "add to library" entry points:
-/// creating a new (sub-)database, importing a PGN from clipboard, and
-/// picking a `.pgn` file from the device.
+/// Bottom sheet that offers library entry points:
+/// creating a new folder/database and, for database targets, importing PGN.
 ///
-/// Pass [showCreateDatabase] = false to hide the create option — e.g. when
-/// shown from inside a sub-database where deeper nesting isn't allowed.
+/// Pass [showImports] = false when the current node is an organizational folder
+/// because folders should not receive games directly.
 Future<AddToLibraryChoice?> showAddToLibrarySheet(
   BuildContext context, {
   String title = 'Add to Library',
   bool showCreateDatabase = true,
-  String createDatabaseTitle = 'Create Database',
-  String createDatabaseSubtitle = 'New empty database or sub-database',
+  String createDatabaseTitle = 'Create Folder or Database',
+  String createDatabaseSubtitle = 'New folder or game database',
+  bool showImports = true,
 }) {
   return showModalBottomSheet<AddToLibraryChoice>(
     context: context,
@@ -65,29 +65,31 @@ Future<AddToLibraryChoice?> showAddToLibrarySheet(
                     color: context.colors.textPrimary.withValues(alpha: 0.05),
                   ),
                 ],
-                _AddSourceTile(
-                  icon: Icons.content_paste_go_rounded,
-                  title: 'Import PGN',
-                  subtitle: 'Paste one or more games from clipboard',
-                  onTap:
-                      () => Navigator.of(
-                        context,
-                      ).pop(AddToLibraryChoice.importPgn),
-                ),
-                Divider(
-                  height: 1,
-                  thickness: 0.5,
-                  color: context.colors.textPrimary.withValues(alpha: 0.05),
-                ),
-                _AddSourceTile(
-                  icon: Icons.folder_open_rounded,
-                  title: 'Import PGN file',
-                  subtitle: 'Choose a .pgn file from your device',
-                  onTap:
-                      () => Navigator.of(
-                        context,
-                      ).pop(AddToLibraryChoice.pickPgnFile),
-                ),
+                if (showImports) ...[
+                  _AddSourceTile(
+                    icon: Icons.content_paste_go_rounded,
+                    title: 'Import PGN',
+                    subtitle: 'Paste one or more games from clipboard',
+                    onTap:
+                        () => Navigator.of(
+                          context,
+                        ).pop(AddToLibraryChoice.importPgn),
+                  ),
+                  Divider(
+                    height: 1,
+                    thickness: 0.5,
+                    color: context.colors.textPrimary.withValues(alpha: 0.05),
+                  ),
+                  _AddSourceTile(
+                    icon: Icons.folder_open_rounded,
+                    title: 'Import PGN file',
+                    subtitle: 'Choose a .pgn file from your device',
+                    onTap:
+                        () => Navigator.of(
+                          context,
+                        ).pop(AddToLibraryChoice.pickPgnFile),
+                  ),
+                ],
                 SizedBox(height: 8.h),
               ],
             ),

--- a/lib/screens/library/widgets/bulk_add_to_folder_sheet.dart
+++ b/lib/screens/library/widgets/bulk_add_to_folder_sheet.dart
@@ -82,7 +82,11 @@ class _BulkAddToFolderSheetShell extends ConsumerWidget {
         isContentScrollAware: true,
       ),
       child: PagedSheet(
-        decoration: ChessSheetDecoration.dark(context, alpha: 0.97, borderRadius: 28.sp),
+        decoration: ChessSheetDecoration.dark(
+          context,
+          alpha: 0.97,
+          borderRadius: 28.sp,
+        ),
         shrinkChildToAvoidDynamicOverlap: true,
         navigator: navigator,
       ),
@@ -204,7 +208,11 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
       final ownedBookCount =
-          folders.where((f) => !f.isSubscribed && f.id != kTwicBookId).length;
+          folders
+              .where(
+                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
+              )
+              .length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -219,16 +227,24 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
     try {
       final created = await ref
           .read(libraryRepositoryProvider)
-          .createFolder(name: data.name, parentId: data.parentId);
+          .createFolder(
+            name: data.name,
+            parentId: data.parentId,
+            nodeType: data.nodeType,
+          );
       ref.invalidate(libraryFoldersStreamProvider);
 
       if (!mounted) return;
-      setState(() => _selectedFolderIds.add(created.id));
+      if (created.isDatabase) {
+        setState(() => _selectedFolderIds.add(created.id));
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Database "${data.name}" created',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            '${data.nodeType == LibraryFolder.nodeTypeFolder ? 'Folder' : 'Database'} "${data.name}" created',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -239,8 +255,10 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Failed to create database: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            'Failed to create item: $e',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -329,7 +347,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
         SnackBar(
           content: Text(
             'Select at least one database',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -478,7 +498,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
             _savedEntries > 0
                 ? 'Added $_savedEntries entries to your databases'
                 : 'No new games were added',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -491,7 +513,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
         SnackBar(
           content: Text(
             'Bulk add failed: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -548,7 +572,10 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
           data:
               (folders) =>
                   folders
-                      .where((f) => _selectedFolderIds.contains(f.id))
+                      .where(
+                        (f) =>
+                            _selectedFolderIds.contains(f.id) && f.isDatabase,
+                      )
                       .toList(),
         ) ??
         [];
@@ -594,7 +621,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                         child: Text(
                           'No databases yet.',
                           style: AppTypography.textSmRegular.copyWith(
-                            color: context.colors.textPrimary.withValues(alpha: 0.5),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.5,
+                            ),
                           ),
                           textAlign: TextAlign.center,
                         ),
@@ -617,8 +646,10 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                     );
                   },
                   loading:
-                      () =>  Center(
-                        child: CircularProgressIndicator(color: context.colors.textPrimary),
+                      () => Center(
+                        child: CircularProgressIndicator(
+                          color: context.colors.textPrimary,
+                        ),
                       ),
                   error:
                       (e, _) => Center(
@@ -643,7 +674,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                       child: LinearProgressIndicator(
                         minHeight: 8.h,
                         color: kPrimaryColor,
-                        backgroundColor: context.colors.textPrimary.withValues(alpha: 0.08),
+                        backgroundColor: context.colors.textPrimary.withValues(
+                          alpha: 0.08,
+                        ),
                         value:
                             widget.games.isEmpty
                                 ? null
@@ -657,7 +690,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                     Text(
                       'Processed $_processedGames/${widget.games.length} · Saved $_savedEntries · Skipped $_skippedEntries · Failed $_failedGames',
                       style: AppTypography.textXsRegular.copyWith(
-                        color: context.colors.textPrimary.withValues(alpha: 0.72),
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.72,
+                        ),
                       ),
                     ),
                   ],
@@ -676,10 +711,14 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                         child: Container(
                           padding: EdgeInsets.symmetric(vertical: 14.h),
                           decoration: BoxDecoration(
-                            color: context.colors.textPrimary.withValues(alpha: 0.10),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.10,
+                            ),
                             borderRadius: BorderRadius.circular(12.br),
                             border: Border.all(
-                              color: context.colors.textPrimary.withValues(alpha: 0.14),
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.14,
+                              ),
                             ),
                           ),
                           child: Row(
@@ -778,13 +817,13 @@ class _BulkFolderSelectionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isSubdatabase = folder.parentId != null;
+    final isChildNode = folder.parentId != null;
 
     return GestureDetector(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.only(
-          left: 16.w + (isSubdatabase ? 24.w : 0),
+          left: 16.w + (isChildNode ? 24.w : 0),
           right: 16.w,
           top: 14.h,
           bottom: 14.h,
@@ -804,7 +843,7 @@ class _BulkFolderSelectionTile extends StatelessWidget {
         ),
         child: Row(
           children: [
-            if (isSubdatabase) ...[
+            if (isChildNode) ...[
               Icon(
                 Icons.subdirectory_arrow_right_rounded,
                 size: 16.sp,
@@ -812,12 +851,18 @@ class _BulkFolderSelectionTile extends StatelessWidget {
               ),
               SizedBox(width: 8.w),
             ],
-            Icon(Icons.folder_rounded, color: context.colors.textPrimary, size: 24.sp),
+            Icon(
+              Icons.folder_rounded,
+              color: context.colors.textPrimary,
+              size: 24.sp,
+            ),
             SizedBox(width: 12.w),
             Expanded(
               child: Text(
                 folder.name,
-                style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textSmMedium.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
             ),
             Icon(

--- a/lib/screens/library/widgets/create_folder_dialog.dart
+++ b/lib/screens/library/widgets/create_folder_dialog.dart
@@ -13,10 +13,11 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class LibraryFolderCreationData {
   final String name;
   final String? parentId;
-  LibraryFolderCreationData(this.name, this.parentId);
+  final String nodeType;
+  LibraryFolderCreationData(this.name, this.parentId, this.nodeType);
 }
 
-/// Shows a refined dialog to create a new database or sub-database.
+/// Shows a refined dialog to create a new folder or database.
 Future<LibraryFolderCreationData?> showCreateFolderDialog(
   BuildContext context, {
   String? initialParentId,
@@ -27,7 +28,7 @@ Future<LibraryFolderCreationData?> showCreateFolderDialog(
     barrierColor: Colors.black.withValues(alpha: 0.8),
     builder:
         (context) => _FolderNameDialog(
-          title: initialParentId != null ? 'New Sub-database' : 'New Database',
+          title: initialParentId != null ? 'Add to Folder' : 'New Library Item',
           confirmLabel: 'Create',
           initialParentId: initialParentId,
           isLocked: lockToParent,
@@ -45,7 +46,7 @@ Future<String?> showRenameFolderDialog(
     barrierColor: Colors.black.withValues(alpha: 0.8),
     builder:
         (context) => _FolderNameDialog(
-          title: 'Rename Database',
+          title: 'Rename',
           confirmLabel: 'Save',
           initialValue: currentName,
           isRename: true,
@@ -78,7 +79,7 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
   late TextEditingController _controller;
   late FocusNode _focusNode;
   String? _selectedParentId;
-  bool _isSubdatabase = false;
+  bool _isDatabase = true;
 
   @override
   void initState() {
@@ -86,7 +87,7 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
     _controller = TextEditingController(text: widget.initialValue ?? '');
     _focusNode = FocusNode();
     _selectedParentId = widget.initialParentId;
-    _isSubdatabase = widget.initialParentId != null;
+    _isDatabase = true;
 
     // Auto-focus the text field
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -114,7 +115,10 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
         Navigator.of(context).pop(
           LibraryFolderCreationData(
             name,
-            _isSubdatabase ? _selectedParentId : null,
+            _selectedParentId,
+            _isDatabase
+                ? LibraryFolder.nodeTypeDatabase
+                : LibraryFolder.nodeTypeFolder,
           ),
         );
       }
@@ -125,9 +129,10 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final rootFolders = ref.watch(rootLibraryFoldersProvider);
+    final allFolders =
+        ref.watch(combinedLibraryFoldersProvider).valueOrNull ?? [];
     final availableParents =
-        rootFolders.where((f) => f.id != kTwicBookId).toList();
+        allFolders.where((f) => f.id != kTwicBookId && f.isFolder).toList();
 
     return Dialog(
       backgroundColor: Colors.transparent,
@@ -167,8 +172,8 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
                       child: Icon(
                         widget.isRename
                             ? Icons.edit_rounded
-                            : (_isSubdatabase
-                                ? Icons.folder_open_rounded
+                            : (_isDatabase
+                                ? Icons.storage_rounded
                                 : Icons.folder_rounded),
                         color: kPrimaryColor,
                         size: 22.sp,
@@ -195,13 +200,15 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
                   SizedBox(height: 20.h),
                 ],
 
-                // Parent selection (if sub-database selected and not locked)
-                if (_isSubdatabase && !widget.isLocked && !widget.isRename) ...[
+                // Parent selection (if a parent folder is being selected)
+                if (_selectedParentId != null &&
+                    !widget.isLocked &&
+                    !widget.isRename) ...[
                   _buildParentSelector(availableParents),
                   SizedBox(height: 20.h),
                 ],
 
-                // Context message for locked sub-database
+                // Context message for a locked parent folder
                 if (widget.isLocked && _selectedParentId != null) ...[
                   _buildLockedContext(availableParents),
                   SizedBox(height: 20.h),
@@ -233,27 +240,21 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
         children: [
           Expanded(
             child: _TypeButton(
-              label: 'Database',
-              isSelected: !_isSubdatabase,
+              label: 'Folder',
+              isSelected: !_isDatabase,
               onTap: () {
-                setState(() => _isSubdatabase = false);
+                setState(() => _isDatabase = false);
                 HapticFeedbackService.light();
               },
             ),
           ),
           Expanded(
             child: _TypeButton(
-              label: 'Subdatabase',
-              isSelected: _isSubdatabase,
+              label: 'Database',
+              isSelected: _isDatabase,
               onTap: () {
                 setState(() {
-                  _isSubdatabase = true;
-                  // Default to first parent if none selected
-                  final roots = ref.read(rootLibraryFoldersProvider);
-                  if (_selectedParentId == null && roots.isNotEmpty) {
-                    _selectedParentId =
-                        roots.firstWhere((f) => f.id != kTwicBookId).id;
-                  }
+                  _isDatabase = true;
                 });
                 HapticFeedbackService.light();
               },
@@ -267,7 +268,7 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
   Widget _buildParentSelector(List<LibraryFolder> parents) {
     if (parents.isEmpty) {
       return Text(
-        'Create a database first to create a sub-database inside.',
+        'Create a folder first to organize databases inside it.',
         style: AppTypography.textXsRegular.copyWith(color: kRedColor),
       ).animate().fadeIn();
     }
@@ -276,7 +277,7 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'PARENT DATABASE',
+          'PARENT FOLDER',
           style: AppTypography.textXsBold.copyWith(
             color: context.colors.textPrimary.withValues(alpha: 0.4),
             letterSpacing: 1.0,
@@ -288,7 +289,9 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
           decoration: BoxDecoration(
             color: context.colors.textPrimary.withValues(alpha: 0.06),
             borderRadius: BorderRadius.circular(12.br),
-            border: Border.all(color: context.colors.textPrimary.withValues(alpha: 0.08)),
+            border: Border.all(
+              color: context.colors.textPrimary.withValues(alpha: 0.08),
+            ),
           ),
           child: DropdownButtonHideUnderline(
             child: DropdownButton<String>(
@@ -341,7 +344,7 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
           SizedBox(width: 10.w),
           Expanded(
             child: Text(
-              'Inside database "${parent.name}"',
+              'Inside folder "${parent.name}"',
               style: AppTypography.textXsMedium.copyWith(
                 color: context.colors.textPrimary.withValues(alpha: 0.7),
               ),
@@ -368,7 +371,9 @@ class _FolderNameDialogState extends ConsumerState<_FolderNameDialog> {
           controller: _controller,
           focusNode: _focusNode,
           maxLength: 40,
-          style: AppTypography.textMdMedium.copyWith(color: context.colors.textPrimary),
+          style: AppTypography.textMdMedium.copyWith(
+            color: context.colors.textPrimary,
+          ),
           cursorColor: kPrimaryColor,
           decoration: InputDecoration(
             hintText: 'e.g. My Openings',
@@ -475,7 +480,9 @@ class _TypeButton extends StatelessWidget {
             label,
             style: AppTypography.textXsBold.copyWith(
               color:
-                  isSelected ? context.colors.textPrimary : context.colors.textPrimary.withValues(alpha: 0.4),
+                  isSelected
+                      ? context.colors.textPrimary
+                      : context.colors.textPrimary.withValues(alpha: 0.4),
             ),
           ),
         ),

--- a/lib/screens/library/widgets/folder_card.dart
+++ b/lib/screens/library/widgets/folder_card.dart
@@ -19,9 +19,15 @@ import 'package:motor/motor.dart';
 import 'package:share_plus/share_plus.dart';
 
 String _formatGameCount(int count) {
-  if (count == 0) return 'Empty';
+  if (count == 0) return 'Empty database';
   if (count == 1) return '1 game';
   return '${formatCompactCount(count)} games';
+}
+
+String _formatChildCount(int count) {
+  if (count == 0) return 'Empty folder';
+  if (count == 1) return '1 item';
+  return '$count items';
 }
 
 class FolderCard extends ConsumerWidget {
@@ -83,12 +89,13 @@ class FolderCard extends ConsumerWidget {
                     SvgAsset.folderOutline,
                     width: 18.sp,
                     height: 18.sp,
-                    colorFilter: context.isLightTheme
-                        ? ColorFilter.mode(
-                            context.colors.iconPrimary,
-                            BlendMode.srcIn,
-                          )
-                        : null,
+                    colorFilter:
+                        context.isLightTheme
+                            ? ColorFilter.mode(
+                              context.colors.iconPrimary,
+                              BlendMode.srcIn,
+                            )
+                            : null,
                   ),
                 ),
               ),
@@ -123,14 +130,25 @@ class FolderCard extends ConsumerWidget {
         height: 16 / 12,
       );
       countWidget = twicTotalAsync.when(
-        data: (count) => Text(
-          count > 0
-              ? '${formatCompactCount(count)} master games'
-              : 'Master games',
-          style: twicLabelStyle,
-        ),
+        data:
+            (count) => Text(
+              count > 0
+                  ? '${formatCompactCount(count)} master games'
+                  : 'Master games',
+              style: twicLabelStyle,
+            ),
         loading: () => Text('Master games', style: twicLabelStyle),
         error: (_, __) => Text('Master games', style: twicLabelStyle),
+      );
+    } else if (folder.isFolder) {
+      final childCount =
+          ref.watch(childLibraryFoldersProvider(folder.id)).length;
+      countWidget = Text(
+        _formatChildCount(childCount),
+        style: AppTypography.textXsRegular.copyWith(
+          color: const Color(0xFFA1A1A1),
+          height: 16 / 12,
+        ),
       );
     } else {
       final countAsync = ref.watch(folderAnalysisCountProvider(folder.id));
@@ -196,12 +214,13 @@ class FolderCard extends ConsumerWidget {
                       SvgAsset.folderOutline,
                       width: svgSize,
                       height: svgSize,
-                      colorFilter: context.isLightTheme
-                          ? ColorFilter.mode(
-                              context.colors.iconPrimary,
-                              BlendMode.srcIn,
-                            )
-                          : null,
+                      colorFilter:
+                          context.isLightTheme
+                              ? ColorFilter.mode(
+                                context.colors.iconPrimary,
+                                BlendMode.srcIn,
+                              )
+                              : null,
                     ),
                   ),
                 ),
@@ -277,7 +296,7 @@ class FolderCard extends ConsumerWidget {
   void _showOverlayMenu(BuildContext context, WidgetRef ref) {
     HapticFeedbackService.light();
 
-    final isSubFolder = folder.parentId != null;
+    final isNonShareable = folder.parentId != null || folder.isFolder;
 
     if (folder.isSubscribed) {
       // Subscribed books: only show Unsubscribe
@@ -293,7 +312,7 @@ class FolderCard extends ConsumerWidget {
         onStopSharing: () => _stopSharing(context, ref),
         onRename: () => _renameFolder(context, ref),
         onDelete: () => _deleteFolder(context, ref),
-        isSubFolder: isSubFolder,
+        isSubFolder: isNonShareable,
       );
     } else {
       // Not shared: show Share, Rename, Delete
@@ -302,7 +321,7 @@ class FolderCard extends ConsumerWidget {
         onShare: () => _shareFolder(context, ref),
         onRename: () => _renameFolder(context, ref),
         onDelete: () => _deleteFolder(context, ref),
-        isSubFolder: isSubFolder,
+        isSubFolder: isNonShareable,
       );
     }
   }
@@ -328,7 +347,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Failed to share: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -345,7 +366,9 @@ class FolderCard extends ConsumerWidget {
       SnackBar(
         content: Text(
           'Link copied',
-          style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+          style: AppTypography.textSmMedium.copyWith(
+            color: context.colors.textPrimary,
+          ),
         ),
         backgroundColor: context.colors.surface.withValues(alpha: 0.95),
         behavior: SnackBarBehavior.floating,
@@ -365,7 +388,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Sharing stopped',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -378,7 +403,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Failed to stop sharing: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -400,7 +427,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Unsubscribed from "${folder.name}"',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -413,7 +442,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Failed to unsubscribe: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -433,16 +464,7 @@ class FolderCard extends ConsumerWidget {
     try {
       final repo = ref.read(libraryRepositoryProvider);
       await repo.updateFolder(
-        LibraryFolder(
-          id: folder.id,
-          userId: folder.userId,
-          name: name,
-          color: folder.color,
-          icon: folder.icon,
-          orderIndex: folder.orderIndex,
-          createdAt: folder.createdAt,
-          updatedAt: DateTime.now(),
-        ),
+        folder.copyWith(name: name, updatedAt: DateTime.now()),
       );
       ref.invalidate(libraryFoldersStreamProvider);
       if (!context.mounted) return;
@@ -451,7 +473,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Renamed to "$name"',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -464,7 +488,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Failed to rename: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -488,11 +514,15 @@ class FolderCard extends ConsumerWidget {
                   borderRadius: BorderRadius.circular(16.br),
                 ),
                 title: Text(
-                  'Delete database?',
-                  style: AppTypography.textSmBold.copyWith(color: context.colors.textPrimary),
+                  'Delete ${folder.isFolder ? 'folder' : 'database'}?',
+                  style: AppTypography.textSmBold.copyWith(
+                    color: context.colors.textPrimary,
+                  ),
                 ),
                 content: Text(
-                  'This permanently deletes the database and every game inside it. This cannot be undone.',
+                  folder.isFolder
+                      ? 'This permanently deletes the folder and everything inside it. This cannot be undone.'
+                      : 'This permanently deletes the database and every game inside it. This cannot be undone.',
                   style: AppTypography.textXsRegular.copyWith(
                     color: context.colors.textPrimary.withValues(alpha: 0.7),
                   ),
@@ -503,7 +533,9 @@ class FolderCard extends ConsumerWidget {
                     child: Text(
                       'Cancel',
                       style: AppTypography.textSmMedium.copyWith(
-                        color: context.colors.textPrimary.withValues(alpha: 0.7),
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.7,
+                        ),
                       ),
                     ),
                   ),
@@ -536,8 +568,10 @@ class FolderCard extends ConsumerWidget {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Database deleted',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            '${folder.isFolder ? 'Folder' : 'Database'} deleted',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -550,7 +584,9 @@ class FolderCard extends ConsumerWidget {
         SnackBar(
           content: Text(
             'Failed to delete: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -663,13 +699,13 @@ void showFolderOverlayMenu({
       ),
       _OverlayMenuItemData(
         Icons.edit_rounded,
-        'Rename Database',
+        'Rename',
         onRename,
         _MenuItemPosition.middle,
       ),
       _OverlayMenuItemData(
         Icons.delete_outline_rounded,
-        'Delete Folder',
+        'Delete',
         onDelete,
         _MenuItemPosition.bottom,
       ),
@@ -717,13 +753,13 @@ void showSharedFolderOverlayMenu({
       ),
       _OverlayMenuItemData(
         Icons.edit_rounded,
-        'Rename Database',
+        'Rename',
         onRename,
         _MenuItemPosition.middle,
       ),
       _OverlayMenuItemData(
         Icons.delete_outline_rounded,
-        'Delete Folder',
+        'Delete',
         onDelete,
         _MenuItemPosition.bottom,
       ),
@@ -958,8 +994,10 @@ class _OverlayMenuItemState extends State<_OverlayMenuItem> {
 
   @override
   Widget build(BuildContext context) {
-    final textColor = widget.isEnabled ? context.colors.textPrimary : const Color(0xFF4D4D4D);
-    final iconColor = widget.isEnabled ? context.colors.textPrimary : const Color(0xFF4D4D4D);
+    final textColor =
+        widget.isEnabled ? context.colors.textPrimary : const Color(0xFF4D4D4D);
+    final iconColor =
+        widget.isEnabled ? context.colors.textPrimary : const Color(0xFF4D4D4D);
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,

--- a/lib/screens/library/widgets/import_pgn_to_folder_sheet.dart
+++ b/lib/screens/library/widgets/import_pgn_to_folder_sheet.dart
@@ -111,7 +111,11 @@ class _ImportPgnToFolderSheetShell extends ConsumerWidget {
         isContentScrollAware: true,
       ),
       child: PagedSheet(
-        decoration: ChessSheetDecoration.dark(context, alpha: 0.97, borderRadius: 28.sp),
+        decoration: ChessSheetDecoration.dark(
+          context,
+          alpha: 0.97,
+          borderRadius: 28.sp,
+        ),
         shrinkChildToAvoidDynamicOverlap: true,
         navigator: navigator,
       ),
@@ -170,7 +174,11 @@ class _ImportPgnToFolderPageState
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
       final ownedBookCount =
-          folders.where((f) => !f.isSubscribed && f.id != kTwicBookId).length;
+          folders
+              .where(
+                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
+              )
+              .length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -185,16 +193,24 @@ class _ImportPgnToFolderPageState
     try {
       final created = await ref
           .read(libraryRepositoryProvider)
-          .createFolder(name: data.name, parentId: data.parentId);
+          .createFolder(
+            name: data.name,
+            parentId: data.parentId,
+            nodeType: data.nodeType,
+          );
       ref.invalidate(libraryFoldersStreamProvider);
 
       if (!mounted) return;
-      setState(() => _selectedFolderIds.add(created.id));
+      if (created.isDatabase) {
+        setState(() => _selectedFolderIds.add(created.id));
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Database "${data.name}" created',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            '${data.nodeType == LibraryFolder.nodeTypeFolder ? 'Folder' : 'Database'} "${data.name}" created',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -205,8 +221,10 @@ class _ImportPgnToFolderPageState
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            'Failed to create database: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            'Failed to create item: $e',
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -230,7 +248,9 @@ class _ImportPgnToFolderPageState
         SnackBar(
           content: Text(
             'Select at least one database',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -303,7 +323,9 @@ class _ImportPgnToFolderPageState
             _savedEntries > 0
                 ? 'Imported $_savedEntries entries into your databases'
                 : 'No games were imported',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: context.colors.surface.withValues(alpha: 0.95),
           behavior: SnackBarBehavior.floating,
@@ -316,7 +338,9 @@ class _ImportPgnToFolderPageState
         SnackBar(
           content: Text(
             'Import failed: $e',
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
           ),
           backgroundColor: kRedColor,
           behavior: SnackBarBehavior.floating,
@@ -368,7 +392,7 @@ class _ImportPgnToFolderPageState
               (folders) =>
                   folders
                       .where((f) => _selectedFolderIds.contains(f.id))
-                      .where((f) => !f.isSubscribed)
+                      .where((f) => !f.isSubscribed && f.isDatabase)
                       .toList(),
         ) ??
         [];
@@ -412,21 +436,24 @@ class _ImportPgnToFolderPageState
                   data: (folders) {
                     // Only owned (not subscribed) folders can receive writes.
                     final writable =
-                        folders.where((f) => !f.isSubscribed).toList();
+                        folders
+                            .where((f) => !f.isSubscribed && f.isDatabase)
+                            .toList();
                     if (writable.isEmpty) {
                       return Padding(
                         padding: EdgeInsets.all(20.sp),
                         child: Text(
                           'No databases yet. Create one below.',
                           style: AppTypography.textSmRegular.copyWith(
-                            color: context.colors.textPrimary.withValues(alpha: 0.5),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.5,
+                            ),
                           ),
                           textAlign: TextAlign.center,
                         ),
                       );
                     }
-                    final sortedFolders =
-                        _sortFoldersHierarchically(writable);
+                    final sortedFolders = _sortFoldersHierarchically(writable);
                     return ListView.separated(
                       shrinkWrap: true,
                       padding: EdgeInsets.symmetric(horizontal: 16.w),
@@ -443,8 +470,10 @@ class _ImportPgnToFolderPageState
                     );
                   },
                   loading:
-                      () =>  Center(
-                        child: CircularProgressIndicator(color: context.colors.textPrimary),
+                      () => Center(
+                        child: CircularProgressIndicator(
+                          color: context.colors.textPrimary,
+                        ),
                       ),
                   error:
                       (e, _) => Center(
@@ -469,7 +498,9 @@ class _ImportPgnToFolderPageState
                       child: LinearProgressIndicator(
                         minHeight: 8.h,
                         color: kPrimaryColor,
-                        backgroundColor: context.colors.textPrimary.withValues(alpha: 0.08),
+                        backgroundColor: context.colors.textPrimary.withValues(
+                          alpha: 0.08,
+                        ),
                         value:
                             totalRows == 0
                                 ? null
@@ -480,7 +511,9 @@ class _ImportPgnToFolderPageState
                     Text(
                       'Saved $_savedEntries / $totalRows',
                       style: AppTypography.textXsRegular.copyWith(
-                        color: context.colors.textPrimary.withValues(alpha: 0.72),
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.72,
+                        ),
                       ),
                     ),
                   ],
@@ -499,10 +532,14 @@ class _ImportPgnToFolderPageState
                         child: Container(
                           padding: EdgeInsets.symmetric(vertical: 14.h),
                           decoration: BoxDecoration(
-                            color: context.colors.textPrimary.withValues(alpha: 0.10),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.10,
+                            ),
                             borderRadius: BorderRadius.circular(12.br),
                             border: Border.all(
-                              color: context.colors.textPrimary.withValues(alpha: 0.14),
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.14,
+                              ),
                             ),
                           ),
                           child: Row(
@@ -601,13 +638,13 @@ class _ImportFolderTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isSubdatabase = folder.parentId != null;
+    final isChildNode = folder.parentId != null;
 
     return GestureDetector(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.only(
-          left: 16.w + (isSubdatabase ? 24.w : 0),
+          left: 16.w + (isChildNode ? 24.w : 0),
           right: 16.w,
           top: 14.h,
           bottom: 14.h,
@@ -627,7 +664,7 @@ class _ImportFolderTile extends StatelessWidget {
         ),
         child: Row(
           children: [
-            if (isSubdatabase) ...[
+            if (isChildNode) ...[
               Icon(
                 Icons.subdirectory_arrow_right_rounded,
                 size: 16.sp,
@@ -635,12 +672,18 @@ class _ImportFolderTile extends StatelessWidget {
               ),
               SizedBox(width: 8.w),
             ],
-            Icon(Icons.folder_rounded, color: context.colors.textPrimary, size: 24.sp),
+            Icon(
+              Icons.folder_rounded,
+              color: context.colors.textPrimary,
+              size: 24.sp,
+            ),
             SizedBox(width: 12.w),
             Expanded(
               child: Text(
                 folder.name,
-                style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textSmMedium.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
             ),
             Icon(

--- a/supabase/migrations/20260530004300_split_library_folders_and_databases_phone.sql
+++ b/supabase/migrations/20260530004300_split_library_folders_and_databases_phone.sql
@@ -1,0 +1,108 @@
+-- Split the legacy "folder that is also a database" model into two clear
+-- user-facing node types:
+--   * folder   : organization only; can contain folders/databases; no games
+--   * database : contains games; cannot contain child nodes going forward
+--
+-- Existing data is migrated without deleting games:
+--   * only games       -> database
+--   * only children    -> folder
+--   * games + children -> folder + a new child database holding the games
+--   * empty            -> folder
+
+ALTER TABLE public.user_folders
+  ADD COLUMN IF NOT EXISTS node_type text NOT NULL DEFAULT 'database';
+
+ALTER TABLE public.user_folders
+  DROP CONSTRAINT IF EXISTS user_folders_node_type_check;
+
+ALTER TABLE public.user_folders
+  ADD CONSTRAINT user_folders_node_type_check
+  CHECK (node_type IN ('folder', 'database'));
+
+-- Mixed legacy nodes need to stop being both things at once. Keep the legacy
+-- row/id as the organization folder so children/subscriptions keep working,
+-- then move its direct games into a newly-created database under it.
+DO $$
+DECLARE
+  mixed record;
+  new_database_id uuid;
+BEGIN
+  FOR mixed IN
+    SELECT f.*
+    FROM public.user_folders f
+    WHERE EXISTS (
+      SELECT 1 FROM public.user_saved_analyses a WHERE a.folder_id = f.id
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.user_folders child WHERE child.parent_id = f.id
+    )
+  LOOP
+    INSERT INTO public.user_folders (
+      user_id,
+      name,
+      color,
+      icon,
+      order_index,
+      parent_id,
+      node_type
+    ) VALUES (
+      mixed.user_id,
+      mixed.name,
+      mixed.color,
+      COALESCE(NULLIF(mixed.icon, ''), 'database'),
+      mixed.order_index,
+      mixed.id,
+      'database'
+    )
+    RETURNING id INTO new_database_id;
+
+    UPDATE public.user_saved_analyses
+    SET folder_id = new_database_id
+    WHERE folder_id = mixed.id;
+
+    UPDATE public.user_folders
+    SET node_type = 'folder', icon = 'folder', updated_at = now()
+    WHERE id = mixed.id;
+  END LOOP;
+END $$;
+
+-- Legacy nodes with no direct games are organizational folders. Nodes with
+-- direct games and no children remain databases.
+UPDATE public.user_folders f
+SET node_type = 'folder',
+    icon = CASE WHEN COALESCE(icon, '') = '' THEN 'folder' ELSE icon END,
+    updated_at = now()
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.user_saved_analyses a WHERE a.folder_id = f.id
+);
+
+-- Guard the new invariant at the database level: games may only point at
+-- database nodes. The trigger is intentionally NOT VALIDATED against old app
+-- versions at compile time; it checks runtime rows and rejects future writes
+-- into organization folders.
+CREATE OR REPLACE FUNCTION public.ensure_saved_analysis_database_folder()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.folder_id IS NOT NULL AND EXISTS (
+    SELECT 1
+    FROM public.user_folders f
+    WHERE f.id = NEW.folder_id
+      AND f.node_type = 'folder'
+  ) THEN
+    RAISE EXCEPTION 'Cannot save games directly into an organization folder';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS ensure_saved_analysis_database_folder_trigger
+  ON public.user_saved_analyses;
+
+CREATE TRIGGER ensure_saved_analysis_database_folder_trigger
+  BEFORE INSERT OR UPDATE OF folder_id ON public.user_saved_analyses
+  FOR EACH ROW
+  EXECUTE FUNCTION public.ensure_saved_analysis_database_folder();

--- a/test/library_folder_node_type_test.dart
+++ b/test/library_folder_node_type_test.dart
@@ -1,0 +1,45 @@
+import 'package:chessever2/repository/library/models/library_folder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> _folderJson({String? nodeType}) {
+  return {
+    'id': 'folder-1',
+    'user_id': 'user-1',
+    'name': 'Study',
+    'color': '#0FB4E5',
+    'icon': 'folder',
+    'order_index': 0,
+    'created_at': '2026-05-30T00:00:00Z',
+    'updated_at': '2026-05-30T00:00:00Z',
+    'parent_id': null,
+    if (nodeType != null) 'node_type': nodeType,
+  };
+}
+
+void main() {
+  test('LibraryFolder defaults legacy rows to database node type', () {
+    final folder = LibraryFolder.fromSupabase(_folderJson());
+
+    expect(folder.nodeType, LibraryFolder.nodeTypeDatabase);
+    expect(folder.isDatabase, isTrue);
+    expect(folder.isFolder, isFalse);
+    expect(
+      folder.toSupabaseInsert()['node_type'],
+      LibraryFolder.nodeTypeDatabase,
+    );
+  });
+
+  test('LibraryFolder preserves folder node type through map and copyWith', () {
+    final folder = LibraryFolder.fromSupabase(
+      _folderJson(nodeType: LibraryFolder.nodeTypeFolder),
+    );
+
+    expect(folder.nodeType, LibraryFolder.nodeTypeFolder);
+    expect(folder.isFolder, isTrue);
+    expect(folder.toSupabaseMap()['node_type'], LibraryFolder.nodeTypeFolder);
+
+    final renamed = folder.copyWith(name: 'Openings');
+    expect(renamed.nodeType, LibraryFolder.nodeTypeFolder);
+    expect(renamed.isDatabase, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- Splits the phone Library model into explicit folder/database node types (`nodeType`) so folders are organizational and databases hold games.
- Updates Library creation, card/menu labels, folder contents, save-analysis, add-to-library, bulk add, and PGN import flows to use only databases as save/import targets.
- Adds a safe Supabase migration mirroring the desktop cleanup for legacy mixed nodes, plus a regression test for legacy/default node type handling.

## Product rules preserved
- Folders can contain folders/databases, but do not directly contain games.
- Databases contain games and are the only save/import targets.
- User-facing copy avoids “subdatabase” / “database inside database” language.
- Legacy hybrid nodes are split safely rather than preserved as hybrids.

## Validation
- `flutter analyze lib/repository/library/library_repository.dart lib/repository/library/models/library_folder.dart lib/repository/library/models/library_folder.mapper.dart lib/screens/chessboard/widgets/save_analysis_sheet.dart lib/screens/library/folder_contents_screen.dart lib/screens/library/library_screen.dart lib/screens/library/providers/library_folders_provider.dart lib/screens/library/utils/folder_pgn_exporter.dart lib/screens/library/widgets/add_to_folder_sheet.dart lib/screens/library/widgets/add_to_library_sheet.dart lib/screens/library/widgets/bulk_add_to_folder_sheet.dart lib/screens/library/widgets/create_folder_dialog.dart lib/screens/library/widgets/folder_card.dart lib/screens/library/widgets/import_pgn_to_folder_sheet.dart test/library_folder_node_type_test.dart`
- `flutter test test/library_folder_node_type_test.dart`
- `git diff --check`

## Notes
- This is the phone-app counterpart to the desktop folder/database cleanup so both platforms use the same Library model.
- Desktop PR reference: Chessever/chessever_frontend_desktop#79
