### PR TITLE
Fix round-start pushes before moves

### DIFF
--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -211,6 +211,14 @@ async function processItem(item: OutboxItem, cloudEvalState: CloudEvalState) {
   try {
     const context = await buildContext(item);
     if (item.event_type === "round_started") {
+      if (!item.round_id || !(await hasRoundWithMoves(item.round_id))) {
+        await markSkipped(item.id, "round_not_live_yet");
+        return {
+          id: item.id,
+          status: "skipped",
+          reason: "round_not_live_yet",
+        };
+      }
       if (await hasSentGroupedRoundStart(item, context)) {
         await markSkipped(item.id, "duplicate_grouped_round_start");
         return {
@@ -466,7 +474,8 @@ async function processItem(item: OutboxItem, cloudEvalState: CloudEvalState) {
       }
 
       const roundId = item.round_id ?? context.round?.id ?? "";
-      const eventName = context.eventName ?? "Live chess";
+      const eventName = context.displayEventName ?? context.eventName ??
+        "Live chess";
       const roundName = context.round?.name ?? "";
       const title = buildEventHeader(eventName, roundName) ?? eventName;
 
@@ -1018,6 +1027,7 @@ async function buildContext(item: OutboxItem) {
   let tour: TourRow | null = null;
   let eventName: string | null = null;
   let groupBroadcastId = item.group_broadcast_id ?? null;
+  let groupSectionCount = 0;
 
   if (item.game_id) {
     const { data } = await supabase
@@ -1057,7 +1067,20 @@ async function buildContext(item: OutboxItem) {
       .eq("id", groupBroadcastId)
       .maybeSingle();
     eventName = data?.name ?? null;
+
+    const { data: groupedTours } = await supabase
+      .from("tours")
+      .select("id,name,slug")
+      .eq("group_broadcast_id", groupBroadcastId);
+    groupSectionCount = ((groupedTours ?? []) as TourRow[])
+      .filter((row) => !isCombinedTour(row)).length;
   }
+
+  const displayEventName = buildRoundEventDisplayName(
+    eventName,
+    tour?.name ?? null,
+    groupSectionCount,
+  );
 
   const playerNames = new Set<string>();
   const fideIdSet = new Set<string>();
@@ -1121,6 +1144,7 @@ async function buildContext(item: OutboxItem) {
     round,
     tour,
     eventName,
+    displayEventName,
     groupBroadcastId,
     tourId,
     eventUserIds,
@@ -1182,6 +1206,18 @@ async function hasSentGroupedRoundStart(
 
   return ((data ?? []) as Array<{ payload?: Record<string, unknown> | null }>)
     .some((row) => sameInstant(row.payload?.starts_at, startsAt));
+}
+
+async function hasRoundWithMoves(roundId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("games")
+    .select("id")
+    .eq("round_id", roundId)
+    .not("last_move_time", "is", null)
+    .limit(1);
+
+  if (error) return false;
+  return (data ?? []).length > 0;
 }
 
 function sameInstant(a: unknown, b: string): boolean {
@@ -2104,6 +2140,49 @@ function buildEventHeader(
   if (eventName && roundName) return `${eventName} — ${roundName}`;
   if (eventName) return eventName;
   return null;
+}
+
+function buildRoundEventDisplayName(
+  eventName: string | null,
+  tourName: string | null,
+  groupSectionCount: number,
+): string | null {
+  if (!eventName) return tourName;
+  if (!tourName || groupSectionCount <= 1) return eventName;
+
+  if (normalizeEventLabel(tourName).startsWith(normalizeEventLabel(eventName))) {
+    return tourName;
+  }
+
+  if (isRedundantOpenSection(eventName, tourName)) {
+    return eventName;
+  }
+
+  const sectionName = extractTourSection(eventName, tourName);
+  if (!sectionName || isRedundantOpenSection(eventName, sectionName)) {
+    return eventName;
+  }
+
+  return `${eventName} — ${sectionName}`;
+}
+
+function extractTourSection(eventName: string, tourName: string): string | null {
+  const pipeSection = tourName.split("|").pop()?.trim();
+  if (pipeSection && pipeSection !== tourName.trim()) return pipeSection;
+
+  const normalizedEvent = normalizeEventLabel(eventName);
+  const normalizedTour = normalizeEventLabel(tourName);
+  if (!normalizedTour.startsWith(normalizedEvent)) return null;
+
+  return tourName.slice(eventName.length).replace(/^\s*[-–—:|]\s*/, "").trim() || null;
+}
+
+function isRedundantOpenSection(eventName: string, sectionName: string): boolean {
+  return /\bopen\b/i.test(sectionName) && /\bopen\b/i.test(eventName);
+}
+
+function normalizeEventLabel(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
 function channelForEvent(eventType: string) {

--- a/supabase/migrations/20260601183000_round_start_requires_moves.sql
+++ b/supabase/migrations/20260601183000_round_start_requires_moves.sql
@@ -1,7 +1,7 @@
--- Grouped events can contain separate raw tours, such as Open, Women, and
--- Combined boards, whose rounds share the same visible start time. Queue one
--- visible round-start notification for a grouped event/start instant instead
--- of one notification per raw tour round.
+-- Round-start pushes must mean the games are actually live.
+-- The previous scheduler queued round_started rows from the scheduled start time;
+-- Armageddon/tiebreak rounds can exist at the scheduled time before any game row
+-- has moved, which produced false "first moves have been played" notifications.
 
 CREATE OR REPLACE FUNCTION public.queue_round_start_notifications()
 RETURNS void AS $$

--- a/test_notification_dispatch_dedupe.py
+++ b/test_notification_dispatch_dedupe.py
@@ -62,6 +62,24 @@ def test_dispatcher_skips_duplicate_grouped_round_starts() -> None:
     assert "sameInstant(row.payload?.starts_at, startsAt)" in source
 
 
+def test_round_started_requires_actual_move_before_dispatch() -> None:
+    source = _source()
+
+    assert "hasRoundWithMoves(item.round_id)" in source
+    assert "round_not_live_yet" in source
+    assert '.select("id")' in source
+    assert '.not("last_move_time", "is", null)' in source
+
+
+def test_round_event_display_name_omits_redundant_single_open_section() -> None:
+    source = _source()
+
+    assert "displayEventName" in source
+    assert "buildRoundEventDisplayName" in source
+    assert "normalizeEventLabel(tourName).startsWith(normalizeEventLabel(eventName))" in source
+    assert "isRedundantOpenSection(eventName, tourName)" in source
+
+
 def test_combined_tours_do_not_send_round_result_notifications() -> None:
     source = _source()
 
@@ -78,3 +96,12 @@ def test_round_start_queue_dedupe_is_exact_group_start_time_not_two_hour_bucket(
     assert "EXTRACT(EPOCH FROM r.starts_at)::bigint::text" in migration
     assert "'round_started:' || r.id::text" in migration
     assert "/ 7200" not in migration
+
+
+def test_round_start_queue_requires_a_real_move_before_enqueue() -> None:
+    migration = ROUND_START_DEDUPE_MIGRATION.read_text(encoding="utf-8")
+
+    assert "EXISTS (" in migration
+    assert "FROM public.games g" in migration
+    assert "g.round_id = r.id" in migration
+    assert "g.last_move_time IS NOT NULL" in migration


### PR DESCRIPTION
## Summary
- Requires an actual game move (`games.last_move_time`) before queuing or dispatching `round_started` push notifications.
- Adds an Edge Function safety net so already-queued false starts are skipped as `round_not_live_yet` instead of sent.
- Adjusts round-start event naming so grouped multi-section events can include the raw tour section, while single/non-grouped events avoid redundant `Open` labeling.
- Adds regression coverage for move-gating and round-start title formatting.

## Why
The Norway Chess 2026 Armageddon round row was scheduled, but no Armageddon game had moved yet. The previous queue logic used `rounds.starts_at`, which allowed a false “first moves have been played” push.

## Validation
- `/opt/data/home/.local/bin/pytest test_notification_dispatch_dedupe.py -q` ✅
- `git diff --check` ✅
- `deno check supabase/functions/onesignal-dispatch/index.ts` not run: `deno` is not installed in this Hermes environment.

## QA / rollout notes
- Deploy the new Supabase migration and redeploy `onesignal-dispatch` together.
- Verify a scheduled Armageddon/tiebreak round with zero moved games stays unsent/skipped.
- Verify the same round sends only after at least one game has `last_move_time`.
- For grouped events, verify the displayed event label is specific only when multiple non-combined sections exist; single/non-grouped `Open` events should not get an extra `Open` suffix.
