### PR TITLE
fix: refresh Android board audio after resume

### DIFF
--- a/lib/utils/audio_player_service.dart
+++ b/lib/utils/audio_player_service.dart
@@ -142,6 +142,7 @@ class AudioPlayerService with WidgetsBindingObserver {
 
   Future<void> _playWithRecovery(SfxType type) async {
     try {
+      await _refreshAndroidAudioIfNeeded('before playback');
       await initializeAndLoadAllAssets();
       // soloud 4.x: play() is sync — no await.
       player.play(_resolve(type));
@@ -242,6 +243,18 @@ class AudioPlayerService with WidgetsBindingObserver {
     return source;
   }
 
+  Future<void> _refreshAndroidAudioIfNeeded(String reason) async {
+    if (!Platform.isAndroid || !_needsAndroidResumeRefresh) return;
+
+    _needsAndroidResumeRefresh = false;
+    // Android can return from background with SoLoud still reporting initialized
+    // while the native output session/asset handles no longer produce sound.
+    // Refresh from both lifecycle resume and the next play as a safety net for
+    // devices that miss/delay lifecycle callbacks around event/board switches.
+    debugPrint('🎧 AudioPlayerService: Android audio refresh needed ($reason)');
+    await initializeAndLoadAllAssets(force: true);
+  }
+
   /// Tear down the native engine only during explicit recovery.
   // SoLoud.instance is per-isolate state, so deinit MUST run on the main
   // isolate. A previous version off-loaded this to Isolate.run, which both
@@ -270,16 +283,10 @@ class AudioPlayerService with WidgetsBindingObserver {
     debugPrint('🎧 AudioPlayerService: lifecycle changed to $state');
     if (state == AppLifecycleState.resumed) {
       if (Platform.isAndroid && _needsAndroidResumeRefresh) {
-        _needsAndroidResumeRefresh = false;
-        // Android can return from background with SoLoud still reporting
-        // initialized while its native output session/asset handles are no
-        // longer producing sound. Force a fresh engine + asset load on resume
-        // after a real background pause; transient inactive states are ignored.
-        debugPrint(
-          '🎧 AudioPlayerService: Android resumed after background, refreshing audio engine',
-        );
         unawaited(
-          _enqueueAudioOperation(() => initializeAndLoadAllAssets(force: true)),
+          _enqueueAudioOperation(
+            () => _refreshAndroidAudioIfNeeded('app resumed'),
+          ),
         );
         return;
       }

--- a/lib/utils/audio_player_service.dart
+++ b/lib/utils/audio_player_service.dart
@@ -39,6 +39,7 @@ class AudioPlayerService with WidgetsBindingObserver {
   DateTime _lastPlayAt = DateTime.fromMillisecondsSinceEpoch(0);
   SfxType? _lastPlayedType;
   bool _audioSessionConfigured = false;
+  bool _needsAndroidResumeRefresh = false;
 
   /// Configure iOS audio session to use ambient mode (doesn't interrupt other audio)
   Future<void> _configureAudioSession() async {
@@ -159,8 +160,17 @@ class AudioPlayerService with WidgetsBindingObserver {
   }
 
   Future<void> _initializeInternal({required bool force}) async {
-    if (force && player.isInitialized) {
-      _teardownPlayer();
+    if (force) {
+      // A forced initialization means the previous Dart AudioSource handles may
+      // no longer match the native Android audio device/session even when
+      // SoLoud still reports initialized after app backgrounding. Always clear
+      // the Dart flags so assets are reloaded with fresh native handles.
+      if (player.isInitialized) {
+        _teardownPlayer();
+      } else {
+        _initialized = false;
+        _assetsLoaded = false;
+      }
     }
 
     // If the native engine was killed while the Dart flag stayed true, reset.
@@ -259,8 +269,23 @@ class AudioPlayerService with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     debugPrint('🎧 AudioPlayerService: lifecycle changed to $state');
     if (state == AppLifecycleState.resumed) {
-      // Only reinitialize if the native engine is gone. Avoids unnecessary
-      // teardown→reinit cycles that create windows of broken audio.
+      if (Platform.isAndroid && _needsAndroidResumeRefresh) {
+        _needsAndroidResumeRefresh = false;
+        // Android can return from background with SoLoud still reporting
+        // initialized while its native output session/asset handles are no
+        // longer producing sound. Force a fresh engine + asset load on resume
+        // after a real background pause; transient inactive states are ignored.
+        debugPrint(
+          '🎧 AudioPlayerService: Android resumed after background, refreshing audio engine',
+        );
+        unawaited(
+          _enqueueAudioOperation(() => initializeAndLoadAllAssets(force: true)),
+        );
+        return;
+      }
+
+      // Only reinitialize if the native engine is gone on non-Android paths, or
+      // if Android resumes without seeing a prior paused signal.
       if (!player.isInitialized) {
         debugPrint(
           '🎧 AudioPlayerService: engine dead after resume, reinitializing',
@@ -281,6 +306,9 @@ class AudioPlayerService with WidgetsBindingObserver {
     // and tearing down there causes sound to disappear on Android.
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.detached) {
+      if (Platform.isAndroid) {
+        _needsAndroidResumeRefresh = true;
+      }
       // Do not deinit during normal lifecycle transitions. SoLoud's native
       // audio callback can still be mixing a short SFX while Dart receives
       // paused/detached, and tearing down then can corrupt the active voice.


### PR DESCRIPTION
## Summary
- Refreshes the Android SoLoud engine/assets after the app truly backgrounds and resumes.
- Keeps transient inactive/hidden states ignored, matching the previous fix that avoided teardown during short lifecycle transitions.
- Forces asset flags to clear on forced initialization even if SoLoud no longer reports initialized, so stale handles cannot be reused.

## Root cause / why
Android can return from a real background pause with SoLoud still reporting `isInitialized`, while the native output session or loaded handles no longer produce board SFX. The existing resume logic skipped recovery in that state because it only reinitialized when `isInitialized == false`.

## Validation
- `dart format --set-exit-if-changed lib/utils/audio_player_service.dart`
- `flutter analyze --no-pub lib/utils/audio_player_service.dart`
- `git diff --check HEAD~1 HEAD`

## QA
Please verify on Android device:
1. Open a game with board sound enabled.
2. Switch to other apps and leave Chess Ever backgrounded for a while.
3. Return to Chess Ever.
4. Move/navigate moves and confirm board SFX still plays.

Berkay should review before merge.