### PR TITLE
Fix phone stale live round ordering

### DIFF
--- a/lib/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart
+++ b/lib/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart
@@ -4,6 +4,30 @@ import 'package:chessever2/utils/time_utils.dart';
 
 enum RoundStatus { completed, ongoing, live, upcoming }
 
+Duration liveRoundFreshnessWindowForTimeControl(String? timeControl) {
+  final normalized = (timeControl ?? '').trim().toLowerCase();
+  if (normalized.contains('blitz')) {
+    return const Duration(minutes: 10);
+  }
+  if (normalized.contains('rapid')) {
+    return const Duration(minutes: 20);
+  }
+  return const Duration(minutes: 120);
+}
+
+bool isFreshLiveRoundActivity({
+  required DateTime? activityAt,
+  required DateTime now,
+  required String? timeControl,
+}) {
+  if (activityAt == null) {
+    return false;
+  }
+  return !now.isAfter(
+    activityAt.add(liveRoundFreshnessWindowForTimeControl(timeControl)),
+  );
+}
+
 class GamesAppBarViewModel {
   const GamesAppBarViewModel({
     required this.gamesAppBarModels,
@@ -29,7 +53,13 @@ class GamesAppBarModel extends Equatable {
   final DateTime? startsAt;
   final RoundStatus roundStatus;
 
-  factory GamesAppBarModel.fromRound(Round round, List<String> liveRound) {
+  factory GamesAppBarModel.fromRound(
+    Round round,
+    List<String> liveRound, {
+    DateTime? latestMoveTime,
+    String? timeControl,
+    DateTime? now,
+  }) {
     final utcStart = round.startsAt;
     final startsAt = TimeUtils.toLocal(utcStart);
 
@@ -41,6 +71,9 @@ class GamesAppBarModel extends Equatable {
         currentId: round.id,
         startsAt: startsAt,
         liveRound: liveRound,
+        latestMoveTime: latestMoveTime,
+        timeControl: timeControl,
+        now: now,
       ),
     );
   }
@@ -49,16 +82,35 @@ class GamesAppBarModel extends Equatable {
     required DateTime? startsAt,
     required String currentId,
     required List<String> liveRound,
+    DateTime? latestMoveTime,
+    String? timeControl,
+    DateTime? now,
   }) {
-    final now = DateTime.now();
+    final effectiveNow = now ?? DateTime.now();
 
     if (startsAt == null) return RoundStatus.upcoming;
 
-    if (liveRound.isNotEmpty && liveRound.contains(currentId)) {
+    final freshMoveActivity =
+        latestMoveTime != null &&
+        isFreshLiveRoundActivity(
+          activityAt: latestMoveTime,
+          now: effectiveNow,
+          timeControl: timeControl,
+        );
+    final freshBackendLiveSignal =
+        liveRound.isNotEmpty &&
+        liveRound.contains(currentId) &&
+        isFreshLiveRoundActivity(
+          activityAt: latestMoveTime ?? startsAt,
+          now: effectiveNow,
+          timeControl: timeControl,
+        );
+    if (freshMoveActivity || freshBackendLiveSignal) {
       return RoundStatus.live;
     }
 
-    if (startsAt.isBefore(now) || startsAt.isAtSameMomentAs(now)) {
+    if (startsAt.isBefore(effectiveNow) ||
+        startsAt.isAtSameMomentAs(effectiveNow)) {
       // Day-boundary fix: a round that started at 23:50 must not flip to
       // `completed` at local midnight while still in progress. Use a rolling
       // 24h window instead of same-calendar-day. Backend `liveRound`
@@ -68,7 +120,7 @@ class GamesAppBarModel extends Equatable {
       // a plausible play window for any time control.
       // See docs/superpowers/specs/2026-05-29-realtime-live-games-implementation-plan.md
       // change #4.
-      final hoursSinceStart = now.difference(startsAt).inHours;
+      final hoursSinceStart = effectiveNow.difference(startsAt).inHours;
       if (hoursSinceStart < 24) {
         return RoundStatus.ongoing;
       } else {

--- a/lib/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart
@@ -1295,10 +1295,7 @@ class _GamesAppBarNotifier
         return;
       }
 
-      final updated = _refreshRoundStatuses(
-        current.gamesAppBarModels,
-        games,
-      );
+      final updated = _refreshRoundStatuses(current.gamesAppBarModels, games);
       _sortRounds(updated);
 
       await _applySelectionFrom(updated, tourId!);
@@ -1324,9 +1321,10 @@ class _GamesAppBarNotifier
     final current = state.valueOrNull;
     if (current == null) return;
 
-    final games = tourId == null
-        ? null
-        : ref.read(gamesTourProvider(tourId!)).valueOrNull;
+    final games =
+        tourId == null
+            ? null
+            : ref.read(gamesTourProvider(tourId!)).valueOrNull;
     final updated = _refreshRoundStatuses(current.gamesAppBarModels, games);
 
     _sortRounds(updated);

--- a/lib/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart
@@ -673,9 +673,19 @@ class _GamesAppBarNotifier
           ),
         );
 
+      final games = ref.read(gamesTourProvider(tourId!)).valueOrNull;
+      final latestMoveByRound = _latestMoveTimeByRound(games);
+      final timeControlByRound = _timeControlByRound(games);
       final models =
           rounds
-              .map((r) => GamesAppBarModel.fromRound(r, _liveRounds))
+              .map(
+                (r) => GamesAppBarModel.fromRound(
+                  r,
+                  _liveRounds,
+                  latestMoveTime: latestMoveByRound[r.id],
+                  timeControl: timeControlByRound[r.id],
+                ),
+              )
               .toList();
 
       // Check if this is a knockout tournament and group sub-rounds
@@ -758,9 +768,19 @@ class _GamesAppBarNotifier
           // Get rounds for this specific tour first
           final repo = ref.read(roundRepositoryProvider);
           final stageRounds = await repo.getRoundsByTourId(tour.id);
+          final stageGames = ref.read(gamesTourProvider(tour.id)).valueOrNull;
+          final latestMoveByRound = _latestMoveTimeByRound(stageGames);
+          final timeControlByRound = _timeControlByRound(stageGames);
           final stageRoundModels =
               stageRounds
-                  .map((r) => GamesAppBarModel.fromRound(r, _liveRounds))
+                  .map(
+                    (r) => GamesAppBarModel.fromRound(
+                      r,
+                      _liveRounds,
+                      latestMoveTime: latestMoveByRound[r.id],
+                      timeControl: timeControlByRound[r.id],
+                    ),
+                  )
                   .toList();
 
           if (stageRoundModels.isEmpty) {
@@ -1229,6 +1249,31 @@ class _GamesAppBarNotifier
       ..addAll(sorted);
   }
 
+  List<GamesAppBarModel> _refreshRoundStatuses(
+    List<GamesAppBarModel> models,
+    List<Games>? games,
+  ) {
+    final latestMoveByRound = _latestMoveTimeByRound(games);
+    final timeControlByRound = _timeControlByRound(games);
+
+    return models
+        .map(
+          (m) => GamesAppBarModel(
+            id: m.id,
+            name: m.name,
+            startsAt: m.startsAt,
+            roundStatus: GamesAppBarModel.status(
+              currentId: m.id,
+              startsAt: m.startsAt,
+              liveRound: _liveRounds,
+              latestMoveTime: latestMoveByRound[m.id],
+              timeControl: timeControlByRound[m.id],
+            ),
+          ),
+        )
+        .toList();
+  }
+
   void _refreshSelectionAfterGamesChange(List<Games> games) {
     if (_selectionRefreshScheduled) return;
     _selectionRefreshScheduled = true;
@@ -1250,10 +1295,13 @@ class _GamesAppBarNotifier
         return;
       }
 
-      await _applySelectionFrom(
-        List<GamesAppBarModel>.from(current.gamesAppBarModels),
-        tourId!,
+      final updated = _refreshRoundStatuses(
+        current.gamesAppBarModels,
+        games,
       );
+      _sortRounds(updated);
+
+      await _applySelectionFrom(updated, tourId!);
     });
   }
 
@@ -1276,21 +1324,10 @@ class _GamesAppBarNotifier
     final current = state.valueOrNull;
     if (current == null) return;
 
-    final updated =
-        current.gamesAppBarModels
-            .map(
-              (m) => GamesAppBarModel(
-                id: m.id,
-                name: m.name,
-                startsAt: m.startsAt,
-                roundStatus: GamesAppBarModel.status(
-                  currentId: m.id,
-                  startsAt: m.startsAt,
-                  liveRound: _liveRounds,
-                ),
-              ),
-            )
-            .toList();
+    final games = tourId == null
+        ? null
+        : ref.read(gamesTourProvider(tourId!)).valueOrNull;
+    final updated = _refreshRoundStatuses(current.gamesAppBarModels, games);
 
     _sortRounds(updated);
 
@@ -1314,24 +1351,6 @@ class _GamesAppBarNotifier
       _scrollToRound(stickyId);
       return;
     }
-    final currentSelected = current.selectedId;
-    final currentStillValid =
-        currentSelected.isNotEmpty &&
-        updated.any((m) => m.id == currentSelected) &&
-        _hasGames(currentSelected, counts);
-
-    if (currentStillValid) {
-      state = AsyncValue.data(
-        GamesAppBarViewModel(
-          gamesAppBarModels: updated,
-          selectedId: currentSelected,
-          userSelectedId: false,
-        ),
-      );
-      _scrollToRound(currentSelected);
-      return;
-    }
-
     final autoModel = _selectAutoRound(updated, counts);
     final nextSelected = autoModel?.id ?? '';
 
@@ -1567,15 +1586,52 @@ int? _parseGameNumber(String? value) {
   return match != null ? int.tryParse(match.group(1)!) : null;
 }
 
+Map<String, DateTime> _latestMoveTimeByRound(List<Games>? games) {
+  final latestByRound = <String, DateTime>{};
+  for (final game in games ?? const <Games>[]) {
+    final lastMoveTime = game.lastMoveTime;
+    if (lastMoveTime == null) continue;
+
+    final current = latestByRound[game.roundId];
+    if (current == null || lastMoveTime.isAfter(current)) {
+      latestByRound[game.roundId] = lastMoveTime;
+    }
+  }
+  return latestByRound;
+}
+
+Map<String, String> _timeControlByRound(List<Games>? games) {
+  final controls = <String, String>{};
+  for (final game in games ?? const <Games>[]) {
+    final timeControl = game.timeControl?.trim();
+    if (timeControl == null || timeControl.isEmpty) continue;
+    controls.putIfAbsent(game.roundId, () => timeControl);
+  }
+  return controls;
+}
+
 String _roundCountSignature(List<Games> games) {
   if (games.isEmpty) return '';
 
   final counts = <String, int>{};
+  final latestMoveByRound = <String, DateTime>{};
   for (final game in games) {
     counts.update(game.roundId, (value) => value + 1, ifAbsent: () => 1);
+
+    final lastMoveTime = game.lastMoveTime;
+    if (lastMoveTime == null) continue;
+    final current = latestMoveByRound[game.roundId];
+    if (current == null || lastMoveTime.isAfter(current)) {
+      latestMoveByRound[game.roundId] = lastMoveTime;
+    }
   }
 
   final entries =
       counts.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
-  return entries.map((entry) => '${entry.key}:${entry.value}').join('|');
+  return entries
+      .map(
+        (entry) =>
+            '${entry.key}:${entry.value}:${latestMoveByRound[entry.key]?.toIso8601String() ?? ''}',
+      )
+      .join('|');
 }

--- a/test/tour_detail_round_ordering_test.dart
+++ b/test/tour_detail_round_ordering_test.dart
@@ -20,6 +20,68 @@ List<String> _ids(List<GamesAppBarModel> rounds) =>
     rounds.map((round) => round.id).toList(growable: false);
 
 void main() {
+  group('GamesAppBarModel.status live freshness', () {
+    test('does not keep a stale blitz live-round signal pinned live', () {
+      final now = DateTime(2026, 5, 30, 19, 39);
+      final status = GamesAppBarModel.status(
+        currentId: 'round-2',
+        startsAt: now.subtract(const Duration(hours: 1, minutes: 30)),
+        liveRound: const ['round-2'],
+        latestMoveTime: now.subtract(const Duration(minutes: 11)),
+        timeControl: 'blitz',
+        now: now,
+      );
+
+      expect(status, RoundStatus.ongoing);
+    });
+
+    test(
+      'treats recent move activity as live even if backend live ids lag',
+      () {
+        final now = DateTime(2026, 5, 30, 19, 39);
+        final status = GamesAppBarModel.status(
+          currentId: 'round-9',
+          startsAt: now.subtract(const Duration(minutes: 3)),
+          liveRound: const ['round-2'],
+          latestMoveTime: now.subtract(const Duration(minutes: 2)),
+          timeControl: 'blitz',
+          now: now,
+        );
+
+        expect(status, RoundStatus.live);
+      },
+    );
+
+    test('uses longer freshness windows for rapid and standard events', () {
+      final now = DateTime(2026, 5, 30, 19, 39);
+
+      expect(
+        liveRoundFreshnessWindowForTimeControl('rapid'),
+        const Duration(minutes: 20),
+      );
+      expect(
+        liveRoundFreshnessWindowForTimeControl('standard'),
+        const Duration(minutes: 120),
+      );
+      expect(
+        isFreshLiveRoundActivity(
+          activityAt: now.subtract(const Duration(minutes: 19)),
+          now: now,
+          timeControl: 'rapid',
+        ),
+        isTrue,
+      );
+      expect(
+        isFreshLiveRoundActivity(
+          activityAt: now.subtract(const Duration(minutes: 21)),
+          now: now,
+          timeControl: 'rapid',
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('sortRoundsForDisplay', () {
     test('keeps all-upcoming preconfigured rounds in ascending order', () {
       final now = DateTime(2026, 3, 29, 10);


### PR DESCRIPTION
## Summary
- Adds time-control-specific freshness checks for phone live-round status: blitz 10m, rapid 20m, standard/classical 120m.
- Treats recent move activity as the live signal even when backend `live_round_ids` is stale, so old rounds like Saturday Night Blitz Round 2 stop staying pinned above newer active rounds.
- Recomputes round status when game `last_move_time` changes and reselects the best auto round unless the user manually selected a round.

## Test Plan
- `flutter test test/tour_detail_round_ordering_test.dart`
- `dart format --set-exit-if-changed lib/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart lib/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart test/tour_detail_round_ordering_test.dart`
- `flutter analyze --no-pub lib/screens/tour_detail/games_tour/models/games_app_bar_view_model.dart test/tour_detail_round_ordering_test.dart`
- `flutter analyze --no-pub lib/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart` *(reports existing legacy `avoid_print`, unused helper, and empty-catch warnings; no new type errors from this change)*
- `git diff --check`

## QA
- Open a live/preplanned blitz event with a stale backend live round and newer move activity in a later round.
- Confirm the stale round no longer appears at the top unless it has move activity within 10 minutes.
- Confirm rapid uses a 20-minute freshness window and standard/classical uses a 120-minute window.

Requested reviewer: @devberkay