### PR TITLE
Fix TWIC player event titles (recover parent event from Site URL)

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -3085,9 +3085,7 @@ class _AppBarState extends ConsumerState<_AppBar> {
             break;
           case AutoSaveStatus.idle:
             diskIcon = Icon(
-              isEditableLibraryGame
-                  ? Icons.edit_outlined
-                  : Icons.save_outlined,
+              isEditableLibraryGame ? Icons.edit_outlined : Icons.save_outlined,
               color: context.colors.textPrimary,
               size: 20.sp,
             );
@@ -6851,7 +6849,10 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
       _debugLatest = this;
       if (!_debugExtRegistered) {
         _debugExtRegistered = true;
-        developer.registerExtension('ext.flutter.likeBoard', (method, params) async {
+        developer.registerExtension('ext.flutter.likeBoard', (
+          method,
+          params,
+        ) async {
           _debugLatest?._handleDoubleTapLike();
           return developer.ServiceExtensionResponse.result('{"ok":true}');
         });
@@ -7031,13 +7032,14 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
       // Debug-only long-press alias for the same like flow. Lets Marionette
       // and other agent-driven test harnesses trigger the chain without
       // having to fight the chessground tap-to-move gesture arena.
-      onLongPressStart: kDebugMode
-          ? (details) {
-              _lastTapPosition = details.localPosition;
-              _lastTapGlobalPosition = details.globalPosition;
-              _handleDoubleTapLike();
-            }
-          : null,
+      onLongPressStart:
+          kDebugMode
+              ? (details) {
+                _lastTapPosition = details.localPosition;
+                _lastTapGlobalPosition = details.globalPosition;
+                _handleDoubleTapLike();
+              }
+              : null,
       child: Stack(
         clipBehavior: Clip.none,
         children: [
@@ -7066,11 +7068,12 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
           // the flip), ignores pointers, and removes itself when each burst ends.
           Positioned.fill(
             child: Builder(
-              builder: (context) => HeartBurstLayer(
-                controller: _burstController,
-                color: context.colors.danger,
-                reduceMotion: MediaQuery.disableAnimationsOf(context),
-              ),
+              builder:
+                  (context) => HeartBurstLayer(
+                    controller: _burstController,
+                    color: context.colors.danger,
+                    reduceMotion: MediaQuery.disableAnimationsOf(context),
+                  ),
             ),
           ),
         ],
@@ -7095,16 +7098,19 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
     debugPrint('[HeartFlight] like-trigger fired source=${game.source.name}');
     if (!_isLikeableSource(game.source)) return;
     final wasLiked =
-        ref.read(likedGamesProvider).valueOrNull?.any(
-              (a) => a.sourceGameId == game.gameId,
-            ) ??
-            false;
-    final tapLocal = _lastTapPosition == Offset.zero
-        ? Offset(widget.size / 2, widget.size / 2)
-        : _lastTapPosition;
-    final tapGlobal = _lastTapGlobalPosition == Offset.zero
-        ? tapLocal
-        : _lastTapGlobalPosition;
+        ref
+            .read(likedGamesProvider)
+            .valueOrNull
+            ?.any((a) => a.sourceGameId == game.gameId) ??
+        false;
+    final tapLocal =
+        _lastTapPosition == Offset.zero
+            ? Offset(widget.size / 2, widget.size / 2)
+            : _lastTapPosition;
+    final tapGlobal =
+        _lastTapGlobalPosition == Offset.zero
+            ? tapLocal
+            : _lastTapGlobalPosition;
 
     final anchor = ref.read(likeFlightAnchorProvider);
 
@@ -7148,26 +7154,27 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
     final startSize = widget.size * 0.55;
     final endSize = math.min(target.width, target.height);
     final entry = OverlayEntry(
-      builder: (_) => FlyingHeart(
-        from: from,
-        to: target.center,
-        color: flightColor,
-        startSize: startSize,
-        endSize: endSize,
-        duration: const Duration(milliseconds: 470),
-        onArrived: () {
-          _flyingHeartEntry?.remove();
-          _flyingHeartEntry = null;
-          if (!mounted) return;
-          anchor.land();
-          // Tiny "click into place" haptic at the moment the heart docks.
-          HapticFeedback.selectionClick();
-          Future.delayed(const Duration(milliseconds: 540), () {
-            if (!mounted) return;
-            anchor.reset();
-          });
-        },
-      ),
+      builder:
+          (_) => FlyingHeart(
+            from: from,
+            to: target.center,
+            color: flightColor,
+            startSize: startSize,
+            endSize: endSize,
+            duration: const Duration(milliseconds: 470),
+            onArrived: () {
+              _flyingHeartEntry?.remove();
+              _flyingHeartEntry = null;
+              if (!mounted) return;
+              anchor.land();
+              // Tiny "click into place" haptic at the moment the heart docks.
+              HapticFeedback.selectionClick();
+              Future.delayed(const Duration(milliseconds: 540), () {
+                if (!mounted) return;
+                anchor.reset();
+              });
+            },
+          ),
     );
     _flyingHeartEntry = entry;
     overlay.insert(entry);
@@ -14389,6 +14396,7 @@ class _EventInfoSheet extends ConsumerWidget {
       pgnEvent: pgnEvent,
       tourSlug: game.tourSlug,
       tourId: game.tourId,
+      site: headers['Site'],
       fallback: 'Game Info',
     );
 

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -42,6 +42,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_p
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/screens/chessboard/widgets/player_first_row_detail_widget.dart';
+import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/repository/supabase/game/game_repository.dart';
@@ -14489,23 +14490,16 @@ class _EventInfoSheet extends ConsumerWidget {
   ) {
     final headers = _parseHeadersFromPgn();
 
-    // Determine event name: PGN [Event] > game.tourSlug > game.tourId (if not UUID)
-    String eventName = 'Game Info';
-    if (headers['Event'] != null &&
-        headers['Event']!.isNotEmpty &&
-        headers['Event'] != '?') {
-      eventName = headers['Event']!;
-    } else if (game.tourSlug != null && game.tourSlug!.isNotEmpty) {
-      eventName = StringUtils.slugToTitle(game.tourSlug!);
-    } else if (game.tourId.isNotEmpty) {
-      final isUuid = RegExp(
-        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-        caseSensitive: false,
-      ).hasMatch(game.tourId);
-      if (!isUuid) {
-        eventName = game.tourId;
-      }
-    }
+    // Determine event name. In TWIC player-profile routes, raw PGN Event can
+    // be a per-round/pairing label; prefer the canonical event from the game
+    // list when that happens.
+    final pgnEvent = headers['Event'];
+    final eventName = preferredTwicEventTitle(
+      pgnEvent: pgnEvent,
+      tourSlug: game.tourSlug,
+      tourId: game.tourId,
+      fallback: 'Game Info',
+    );
 
     return ListView(
       controller: scrollController,

--- a/lib/screens/player_profile/provider/player_profile_provider.dart
+++ b/lib/screens/player_profile/provider/player_profile_provider.dart
@@ -11,6 +11,7 @@ import 'package:dio/dio.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/player_profile/player_profile_data_source.dart';
+import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/utils/chess_title_utils.dart';
 import 'package:chessever2/utils/time_utils.dart';
@@ -627,6 +628,12 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
         final opening = row['opening']?.toString();
         final variation = row['variation']?.toString();
         final event = (row['event']?.toString() ?? 'Gamebase').trim();
+        final canonicalEvent = preferredTwicEventTitle(
+          pgnEvent: event,
+          tourSlug: row['tourSlug']?.toString(),
+          tourId: row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          fallback: event.isNotEmpty ? event : 'Gamebase',
+        );
 
         final whiteName = (row['white']?.toString() ?? 'White').trim();
         final blackName = (row['black']?.toString() ?? 'Black').trim();
@@ -635,7 +642,7 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
           whiteName: whiteName,
           blackName: blackName,
           result: result,
-          event: event.isNotEmpty ? event : 'Gamebase',
+          event: canonicalEvent,
           date: date,
           eco: eco,
           opening: opening,
@@ -667,7 +674,7 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
         final tourId =
             (row['tour_id']?.toString() ??
                     row['tournament_id']?.toString() ??
-                    event)
+                    canonicalEvent)
                 .trim();
 
         return GamesTourModel(
@@ -685,8 +692,8 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
               (eco != null && eco.trim().isNotEmpty)
                   ? eco.trim()
                   : (timeControl ?? ''),
-          tourId: tourId.isNotEmpty ? tourId : 'Gamebase',
-          tourSlug: event.isNotEmpty ? event : 'Gamebase',
+          tourId: tourId.isNotEmpty ? tourId : canonicalEvent,
+          tourSlug: canonicalEvent,
           pgn: pgn,
           lastMoveTime: date,
           eco: (eco != null && eco.trim().isNotEmpty) ? eco.trim() : null,
@@ -817,6 +824,12 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
                 .trim();
 
         final event = (row['event']?.toString() ?? 'Gamebase').trim();
+        final canonicalEvent = preferredTwicEventTitle(
+          pgnEvent: event,
+          tourSlug: row['tourSlug']?.toString(),
+          tourId: row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          fallback: event.isNotEmpty ? event : 'Gamebase',
+        );
         final site = row['site']?.toString();
         final eco = row['eco']?.toString();
         final opening = row['opening']?.toString();
@@ -826,7 +839,7 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
           whiteName: whiteName,
           blackName: blackName,
           result: result,
-          event: event.isNotEmpty ? event : 'Gamebase',
+          event: canonicalEvent,
           site: site,
           date: date,
           eco: eco,
@@ -859,7 +872,7 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
         final tourId =
             (row['tour_id']?.toString() ??
                     row['tournament_id']?.toString() ??
-                    event)
+                    canonicalEvent)
                 .trim();
 
         return GamesTourModel(
@@ -877,8 +890,8 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
               (eco != null && eco.trim().isNotEmpty)
                   ? eco.trim()
                   : (timeControl ?? ''),
-          tourId: tourId.isNotEmpty ? tourId : 'Gamebase',
-          tourSlug: event.isNotEmpty ? event : 'Gamebase',
+          tourId: tourId.isNotEmpty ? tourId : canonicalEvent,
+          tourSlug: canonicalEvent,
           pgn: pgn,
           lastMoveTime: date,
           eco: (eco != null && eco.trim().isNotEmpty) ? eco.trim() : null,
@@ -1268,6 +1281,11 @@ Future<List<PlayerEventData>> _getTwicPlayerEvents(
   Ref ref,
   PlayerProfileKey playerKey,
 ) async {
+  final games = await ref.watch(playerGamesDataKeyProvider(playerKey).future);
+  if (games.isNotEmpty) {
+    return _buildTwicPlayerEventsFromGames(games);
+  }
+
   final repo = ref.read(gamebaseRepositoryProvider);
   final playerId = await _resolveTwicPlayerId(ref, playerKey);
   if (playerId == null || playerId.isEmpty) return const [];
@@ -1299,6 +1317,74 @@ PlayerEventData playerEventDataFromGamebaseEvent(GamebaseEventSearchItem item) {
     avgElo: item.avgElo,
     maxElo: item.maxElo,
   );
+}
+
+List<PlayerEventData> _buildTwicPlayerEventsFromGames(
+  List<GamesTourModel> games,
+) {
+  final byKey = <String, List<GamesTourModel>>{};
+  for (final game in games) {
+    final key = twicCanonicalEventKeyForGame(game);
+    if (key.isEmpty) continue;
+    byKey.putIfAbsent(key, () => <GamesTourModel>[]).add(game);
+  }
+
+  final events = <PlayerEventData>[];
+  for (final entry in byKey.entries) {
+    final eventGames = entry.value;
+    eventGames.sort((a, b) {
+      final aDate = a.lastMoveTime ?? DateTime(1900);
+      final bDate = b.lastMoveTime ?? DateTime(1900);
+      return aDate.compareTo(bDate);
+    });
+
+    final first = eventGames.first;
+    final title = preferredTwicEventTitle(
+      tourSlug: first.tourSlug,
+      tourId: first.tourId,
+      fallback: 'Gamebase',
+    );
+    final ratings = <int>[];
+    for (final game in eventGames) {
+      if (game.whitePlayer.rating > 0) ratings.add(game.whitePlayer.rating);
+      if (game.blackPlayer.rating > 0) ratings.add(game.blackPlayer.rating);
+    }
+    final avgElo = ratings.isEmpty
+        ? null
+        : ratings.reduce((a, b) => a + b) ~/ ratings.length;
+    final maxElo = ratings.isEmpty
+        ? null
+        : ratings.reduce((a, b) => a > b ? a : b);
+
+    events.add(
+      PlayerEventData(
+        tourId: title,
+        tourName: title,
+        tourSlug: title,
+        gamesPlayed: eventGames.length,
+        startDate: eventGames.first.lastMoveTime,
+        endDate: eventGames.last.lastMoveTime,
+        site: _siteFromPgn(first.pgn),
+        dominantTimeControl: first.timeControl,
+        avgElo: avgElo,
+        maxElo: maxElo,
+      ),
+    );
+  }
+
+  events.sort((a, b) {
+    final aDate = a.endDate ?? a.startDate ?? DateTime(1900);
+    final bDate = b.endDate ?? b.startDate ?? DateTime(1900);
+    return bDate.compareTo(aDate);
+  });
+  return events;
+}
+
+String? _siteFromPgn(String? pgn) {
+  if (pgn == null) return null;
+  final match = RegExp(r'^\[Site\s+"(.*)"\]$', multiLine: true).firstMatch(pgn);
+  final site = match?.group(1)?.trim();
+  return site == null || site.isEmpty || site == '?' ? null : site;
 }
 
 String _formatEventTimeControl(String? raw) {

--- a/lib/screens/player_profile/provider/player_profile_provider.dart
+++ b/lib/screens/player_profile/provider/player_profile_provider.dart
@@ -631,7 +631,9 @@ Future<List<GamesTourModel>> _getTwicGamesViaPlayerEndpoint(
         final canonicalEvent = preferredTwicEventTitle(
           pgnEvent: event,
           tourSlug: row['tourSlug']?.toString(),
-          tourId: row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          tourId:
+              row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          site: row['site']?.toString(),
           fallback: event.isNotEmpty ? event : 'Gamebase',
         );
 
@@ -824,13 +826,15 @@ Future<List<GamesTourModel>> _getTwicGamesFromGamebase(
                 .trim();
 
         final event = (row['event']?.toString() ?? 'Gamebase').trim();
+        final site = row['site']?.toString();
         final canonicalEvent = preferredTwicEventTitle(
           pgnEvent: event,
           tourSlug: row['tourSlug']?.toString(),
-          tourId: row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          tourId:
+              row['tour_id']?.toString() ?? row['tournament_id']?.toString(),
+          site: site,
           fallback: event.isNotEmpty ? event : 'Gamebase',
         );
-        final site = row['site']?.toString();
         final eco = row['eco']?.toString();
         final opening = row['opening']?.toString();
         final variation = row['variation']?.toString();
@@ -1349,12 +1353,12 @@ List<PlayerEventData> _buildTwicPlayerEventsFromGames(
       if (game.whitePlayer.rating > 0) ratings.add(game.whitePlayer.rating);
       if (game.blackPlayer.rating > 0) ratings.add(game.blackPlayer.rating);
     }
-    final avgElo = ratings.isEmpty
-        ? null
-        : ratings.reduce((a, b) => a + b) ~/ ratings.length;
-    final maxElo = ratings.isEmpty
-        ? null
-        : ratings.reduce((a, b) => a > b ? a : b);
+    final avgElo =
+        ratings.isEmpty
+            ? null
+            : ratings.reduce((a, b) => a + b) ~/ ratings.length;
+    final maxElo =
+        ratings.isEmpty ? null : ratings.reduce((a, b) => a > b ? a : b);
 
     events.add(
       PlayerEventData(

--- a/lib/screens/player_profile/tabs/player_events_tab.dart
+++ b/lib/screens/player_profile/tabs/player_events_tab.dart
@@ -120,6 +120,20 @@ class _PlayerEventsTabState extends ConsumerState<PlayerEventsTab>
     }
 
     final token = _loadToken;
+    if (reset) {
+      final derivedEvents = await ref.read(playerEventsKeyProvider(_playerKey).future);
+      if (!mounted || token != _loadToken) return;
+      if (derivedEvents.isNotEmpty) {
+        _twicEvents = derivedEvents;
+        _twicTotalEvents = derivedEvents.length;
+        _twicHasMore = false;
+        _twicIsLoading = false;
+        _twicIsLoadingMore = false;
+        setState(() {});
+        return;
+      }
+    }
+
     final repo = ref.read(gamebaseRepositoryProvider);
     final playerId = await ref.read(twicPlayerIdProvider(_playerKey).future);
     if (!mounted || token != _loadToken) return;

--- a/lib/screens/player_profile/utils/twic_event_identity.dart
+++ b/lib/screens/player_profile/utils/twic_event_identity.dart
@@ -1,0 +1,58 @@
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+
+final RegExp _roundTitlePattern = RegExp(
+  r'^\s*(?:round|rd|r)\s*\d+[A-Za-z]?(?:\.\d+)?\s*[:\-–—]',
+  caseSensitive: false,
+);
+
+/// Returns true for TWIC/Gamebase labels that describe a round or pairing,
+/// not the parent tournament/event.
+///
+/// These labels can arrive in PGN Event headers or player-events rows. They
+/// should never replace a canonical event title when one is available from the
+/// player-games list.
+bool isTwicRoundDisplayTitle(String? value) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) return false;
+  return _roundTitlePattern.hasMatch(text);
+}
+
+bool _isUsefulEventTitle(String? value) {
+  final text = value?.trim();
+  if (text == null || text.isEmpty) return false;
+  if (text == '?' || text == 'Gamebase' || text == 'library') return false;
+  return !isTwicRoundDisplayTitle(text);
+}
+
+/// Prefer the canonical event carried by the game list over a PGN/Event value
+/// that is only a round/pairing label (e.g. `Round 13: Yilmaz, Mustafa ...`).
+String preferredTwicEventTitle({
+  String? pgnEvent,
+  String? tourSlug,
+  String? tourId,
+  String fallback = 'Game Info',
+}) {
+  final pgn = pgnEvent?.trim();
+  final slug = tourSlug?.trim();
+  final id = tourId?.trim();
+
+  if (_isUsefulEventTitle(pgn)) return pgn!;
+  if (_isUsefulEventTitle(slug)) return slug!;
+  if (_isUsefulEventTitle(id)) return id!;
+  if (pgn != null && pgn.isNotEmpty && pgn != '?') return pgn;
+  if (slug != null && slug.isNotEmpty) return slug;
+  if (id != null && id.isNotEmpty) return id;
+  return fallback;
+}
+
+String twicCanonicalEventKeyForGame(GamesTourModel game) {
+  final title = preferredTwicEventTitle(
+    tourSlug: game.tourSlug,
+    tourId: game.tourId,
+    fallback: game.gameId,
+  );
+  return title
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^\p{L}\p{N}]+', unicode: true), ' ')
+      .trim();
+}

--- a/lib/screens/player_profile/utils/twic_event_identity.dart
+++ b/lib/screens/player_profile/utils/twic_event_identity.dart
@@ -1,9 +1,34 @@
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/utils/string_utils.dart';
 
 final RegExp _roundTitlePattern = RegExp(
   r'^\s*(?:round|rd|r)\s*\d+[A-Za-z]?(?:\.\d+)?\s*[:\-–—]',
   caseSensitive: false,
 );
+
+/// Matches the parent broadcast slug in a Lichess broadcast `Site` URL, e.g.
+/// `https://lichess.org/broadcast/<parent-slug>/round-7/<roundId>/<chapterId>`
+/// -> `<parent-slug>`. This is the only place the canonical parent-event name
+/// survives for TWIC/broadcast games whose PGN Event is a per-round pairing
+/// label; the gamebase rows carry no tour_id/tournament_id/tourSlug field.
+final RegExp _lichessBroadcastSitePattern = RegExp(
+  r'lichess\.org/broadcast/([^/?#]+)',
+  caseSensitive: false,
+);
+
+/// Derives a canonical event title from a Lichess broadcast `Site` URL by
+/// title-casing the parent broadcast slug. Returns null when [site] is not a
+/// recognizable Lichess broadcast URL (e.g. `Chess.com`, `Oslo, NO`).
+String? eventTitleFromBroadcastSite(String? site) {
+  final value = site?.trim();
+  if (value == null || value.isEmpty) return null;
+  final slug = _lichessBroadcastSitePattern.firstMatch(value)?.group(1)?.trim();
+  if (slug == null || slug.isEmpty) return null;
+  // `--` slug separators become double spaces via slugToTitle; collapse them.
+  final title =
+      StringUtils.slugToTitle(slug).replaceAll(RegExp(r'\s+'), ' ').trim();
+  return title.isEmpty ? null : title;
+}
 
 /// Returns true for TWIC/Gamebase labels that describe a round or pairing,
 /// not the parent tournament/event.
@@ -30,6 +55,7 @@ String preferredTwicEventTitle({
   String? pgnEvent,
   String? tourSlug,
   String? tourId,
+  String? site,
   String fallback = 'Game Info',
 }) {
   final pgn = pgnEvent?.trim();
@@ -39,6 +65,12 @@ String preferredTwicEventTitle({
   if (_isUsefulEventTitle(pgn)) return pgn!;
   if (_isUsefulEventTitle(slug)) return slug!;
   if (_isUsefulEventTitle(id)) return id!;
+
+  // PGN Event / tour fields were only round/pairing labels. For TWIC broadcast
+  // games the canonical parent event survives solely in the Lichess `Site` URL.
+  final fromSite = eventTitleFromBroadcastSite(site);
+  if (fromSite != null) return fromSite;
+
   if (pgn != null && pgn.isNotEmpty && pgn != '?') return pgn;
   if (slug != null && slug.isNotEmpty) return slug;
   if (id != null && id.isNotEmpty) return id;

--- a/test/twic_event_identity_test.dart
+++ b/test/twic_event_identity_test.dart
@@ -1,0 +1,42 @@
+import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TWIC event identity', () {
+    test('detects round/pairing display labels', () {
+      expect(
+        isTwicRoundDisplayTitle('Round 13: Yilmaz, Mustafa - Gurel, Ediz'),
+        isTrue,
+      );
+      expect(isTwicRoundDisplayTitle('Rd 9 - Some Pairing'), isTrue);
+      expect(
+        isTwicRoundDisplayTitle(
+          "5. Chess 365 Training Camp Instructors' Chess Tournament",
+        ),
+        isFalse,
+      );
+    });
+
+    test('prefers canonical event when PGN Event is only a round label', () {
+      expect(
+        preferredTwicEventTitle(
+          pgnEvent: 'Round 13: Yilmaz, Mustafa - Gurel, Ediz',
+          tourSlug: "5. Chess 365 Training Camp Instructors' Chess Tournament",
+          tourId: 'twic-event-id',
+        ),
+        "5. Chess 365 Training Camp Instructors' Chess Tournament",
+      );
+    });
+
+    test('keeps real PGN event title when it is not a round label', () {
+      expect(
+        preferredTwicEventTitle(
+          pgnEvent: 'Chicago Open 2026',
+          tourSlug: 'fallback-event',
+          tourId: 'fallback-id',
+        ),
+        'Chicago Open 2026',
+      );
+    });
+  });
+}

--- a/test/twic_event_identity_test.dart
+++ b/test/twic_event_identity_test.dart
@@ -39,4 +39,47 @@ void main() {
       );
     });
   });
+
+  group('broadcast site URL -> parent event', () {
+    test('derives parent event from Lichess broadcast site slug', () {
+      expect(
+        eventTitleFromBroadcastSite(
+          'https://lichess.org/broadcast/5-satranc-365-egitim-kampi-ogrenciler-arasi-yildirim-satranc-turnuvasi/round-7/PoRD5Hrr/FpdAFxZU',
+        ),
+        '5 Satranc 365 Egitim Kampi Ogrenciler Arasi Yildirim Satranc Turnuvasi',
+      );
+    });
+
+    test('collapses -- separators in broadcast slug', () {
+      expect(
+        eventTitleFromBroadcastSite(
+          'https://lichess.org/broadcast/35th-drogheda-chess-congress--fox-major/round-3/xyDQsv9C/cwI8k8fj',
+        ),
+        '35th Drogheda Chess Congress Fox Major',
+      );
+    });
+
+    test('returns null for non-broadcast sites', () {
+      expect(eventTitleFromBroadcastSite('Chess.com'), isNull);
+      expect(eventTitleFromBroadcastSite('Oslo, NO'), isNull);
+      expect(eventTitleFromBroadcastSite(null), isNull);
+    });
+
+    // The decisive real-data case: gamebase player-games rows carry NO
+    // tour_id/tournament_id/tourSlug; the PGN Event is a round/pairing label
+    // and the parent event survives only in the Lichess `Site` URL.
+    test('recovers parent event from site when only a round label exists', () {
+      expect(
+        preferredTwicEventTitle(
+          pgnEvent: 'Round 7: Nazli, Sertan - Akal, Muhammed Furkan',
+          tourSlug: null,
+          tourId: null,
+          site:
+              'https://lichess.org/broadcast/5-satranc-365-egitim-kampi-ogrenciler-arasi-yildirim-satranc-turnuvasi/round-7/PoRD5Hrr/FpdAFxZU',
+          fallback: 'Gamebase',
+        ),
+        '5 Satranc 365 Egitim Kampi Ogrenciler Arasi Yildirim Satranc Turnuvasi',
+      );
+    });
+  });
 }


### PR DESCRIPTION
Supersedes #200.

## Problem
#200 tried to recover the canonical parent event by reading `tour_id` / `tournament_id` / `tourSlug` from gamebase player-games rows. **Those fields do not exist** on any gamebase row (verified live against `service.chessever.com`). For round-labeled broadcast games the PGN `Event` is a per-round pairing label (e.g. `Round 7: Nazli, Sertan - Akal, Muhammed Furkan`), so #200's helper returned that label unchanged — the bug remained. Its tests only passed because they hand-fed `tourSlug`, a path real data never hits.

## Fix
The canonical parent event survives only in the Lichess `Site` URL:
`https://lichess.org/broadcast/<parent-slug>/round-N/<roundId>/<chapterId>`.
- `eventTitleFromBroadcastSite()` extracts `<parent-slug>` and title-cases it (collapsing `--` separators).
- `preferredTwicEventTitle()` gains a `site` param, used as the fallback before the raw round label.
- Threaded `site` into both TWIC game builders and the board info sheet. Player-events grouping already keys off `tourSlug` (now the parent name), so rounds collapse into one event card.

Builds on #200's commits (kept its round-label detection + grouping scaffold).

## Verification
- `flutter test test/twic_event_identity_test.dart` (7 pass, incl. real Akal/Drogheda site cases)
- `flutter analyze` touched files — only pre-existing legacy warnings, no new issues
- Verified live: player `b21543df…` games all carry `Site` broadcast URLs and no tour fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)