### PR TITLE
Fix TWIC player event titles

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -42,6 +42,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_p
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/screens/chessboard/widgets/player_first_row_detail_widget.dart';
+import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/repository/supabase/game/game_repository.dart';
@@ -14489,23 +14490,16 @@ class _EventInfoSheet extends ConsumerWidget {
   ) {
     final headers = _parseHeadersFromPgn();
 
-    // Determine event name: PGN [Event] > game.tourSlug > game.tourId (if not UUID)
-    String eventName = 'Game Info';
-    if (headers['Event'] != null &&
-        headers['Event']!.isNotEmpty &&
-        headers['Event'] != '?') {
-      eventName = headers['Event']!;
-    } else if (game.tourSlug != null && game.tourSlug!.isNotEmpty) {
-      eventName = StringUtils.slugToTitle(game.tourSlug!);
-    } else if (game.tourId.isNotEmpty) {
-      final isUuid = RegExp(
-        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-        caseSensitive: false,
-      ).hasMatch(game.tourId);
-      if (!isUuid) {
-        eventName = game.tourId;
-      }
-    }
+    // Determine event name. In TWIC player-profile routes, raw PGN Event can
+    // be a per-round/pairing label; prefer the canonical event from the game
+    // list when that happens.
+    final pgnEvent = headers['Event'];
+    final eventName = preferredTwicEventTitle(
+      pgnEvent: pgnEvent,
+      tourSlug: game.tourSlug,
+      tourId: game.tourId,
+      fallback: 'Game Info',
+    );
 
     return ListView(
       controller: scrollController,

--- a/lib/screens/player_profile/provider/player_profile_provider.dart
+++ b/lib/screens/player_profile/provider/player_profile_provider.dart
@@ -11,6 +11,7 @@ import 'package:dio/dio.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/player_profile/player_profile_data_source.dart';
+import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/utils/chess_title_utils.dart';
 import 'package:chessever2/utils/time_utils.dart';
@@ -627,6 +628,12 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
         final opening = row['opening']?.toString();
         final variation = row['variation']?.toString();
         final event = (row['event']?.toString() ?? 'Gamebase').trim();
+        final canonicalEvent = preferredTwicEventTitle(
+          pgnEvent: event,
+          tourSlug: row['tourSlug']?.toString(),
+          tourId: row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          fallback: event.isNotEmpty ? event : 'Gamebase',
+        );
 
         final whiteName = (row['white']?.toString() ?? 'White').trim();
         final blackName = (row['black']?.toString() ?? 'Black').trim();
@@ -635,7 +642,7 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
           whiteName: whiteName,
           blackName: blackName,
           result: result,
-          event: event.isNotEmpty ? event : 'Gamebase',
+          event: canonicalEvent,
           date: date,
           eco: eco,
           opening: opening,
@@ -667,7 +674,7 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
         final tourId =
             (row['tour_id']?.toString() ??
                     row['tournament_id']?.toString() ??
-                    event)
+                    canonicalEvent)
                 .trim();
 
         return GamesTourModel(
@@ -685,8 +692,8 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
               (eco != null && eco.trim().isNotEmpty)
                   ? eco.trim()
                   : (timeControl ?? ''),
-          tourId: tourId.isNotEmpty ? tourId : 'Gamebase',
-          tourSlug: event.isNotEmpty ? event : 'Gamebase',
+          tourId: tourId.isNotEmpty ? tourId : canonicalEvent,
+          tourSlug: canonicalEvent,
           pgn: pgn,
           lastMoveTime: date,
           eco: (eco != null && eco.trim().isNotEmpty) ? eco.trim() : null,
@@ -817,6 +824,12 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
                 .trim();
 
         final event = (row['event']?.toString() ?? 'Gamebase').trim();
+        final canonicalEvent = preferredTwicEventTitle(
+          pgnEvent: event,
+          tourSlug: row['tourSlug']?.toString(),
+          tourId: row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          fallback: event.isNotEmpty ? event : 'Gamebase',
+        );
         final site = row['site']?.toString();
         final eco = row['eco']?.toString();
         final opening = row['opening']?.toString();
@@ -826,7 +839,7 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
           whiteName: whiteName,
           blackName: blackName,
           result: result,
-          event: event.isNotEmpty ? event : 'Gamebase',
+          event: canonicalEvent,
           site: site,
           date: date,
           eco: eco,
@@ -859,7 +872,7 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
         final tourId =
             (row['tour_id']?.toString() ??
                     row['tournament_id']?.toString() ??
-                    event)
+                    canonicalEvent)
                 .trim();
 
         return GamesTourModel(
@@ -877,8 +890,8 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
               (eco != null && eco.trim().isNotEmpty)
                   ? eco.trim()
                   : (timeControl ?? ''),
-          tourId: tourId.isNotEmpty ? tourId : 'Gamebase',
-          tourSlug: event.isNotEmpty ? event : 'Gamebase',
+          tourId: tourId.isNotEmpty ? tourId : canonicalEvent,
+          tourSlug: canonicalEvent,
           pgn: pgn,
           lastMoveTime: date,
           eco: (eco != null && eco.trim().isNotEmpty) ? eco.trim() : null,
@@ -1268,6 +1281,11 @@ Future<List<PlayerEventData>> _getTwicPlayerEvents(
   Ref ref,
   PlayerProfileKey playerKey,
 ) async {
+  final games = await ref.watch(playerGamesDataKeyProvider(playerKey).future);
+  if (games.isNotEmpty) {
+    return _buildTwicPlayerEventsFromGames(games);
+  }
+
   final repo = ref.read(gamebaseRepositoryProvider);
   final playerId = await _resolveTwicPlayerId(ref, playerKey);
   if (playerId == null || playerId.isEmpty) return const [];
@@ -1299,6 +1317,74 @@ PlayerEventData playerEventDataFromGamebaseEvent(GamebaseEventSearchItem item) {
     avgElo: item.avgElo,
     maxElo: item.maxElo,
   );
+}
+
+List<PlayerEventData> _buildTwicPlayerEventsFromGames(
+  List<GamesTourModel> games,
+) {
+  final byKey = <String, List<GamesTourModel>>{};
+  for (final game in games) {
+    final key = twicCanonicalEventKeyForGame(game);
+    if (key.isEmpty) continue;
+    byKey.putIfAbsent(key, () => <GamesTourModel>[]).add(game);
+  }
+
+  final events = <PlayerEventData>[];
+  for (final entry in byKey.entries) {
+    final eventGames = entry.value;
+    eventGames.sort((a, b) {
+      final aDate = a.lastMoveTime ?? DateTime(1900);
+      final bDate = b.lastMoveTime ?? DateTime(1900);
+      return aDate.compareTo(bDate);
+    });
+
+    final first = eventGames.first;
+    final title = preferredTwicEventTitle(
+      tourSlug: first.tourSlug,
+      tourId: first.tourId,
+      fallback: 'Gamebase',
+    );
+    final ratings = <int>[];
+    for (final game in eventGames) {
+      if (game.whitePlayer.rating > 0) ratings.add(game.whitePlayer.rating);
+      if (game.blackPlayer.rating > 0) ratings.add(game.blackPlayer.rating);
+    }
+    final avgElo = ratings.isEmpty
+        ? null
+        : ratings.reduce((a, b) => a + b) ~/ ratings.length;
+    final maxElo = ratings.isEmpty
+        ? null
+        : ratings.reduce((a, b) => a > b ? a : b);
+
+    events.add(
+      PlayerEventData(
+        tourId: title,
+        tourName: title,
+        tourSlug: title,
+        gamesPlayed: eventGames.length,
+        startDate: eventGames.first.lastMoveTime,
+        endDate: eventGames.last.lastMoveTime,
+        site: _siteFromPgn(first.pgn),
+        dominantTimeControl: first.timeControl,
+        avgElo: avgElo,
+        maxElo: maxElo,
+      ),
+    );
+  }
+
+  events.sort((a, b) {
+    final aDate = a.endDate ?? a.startDate ?? DateTime(1900);
+    final bDate = b.endDate ?? b.startDate ?? DateTime(1900);
+    return bDate.compareTo(aDate);
+  });
+  return events;
+}
+
+String? _siteFromPgn(String? pgn) {
+  if (pgn == null) return null;
+  final match = RegExp(r'^\[Site\s+"(.*)"\]$', multiLine: true).firstMatch(pgn);
+  final site = match?.group(1)?.trim();
+  return site == null || site.isEmpty || site == '?' ? null : site;
 }
 
 String _formatEventTimeControl(String? raw) {

--- a/lib/screens/player_profile/tabs/player_events_tab.dart
+++ b/lib/screens/player_profile/tabs/player_events_tab.dart
@@ -120,6 +120,20 @@ class _PlayerEventsTabState extends ConsumerState<PlayerEventsTab>
     }
 
     final token = _loadToken;
+    if (reset) {
+      final derivedEvents = await ref.read(playerEventsKeyProvider(_playerKey).future);
+      if (!mounted || token != _loadToken) return;
+      if (derivedEvents.isNotEmpty) {
+        _twicEvents = derivedEvents;
+        _twicTotalEvents = derivedEvents.length;
+        _twicHasMore = false;
+        _twicIsLoading = false;
+        _twicIsLoadingMore = false;
+        setState(() {});
+        return;
+      }
+    }
+
     final repo = ref.read(gamebaseRepositoryProvider);
     final playerId = await ref.read(twicPlayerIdProvider(_playerKey).future);
     if (!mounted || token != _loadToken) return;

--- a/lib/screens/player_profile/utils/twic_event_identity.dart
+++ b/lib/screens/player_profile/utils/twic_event_identity.dart
@@ -1,0 +1,58 @@
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+
+final RegExp _roundTitlePattern = RegExp(
+  r'^\s*(?:round|rd|r)\s*\d+[A-Za-z]?(?:\.\d+)?\s*[:\-–—]',
+  caseSensitive: false,
+);
+
+/// Returns true for TWIC/Gamebase labels that describe a round or pairing,
+/// not the parent tournament/event.
+///
+/// These labels can arrive in PGN Event headers or player-events rows. They
+/// should never replace a canonical event title when one is available from the
+/// player-games list.
+bool isTwicRoundDisplayTitle(String? value) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) return false;
+  return _roundTitlePattern.hasMatch(text);
+}
+
+bool _isUsefulEventTitle(String? value) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) return false;
+  if (text == '?' || text == 'Gamebase' || text == 'library') return false;
+  return !isTwicRoundDisplayTitle(text);
+}
+
+/// Prefer the canonical event carried by the game list over a PGN/Event value
+/// that is only a round/pairing label (e.g. `Round 13: Yilmaz, Mustafa ...`).
+String preferredTwicEventTitle({
+  String? pgnEvent,
+  String? tourSlug,
+  String? tourId,
+  String fallback = 'Game Info',
+}) {
+  final pgn = pgnEvent?.trim();
+  final slug = tourSlug?.trim();
+  final id = tourId?.trim();
+
+  if (_isUsefulEventTitle(pgn)) return pgn!;
+  if (_isUsefulEventTitle(slug)) return slug!;
+  if (_isUsefulEventTitle(id)) return id!;
+  if (pgn != null && pgn.isNotEmpty && pgn != '?') return pgn;
+  if (slug != null && slug.isNotEmpty) return slug;
+  if (id != null && id.isNotEmpty) return id;
+  return fallback;
+}
+
+String twicCanonicalEventKeyForGame(GamesTourModel game) {
+  final title = preferredTwicEventTitle(
+    tourSlug: game.tourSlug,
+    tourId: game.tourId,
+    fallback: game.gameId,
+  );
+  return title
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^\p{L}\p{N}]+', unicode: true), ' ')
+      .trim();
+}

--- a/test/twic_event_identity_test.dart
+++ b/test/twic_event_identity_test.dart
@@ -1,0 +1,42 @@
+import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TWIC event identity', () {
+    test('detects round/pairing display labels', () {
+      expect(
+        isTwicRoundDisplayTitle('Round 13: Yilmaz, Mustafa - Gurel, Ediz'),
+        isTrue,
+      );
+      expect(isTwicRoundDisplayTitle('Rd 9 - Some Pairing'), isTrue);
+      expect(
+        isTwicRoundDisplayTitle(
+          "5. Chess 365 Training Camp Instructors' Chess Tournament",
+        ),
+        isFalse,
+      );
+    });
+
+    test('prefers canonical event when PGN Event is only a round label', () {
+      expect(
+        preferredTwicEventTitle(
+          pgnEvent: 'Round 13: Yilmaz, Mustafa - Gurel, Ediz',
+          tourSlug: "5. Chess 365 Training Camp Instructors' Chess Tournament",
+          tourId: 'twic-event-id',
+        ),
+        "5. Chess 365 Training Camp Instructors' Chess Tournament",
+      );
+    });
+
+    test('keeps real PGN event title when it is not a round label', () {
+      expect(
+        preferredTwicEventTitle(
+          pgnEvent: 'Chicago Open 2026',
+          tourSlug: 'fallback-event',
+          tourId: 'fallback-id',
+        ),
+        'Chicago Open 2026',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary\n- prefer canonical TWIC event names from player-game rows when PGN Event is only a round/pairing label\n- build TWIC player Events tab from canonical game grouping to avoid showing each round as a separate event\n- add TWIC event identity helper tests\n\n## Test plan\n- flutter test test/twic_event_identity_test.dart\n- flutter analyze lib/screens/player_profile/utils/twic_event_identity.dart lib/screens/player_profile/provider/player_profile_provider.dart lib/screens/player_profile/tabs/player_events_tab.dart test/twic_event_identity_test.dart\n\n## QA\n- Search player -> select TWIC -> open games list -> open board -> tap i; title should be parent event, not Round 13/pairing label\n- Player statistics Events tab for TWIC should group games by parent event instead of one card per round\n