### PR TITLE
Fix phone Events search relevance for historical queries

### DIFF
--- a/lib/screens/group_event/providers/supabase_combined_search_provider.dart
+++ b/lib/screens/group_event/providers/supabase_combined_search_provider.dart
@@ -151,31 +151,18 @@ final supabaseCombinedSearchProvider = AutoDisposeFutureProvider.family<
 
   for (final gb in broadcasts) {
     final tourEventModel = GroupEventCardModel.fromGroupBroadcast(gb, liveIds);
-    var bestTournamentScore = SearchScorer.calculateScore(
-      trimmedQuery,
-      gb.name,
-      SearchResultType.tournament,
+    final tournamentMatch = SearchScorer.bestTournamentMatch(
+      query: trimmedQuery,
+      name: gb.name,
+      aliases: gb.search,
     );
-    var bestTournamentMatch = gb.name;
 
-    for (final searchTerm in gb.search) {
-      final score = SearchScorer.calculateScore(
-        trimmedQuery,
-        searchTerm,
-        SearchResultType.tournament,
-      );
-      if (score > bestTournamentScore) {
-        bestTournamentScore = score;
-        bestTournamentMatch = searchTerm;
-      }
-    }
-
-    if (bestTournamentScore > 10.0) {
+    if (tournamentMatch.score > 10.0) {
       tournamentResults.add(
         SearchResult(
           tournament: tourEventModel,
-          score: bestTournamentScore,
-          matchedText: bestTournamentMatch,
+          score: tournamentMatch.score,
+          matchedText: tournamentMatch.matchedText,
           type: SearchResultType.tournament,
         ),
       );

--- a/lib/screens/group_event/providers/supabase_combined_search_provider.dart
+++ b/lib/screens/group_event/providers/supabase_combined_search_provider.dart
@@ -11,6 +11,7 @@ import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.d
 import 'package:chessever2/repository/supabase/group_broadcast/group_tour_repository.dart';
 import 'package:chessever2/widgets/search/enhanced_group_broadcast_local_storage.dart';
 import 'package:chessever2/widgets/search/search_result_model.dart';
+import 'package:chessever2/widgets/search/search_scorer.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/repository/local_storage/group_broadcast/group_broadcast_local_storage.dart';
 import 'package:chessever2/utils/player_name_search.dart';
@@ -150,15 +151,35 @@ final supabaseCombinedSearchProvider = AutoDisposeFutureProvider.family<
 
   for (final gb in broadcasts) {
     final tourEventModel = GroupEventCardModel.fromGroupBroadcast(gb, liveIds);
-
-    tournamentResults.add(
-      SearchResult(
-        tournament: tourEventModel,
-        score: 100.0,
-        matchedText: gb.name,
-        type: SearchResultType.tournament,
-      ),
+    var bestTournamentScore = SearchScorer.calculateScore(
+      trimmedQuery,
+      gb.name,
+      SearchResultType.tournament,
     );
+    var bestTournamentMatch = gb.name;
+
+    for (final searchTerm in gb.search) {
+      final score = SearchScorer.calculateScore(
+        trimmedQuery,
+        searchTerm,
+        SearchResultType.tournament,
+      );
+      if (score > bestTournamentScore) {
+        bestTournamentScore = score;
+        bestTournamentMatch = searchTerm;
+      }
+    }
+
+    if (bestTournamentScore > 10.0) {
+      tournamentResults.add(
+        SearchResult(
+          tournament: tourEventModel,
+          score: bestTournamentScore,
+          matchedText: bestTournamentMatch,
+          type: SearchResultType.tournament,
+        ),
+      );
+    }
 
     // Note: We no longer create SearchPlayers from broadcast search terms
     // because they lack FIDE IDs. Player search results now come entirely
@@ -334,6 +355,24 @@ final supabaseCombinedSearchProvider = AutoDisposeFutureProvider.family<
       allPlayers.add(result.player!);
     }
   }
+
+  tournamentResults.sort((a, b) {
+    final scoreCompare = b.score.compareTo(a.score);
+    if (scoreCompare != 0) return scoreCompare;
+
+    final aDate = a.tournament.startDate;
+    final bDate = b.tournament.startDate;
+    if (aDate != null && bDate != null) {
+      final dateCompare = bDate.compareTo(aDate);
+      if (dateCompare != 0) return dateCompare;
+    } else if (aDate != null) {
+      return -1;
+    } else if (bDate != null) {
+      return 1;
+    }
+
+    return a.tournament.title.compareTo(b.tournament.title);
+  });
 
   final searchResult = EnhancedSearchResult(
     tournamentResults: tournamentResults,

--- a/lib/widgets/search/enhanced_group_broadcast_local_storage.dart
+++ b/lib/widgets/search/enhanced_group_broadcast_local_storage.dart
@@ -4,8 +4,6 @@ import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart'
 import 'package:chessever2/widgets/search/search_result_model.dart';
 import 'package:chessever2/widgets/search/search_scorer.dart';
 
-import '../../screens/group_event/group_event_screen.dart';
-
 class EnhancedSearchResult {
   final List<SearchResult> tournamentResults;
   final List<SearchResult> playerResults;
@@ -67,33 +65,18 @@ extension GroupBroadcastLocalStorageSearch on GroupBroadcastLocalStorage {
           liveBroadcastId ?? [],
         );
 
-        final tournamentScore = SearchScorer.calculateScore(
-          queryLower,
-          gb.name,
-          SearchResultType.tournament,
+        final tournamentMatch = SearchScorer.bestTournamentMatch(
+          query: queryLower,
+          name: gb.name,
+          aliases: gb.search,
         );
 
-        var bestTournamentScore = tournamentScore;
-        var bestTournamentMatch = gb.name;
-
-        for (final searchTerm in gb.search) {
-          final score = SearchScorer.calculateScore(
-            queryLower,
-            searchTerm,
-            SearchResultType.tournament,
-          );
-          if (score > bestTournamentScore) {
-            bestTournamentScore = score;
-            bestTournamentMatch = searchTerm;
-          }
-        }
-
-        if (bestTournamentScore > 10.0) {
+        if (tournamentMatch.score > 10.0) {
           tournamentResults.add(
             SearchResult(
               tournament: tourEventModel,
-              score: bestTournamentScore,
-              matchedText: bestTournamentMatch,
+              score: tournamentMatch.score,
+              matchedText: tournamentMatch.matchedText,
               type: SearchResultType.tournament,
             ),
           );

--- a/lib/widgets/search/search_scorer.dart
+++ b/lib/widgets/search/search_scorer.dart
@@ -2,7 +2,41 @@ import 'dart:math' as math;
 
 import 'package:chessever2/widgets/search/search_result_model.dart';
 
+class SearchScoreMatch {
+  const SearchScoreMatch({required this.score, required this.matchedText});
+
+  final double score;
+  final String matchedText;
+}
+
 class SearchScorer {
+  static const SearchScoreMatch noMatch = SearchScoreMatch(
+    score: 0,
+    matchedText: '',
+  );
+
+  static SearchScoreMatch bestTournamentMatch({
+    required String query,
+    required String name,
+    Iterable<String> aliases = const [],
+  }) {
+    var bestScore = calculateScore(query, name, SearchResultType.tournament);
+    var bestMatch = name;
+
+    for (final alias in aliases) {
+      if (!_isTournamentIdentityAlias(name, alias)) continue;
+
+      final score = calculateScore(query, alias, SearchResultType.tournament);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = alias;
+      }
+    }
+
+    if (bestScore <= 0) return noMatch;
+    return SearchScoreMatch(score: bestScore, matchedText: bestMatch);
+  }
+
   static double calculateScore(
     String query,
     String text,
@@ -38,7 +72,7 @@ class SearchScorer {
     }
 
     if (type == SearchResultType.tournament) {
-      if (!_hasSpecificTournamentTokenMatch(queryLower, textLower)) {
+      if (!_hasTournamentQueryIdentityMatch(queryLower, textLower)) {
         return 0.0;
       }
 
@@ -49,55 +83,60 @@ class SearchScorer {
     return score.clamp(0.0, 100.0);
   }
 
-  static bool _hasSpecificTournamentTokenMatch(String query, String text) {
-    final specificQueryTokens =
+  static bool _hasTournamentQueryIdentityMatch(String query, String text) {
+    final queryTokens =
         _normalizedTokens(
           query,
-        ).where((token) => !_genericTournamentTokens.contains(token)).toList();
-
-    if (specificQueryTokens.length < 2) return true;
-
+        ).where((token) => !_isYearToken(token)).toList();
     final textTokens = _normalizedTokens(text);
-    if (textTokens.isEmpty) return false;
+    if (queryTokens.isEmpty || textTokens.isEmpty) return false;
 
-    for (final queryToken in specificQueryTokens) {
-      for (final textToken in textTokens) {
-        if (textToken == queryToken ||
-            textToken.startsWith(queryToken) ||
-            queryToken.startsWith(textToken)) {
-          return true;
-        }
-      }
+    if (queryTokens.length == 1) {
+      return textTokens.any((textToken) {
+        return _tokensMatch(queryTokens.first, textToken);
+      });
     }
 
-    return false;
+    return queryTokens.every((queryToken) {
+      return textTokens.any((textToken) {
+        return _tokensMatch(queryToken, textToken);
+      });
+    });
+  }
+
+  static bool _isTournamentIdentityAlias(String name, String alias) {
+    final nameTokens = _normalizedTokens(name);
+    final aliasTokens = _normalizedTokens(alias);
+    if (nameTokens.isEmpty || aliasTokens.isEmpty) return false;
+
+    final normalizedName = nameTokens.join(' ');
+    final normalizedAlias = aliasTokens.join(' ');
+    if (normalizedAlias == normalizedName) return true;
+    if (normalizedAlias.startsWith('$normalizedName ')) return true;
+
+    final requiredNameTokens =
+        nameTokens.where((token) => !_isYearToken(token)).toSet();
+    if (requiredNameTokens.isEmpty) return false;
+
+    final aliasTokenSet = aliasTokens.toSet();
+    return requiredNameTokens.every(aliasTokenSet.contains);
+  }
+
+  static bool _tokensMatch(String queryToken, String textToken) {
+    return textToken == queryToken || textToken.startsWith(queryToken);
+  }
+
+  static bool _isYearToken(String token) {
+    final year = int.tryParse(token);
+    return token.length == 4 && year != null && year >= 1800 && year <= 2200;
   }
 
   static List<String> _normalizedTokens(String value) {
-    final normalized = value.replaceAll(RegExp(r'[^a-z0-9]+'), ' ').trim();
+    final normalized =
+        value.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), ' ').trim();
     if (normalized.isEmpty) return const [];
     return normalized.split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
   }
-
-  static const Set<String> _genericTournamentTokens = {
-    'chess',
-    'championship',
-    'championships',
-    'tournament',
-    'festival',
-    'open',
-    'classic',
-    'cup',
-    'final',
-    'finals',
-    'men',
-    'women',
-    'girls',
-    'boys',
-    'team',
-    'teams',
-    'event',
-  };
 
   static double _calculateFuzzyScore(String query, String text) {
     final queryWords = query.split(' ').where((w) => w.isNotEmpty).toList();

--- a/lib/widgets/search/search_scorer.dart
+++ b/lib/widgets/search/search_scorer.dart
@@ -37,13 +37,67 @@ class SearchScorer {
       score = _calculateFuzzyScore(queryLower, textLower);
     }
 
-    // Boost score for tournament name matches vs player matches
     if (type == SearchResultType.tournament) {
-      score *= 1.1; // Slight boost for tournament name matches
+      if (!_hasSpecificTournamentTokenMatch(queryLower, textLower)) {
+        return 0.0;
+      }
+
+      // Boost score for tournament name matches vs player matches.
+      score *= 1.1;
     }
 
     return score.clamp(0.0, 100.0);
   }
+
+  static bool _hasSpecificTournamentTokenMatch(String query, String text) {
+    final specificQueryTokens =
+        _normalizedTokens(
+          query,
+        ).where((token) => !_genericTournamentTokens.contains(token)).toList();
+
+    if (specificQueryTokens.length < 2) return true;
+
+    final textTokens = _normalizedTokens(text);
+    if (textTokens.isEmpty) return false;
+
+    for (final queryToken in specificQueryTokens) {
+      for (final textToken in textTokens) {
+        if (textToken == queryToken ||
+            textToken.startsWith(queryToken) ||
+            queryToken.startsWith(textToken)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  static List<String> _normalizedTokens(String value) {
+    final normalized = value.replaceAll(RegExp(r'[^a-z0-9]+'), ' ').trim();
+    if (normalized.isEmpty) return const [];
+    return normalized.split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
+  }
+
+  static const Set<String> _genericTournamentTokens = {
+    'chess',
+    'championship',
+    'championships',
+    'tournament',
+    'festival',
+    'open',
+    'classic',
+    'cup',
+    'final',
+    'finals',
+    'men',
+    'women',
+    'girls',
+    'boys',
+    'team',
+    'teams',
+    'event',
+  };
 
   static double _calculateFuzzyScore(String query, String text) {
     final queryWords = query.split(' ').where((w) => w.isNotEmpty).toList();
@@ -77,7 +131,7 @@ class SearchScorer {
     final longer = s1.length > s2.length ? s1 : s2;
     final shorter = s1.length > s2.length ? s2 : s1;
 
-    if (longer.length == 0) return 1.0;
+    if (longer.isEmpty) return 1.0;
 
     final editDistance = _levenshteinDistance(longer, shorter);
     return (longer.length - editDistance) / longer.length;

--- a/test/search_scorer_test.dart
+++ b/test/search_scorer_test.dart
@@ -27,6 +27,61 @@ void main() {
       },
     );
 
+    test('rejects broad player or country matches outside the event title', () {
+      final match = SearchScorer.bestTournamentMatch(
+        query: 'norway chess',
+        name:
+            '5th FIDE Intercontinental Online Chess Championship for Prisoners',
+        aliases: const [
+          '5th FIDE Intercontinental Online Chess Championship for Prisoners',
+          '5th FIDE Intercontinental Online Chess Championship for Prisoners Men Group 6',
+          'Norway_AA',
+          'Norway_BB',
+          'Norway_CC',
+        ],
+      );
+
+      expect(match.score, 0);
+    });
+
+    test('rejects player-name hits from tournament results', () {
+      final match = SearchScorer.bestTournamentMatch(
+        query: 'magnus carlsen',
+        name: 'Norway Chess 2026',
+        aliases: const [
+          'Norway Chess 2026',
+          'Norway Chess 2026 | Open',
+          'Carlsen, Magnus',
+        ],
+      );
+
+      expect(match.score, 0);
+    });
+
+    test('uses title-like aliases but ignores unrelated search terms', () {
+      final match = SearchScorer.bestTournamentMatch(
+        query: 'norway chess open may',
+        name: 'Norway Chess Open 2026',
+        aliases: const [
+          'Norway Chess Open 2026 MAY',
+          'Urkedal, Frode Olav Olsen',
+        ],
+      );
+
+      expect(match.score, greaterThan(10));
+      expect(match.matchedText, 'Norway Chess Open 2026 MAY');
+    });
+
+    test('keeps Norway Chess results for the plain branded query', () {
+      final score = SearchScorer.calculateScore(
+        'norway chess',
+        'Norway Chess 2026',
+        SearchResultType.tournament,
+      );
+
+      expect(score, greaterThan(10));
+    });
+
     test('ranks exact historical event above same-name current event', () {
       final exactScore = SearchScorer.calculateScore(
         'norway chess 2015',

--- a/test/search_scorer_test.dart
+++ b/test/search_scorer_test.dart
@@ -1,0 +1,45 @@
+import 'package:chessever2/widgets/search/search_result_model.dart';
+import 'package:chessever2/widgets/search/search_scorer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SearchScorer tournament relevance', () {
+    test('keeps close event-name matches when the queried year differs', () {
+      final score = SearchScorer.calculateScore(
+        'norway chess 2015',
+        'Norway Chess 2026',
+        SearchResultType.tournament,
+      );
+
+      expect(score, greaterThan(10));
+    });
+
+    test(
+      'rejects generic chess-only matches for a specific historical event query',
+      () {
+        final score = SearchScorer.calculateScore(
+          'norway chess 2015',
+          'Asian Individual Chess Championship 2026',
+          SearchResultType.tournament,
+        );
+
+        expect(score, 0);
+      },
+    );
+
+    test('ranks exact historical event above same-name current event', () {
+      final exactScore = SearchScorer.calculateScore(
+        'norway chess 2015',
+        'Norway Chess 2015',
+        SearchResultType.tournament,
+      );
+      final currentScore = SearchScorer.calculateScore(
+        'norway chess 2015',
+        'Norway Chess 2026',
+        SearchResultType.tournament,
+      );
+
+      expect(exactScore, greaterThan(currentScore));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Tightens phone Events tournament relevance scoring for specific multi-token searches like `norway chess 2015`.
- Keeps close event-name matches such as `Norway Chess 2026`, but filters out generic chess-only/current-event matches such as unrelated championships.
- Re-scores Supabase event search results before displaying them instead of treating every backend result as an equal `100` score, then sorts by relevance before date.

## Test Plan
- `flutter test --no-pub test/search_scorer_test.dart`
- `flutter analyze --no-pub lib/widgets/search/search_scorer.dart lib/screens/group_event/providers/supabase_combined_search_provider.dart test/search_scorer_test.dart`
- `git diff --check`

## QA
- Search Events for `norway chess 2015` on phone.
- Expected: Norway Chess-related results may appear, but unrelated current events should not fill the list just because they contain generic terms like “Chess”.