### PR TITLE
Add My Likes organization tools

### DIFF
--- a/lib/repository/library/library_repository.dart
+++ b/lib/repository/library/library_repository.dart
@@ -139,7 +139,7 @@ class LibraryRepository extends BaseRepository {
             .from('user_folders')
             .insert({
               'user_id': userId,
-              'name': 'Liked Games',
+              'name': 'My Likes',
               'color': '#F5453A',
               'icon': 'liked',
               'order_index': nextOrder,

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -3085,7 +3085,9 @@ class _AppBarState extends ConsumerState<_AppBar> {
             break;
           case AutoSaveStatus.idle:
             diskIcon = Icon(
-              isEditableLibraryGame ? Icons.edit_outlined : Icons.save_outlined,
+              isEditableLibraryGame
+                  ? Icons.edit_outlined
+                  : Icons.bookmark_add_outlined,
               color: context.colors.textPrimary,
               size: 20.sp,
             );

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:chessever2/providers/board_settings_provider_new.dart';
 import 'package:chessever2/repository/library/library_repository.dart';
 import 'package:chessever2/repository/library/models/saved_analysis.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/providers/engine_settings_provider.dart';
 import 'package:chessever2/repository/lichess/cloud_eval/cloud_eval.dart';
 import 'package:chessever2/repository/local_storage/local_eval/local_eval_cache.dart';
@@ -21,7 +22,6 @@ import 'package:chessever2/screens/chessboard/notation/notation_tree.dart';
 import 'package:chessever2/screens/chessboard/widgets/nag_display.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
-import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/audio_player_service.dart';
 import 'package:chessever2/utils/pgn_clock_utils.dart';
@@ -3471,6 +3471,7 @@ class ChessBoardScreenNotifierNew
     required String analysisId,
     required String title,
     String? folderId,
+    List<String> tags = const <String>[],
   }) {
     final currentState = state.valueOrNull;
     savedAnalysisData = SavedAnalysisData(
@@ -3488,6 +3489,7 @@ class ChessBoardScreenNotifierNew
       lastViewedPosition: currentState?.analysisState.currentMoveIndex ?? 0,
       title: title,
       folderId: folderId,
+      tags: tags,
     );
     // Snapshot current game tree so auto-save doesn't immediately re-save
     final analysisGame = currentState?.analysisState.game;
@@ -3518,6 +3520,7 @@ class ChessBoardScreenNotifierNew
     _autoSaveTimer?.cancel();
     final analysisId = savedAnalysisData?.analysisId;
     if (analysisId == null) return false;
+    if (!ref.read(subscriptionProvider).isSubscribed) return false;
 
     final currentState = state.valueOrNull;
     if (currentState == null) return false;
@@ -3547,7 +3550,7 @@ class ChessBoardScreenNotifierNew
         variationComments: currentState.variationComments,
         moveNags: currentState.moveNags,
         lastViewedPosition: currentState.analysisState.currentMoveIndex,
-        tags: const [],
+        tags: savedAnalysisData?.tags ?? const <String>[],
         isFavorite: false,
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),
@@ -3600,6 +3603,7 @@ class ChessBoardScreenNotifierNew
   Future<void> _performAutoSave() async {
     final analysisId = savedAnalysisData?.analysisId;
     if (analysisId == null || !mounted) return;
+    if (!ref.read(subscriptionProvider).isSubscribed) return;
 
     final currentState = state.valueOrNull;
     if (currentState == null) return;
@@ -3639,7 +3643,7 @@ class ChessBoardScreenNotifierNew
         variationComments: currentState.variationComments,
         moveNags: currentState.moveNags,
         lastViewedPosition: currentState.analysisState.currentMoveIndex,
-        tags: const [],
+        tags: savedAnalysisData?.tags ?? const <String>[],
         isFavorite: false,
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),
@@ -4614,7 +4618,6 @@ class ChessBoardScreenNotifierNew
     _clearActiveEvalState();
     _updateEvaluation(force: force);
   }
-
 
   String _getSamplePgnData() {
     return '''
@@ -7325,6 +7328,9 @@ class SavedAnalysisData {
   /// Folder ID the analysis belongs to (for auto-save updates)
   final String? folderId;
 
+  /// Personal organization tags attached to this saved game.
+  final List<String> tags;
+
   const SavedAnalysisData({
     this.analysisId,
     this.sourceGameId,
@@ -7336,6 +7342,7 @@ class SavedAnalysisData {
     required this.lastViewedPosition,
     this.title,
     this.folderId,
+    this.tags = const <String>[],
   });
 }
 

--- a/lib/screens/chessboard/widgets/save_analysis_sheet.dart
+++ b/lib/screens/chessboard/widgets/save_analysis_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:chessever2/repository/library/library_repository.dart';
 import 'package:chessever2/repository/library/models/library_folder.dart';
 import 'package:chessever2/repository/library/models/saved_analysis.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
 import 'package:chessever2/screens/chessboard/widgets/smooth_sheet_config.dart';
@@ -11,6 +12,7 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/save_to_library_guard.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -145,8 +147,23 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
   String? _errorMessage;
   bool _isCreatingNewFolder = false;
   bool _showGameDetails = false;
+  bool _showTags = false;
   String _selectedResult = '*';
   Color _selectedFolderColor = _folderColorPresets.first;
+  final Set<String> _selectedTags = <String>{};
+
+  static const List<String> _officialTags = <String>[
+    'Wild Game',
+    'Beautiful Mate',
+    'Trap',
+    'Good Defense',
+    'Comeback',
+    'High Technique',
+    'Positional Masterpiece',
+    'Sacrifice',
+    'Combination',
+    'Blunder',
+  ];
 
   // Edit-existing mode: tracked once at construction so the sheet behaves
   // consistently even if the underlying SavedAnalysisData mutates mid-flow.
@@ -222,6 +239,9 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
     );
 
     _selectedResult = metadata['Result']?.toString() ?? '*';
+    _selectedTags
+      ..clear()
+      ..addAll(notifier.savedAnalysisData?.tags ?? const <String>[]);
 
     // Parse date YYYY.MM.DD
     final dateStr = metadata['Date']?.toString() ?? '';
@@ -300,6 +320,11 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
         _errorMessage = 'Pick a database to save into';
       });
       HapticFeedback.lightImpact();
+      return;
+    }
+
+    if (_isEditMode && !ref.read(subscriptionProvider).isSubscribed) {
+      await showPremiumPaywallSheet(context: context);
       return;
     }
 
@@ -404,7 +429,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           variationComments: state.variationComments,
           moveNags: state.moveNags,
           lastViewedPosition: state.analysisState.currentMoveIndex,
-          tags: const [],
+          tags: _selectedTags.toList(growable: false),
           notes: null,
           isFavorite: false,
           createdAt: DateTime.now(),
@@ -424,7 +449,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           analysisState: analysisStateJson,
           variationComments: state.variationComments,
           lastViewedPosition: state.analysisState.currentMoveIndex,
-          tags: const [],
+          tags: _selectedTags.toList(growable: false),
           notes: null,
           isFavorite: false,
           createdAt: DateTime.now(),
@@ -447,6 +472,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
             analysisId: resolvedAnalysisId,
             title: title,
             folderId: targetFolderId,
+            tags: _selectedTags.toList(growable: false),
           );
 
       if (mounted && context.mounted) {
@@ -579,6 +605,18 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 _buildGameDetailsSection()
                     .animate()
                     .fadeIn(duration: 300.ms, delay: 100.ms)
+                    .slideY(
+                      begin: 0.1,
+                      end: 0,
+                      duration: 350.ms,
+                      curve: Curves.easeOutCubic,
+                    ),
+
+                SizedBox(height: 12.h),
+
+                _buildTagsSection()
+                    .animate()
+                    .fadeIn(duration: 300.ms, delay: 125.ms)
                     .slideY(
                       begin: 0.1,
                       end: 0,
@@ -846,6 +884,140 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                   ),
                 ),
               ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTagsSection() {
+    final locked = !ref.watch(subscriptionProvider).isSubscribed;
+    final summary =
+        _selectedTags.isEmpty
+            ? 'Add'
+            : _selectedTags.length == 1
+            ? _selectedTags.first
+            : '${_selectedTags.length} tags';
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24.w),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          GestureDetector(
+            onTap: () async {
+              if (locked) {
+                HapticFeedback.lightImpact();
+                await showPremiumPaywallSheet(context: context);
+                return;
+              }
+              setState(() => _showTags = !_showTags);
+              HapticFeedback.selectionClick();
+            },
+            child: Container(
+              padding: EdgeInsets.symmetric(vertical: 12.h, horizontal: 16.w),
+              decoration: BoxDecoration(
+                color: context.colors.textPrimary.withValues(alpha: 0.04),
+                borderRadius: BorderRadius.circular(12.br),
+                border: Border.all(
+                  color: context.colors.textPrimary.withValues(alpha: 0.08),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    locked ? Icons.lock_outline_rounded : Icons.sell_outlined,
+                    color: context.colors.textPrimary.withValues(alpha: 0.6),
+                    size: 20.sp,
+                  ),
+                  SizedBox(width: 12.w),
+                  Expanded(
+                    child: Text(
+                      'Tags',
+                      style: AppTypography.textSmMedium.copyWith(
+                        color: context.colors.textPrimary.withValues(
+                          alpha: 0.9,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Flexible(
+                    child: Text(
+                      locked ? 'Premium' : (_showTags ? 'Hide' : summary),
+                      style: AppTypography.textXsMedium.copyWith(
+                        color: kPrimaryColor,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  SizedBox(width: 4.w),
+                  Icon(
+                    _showTags
+                        ? Icons.keyboard_arrow_up_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                    color: kPrimaryColor,
+                    size: 18.sp,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (_showTags) ...[
+            SizedBox(height: 12.h),
+            Wrap(
+              spacing: 8.w,
+              runSpacing: 8.h,
+              children:
+                  _officialTags.map((tag) {
+                    final selected = _selectedTags.contains(tag);
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          if (selected) {
+                            _selectedTags.remove(tag);
+                          } else {
+                            _selectedTags.add(tag);
+                          }
+                        });
+                      },
+                      child: Container(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 12.w,
+                          vertical: 8.h,
+                        ),
+                        decoration: BoxDecoration(
+                          color:
+                              selected
+                                  ? kPrimaryColor.withValues(alpha: 0.18)
+                                  : context.colors.textPrimary.withValues(
+                                    alpha: 0.05,
+                                  ),
+                          borderRadius: BorderRadius.circular(18.br),
+                          border: Border.all(
+                            color:
+                                selected
+                                    ? kPrimaryColor.withValues(alpha: 0.55)
+                                    : context.colors.textPrimary.withValues(
+                                      alpha: 0.08,
+                                    ),
+                          ),
+                        ),
+                        child: Text(
+                          tag,
+                          style: AppTypography.textXsMedium.copyWith(
+                            color:
+                                selected
+                                    ? kPrimaryColor
+                                    : context.colors.textPrimary.withValues(
+                                      alpha: 0.75,
+                                    ),
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
             ),
           ],
         ],
@@ -1850,9 +2022,10 @@ class _FolderListItem extends ConsumerWidget {
                         ? Icons.favorite_rounded
                         : Icons.folder_rounded,
                     size: 18.sp,
-                    color: folder.isLikedGames
-                        ? context.colors.danger
-                        : folderColor,
+                    color:
+                        folder.isLikedGames
+                            ? context.colors.danger
+                            : folderColor,
                   ),
                 ),
                 SizedBox(width: 14.w),

--- a/lib/screens/library/folder_contents_screen.dart
+++ b/lib/screens/library/folder_contents_screen.dart
@@ -5,6 +5,7 @@ import 'package:chessever2/repository/gamebase/search/gamebase_search_models.dar
 import 'package:chessever2/repository/library/library_repository.dart';
 import 'package:chessever2/repository/library/models/library_folder.dart';
 import 'package:chessever2/repository/library/models/saved_analysis.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/library/pgn_import_preview_screen.dart';
 import 'package:chessever2/screens/gamebase/widgets/position_games_sheet.dart';
 import 'package:chessever2/screens/library/providers/book_games_paginated_provider.dart';
@@ -31,6 +32,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 
 class FolderContentsScreen extends ConsumerStatefulWidget {
   final LibraryFolder folder;
@@ -52,12 +54,36 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   // Overrides widget.folder.name after an in-place rename so the header
   // reflects the new name without needing to pop/reopen.
   String? _overrideFolderName;
+  final Set<String> _selectedTags = <String>{};
 
   bool get _isSubscribed => widget.folder.isSubscribed;
   bool get _isFolder => widget.folder.isFolder;
   bool get _isDatabase => widget.folder.isDatabase;
+  bool get _isMyLikes => widget.folder.isLikedGames;
 
-  String get _currentFolderName => _overrideFolderName ?? widget.folder.name;
+  static const List<String> _officialTags = <String>[
+    'Wild Game',
+    'Beautiful Mate',
+    'Trap',
+    'Good Defense',
+    'Comeback',
+    'High Technique',
+    'Positional Masterpiece',
+    'Sacrifice',
+    'Combination',
+    'Blunder',
+  ];
+
+  String get _currentFolderName =>
+      _isMyLikes ? 'My Likes' : (_overrideFolderName ?? widget.folder.name);
+
+  bool _canUseMyLikesTools() =>
+      !_isMyLikes || ref.read(subscriptionProvider).isSubscribed;
+
+  Future<void> _showMyLikesPremiumPaywall() async {
+    HapticFeedbackService.light();
+    await showPremiumPaywallSheet(context: context);
+  }
 
   @override
   void initState() {
@@ -101,6 +127,10 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   }
 
   void _showSortOptions() {
+    if (!_canUseMyLikesTools()) {
+      _showMyLikesPremiumPaywall();
+      return;
+    }
     HapticFeedbackService.buttonPress();
     showGamebaseSortOptions(
       context: context,
@@ -431,6 +461,10 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   }
 
   Future<void> _handleExportPgn() async {
+    if (!_canUseMyLikesTools()) {
+      await _showMyLikesPremiumPaywall();
+      return;
+    }
     HapticFeedbackService.medium();
 
     final repo = ref.read(libraryRepositoryProvider);
@@ -536,7 +570,10 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   @override
   Widget build(BuildContext context) {
     final bookAsync = ref.watch(bookGamesPaginatedProvider(_paginationKey));
-    final query = _searchController.text.trim().toLowerCase();
+    final toolsAllowed =
+        !_isMyLikes || ref.watch(subscriptionProvider).isSubscribed;
+    final query =
+        toolsAllowed ? _searchController.text.trim().toLowerCase() : '';
 
     return Scaffold(
       key: e2eKey(E2eIds.folderContentsRoot),
@@ -581,7 +618,11 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
         ),
       ),
       child: Column(
-        children: [_buildHeader(context, bookAsync), _buildSearchBar()],
+        children: [
+          _buildHeader(context, bookAsync),
+          _buildSearchBar(),
+          if (_isMyLikes) _buildTagChips(),
+        ],
       ),
     );
   }
@@ -598,8 +639,8 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
 
     final bool showExport =
         _isDatabase && (bookAsync.valueOrNull?.totalCount ?? 0) > 0;
-    final bool showRename = !_isSubscribed;
-    final bool showAdd = !_isSubscribed;
+    final bool showRename = !_isSubscribed && !_isMyLikes;
+    final bool showAdd = !_isSubscribed && !_isMyLikes;
 
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -630,16 +671,32 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  _currentFolderName,
-                  style: AppTypography.textMdBold.copyWith(
-                    color: context.colors.textPrimary,
-                    height: 1.15,
-                    letterSpacing: -0.2,
-                  ),
-                  textAlign: TextAlign.center,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_isMyLikes) ...[
+                      Icon(
+                        Icons.favorite_rounded,
+                        color: context.colors.danger,
+                        size: 18.ic,
+                      ),
+                      SizedBox(width: 6.w),
+                    ],
+                    Flexible(
+                      child: Text(
+                        _currentFolderName,
+                        style: AppTypography.textMdBold.copyWith(
+                          color: context.colors.textPrimary,
+                          height: 1.15,
+                          letterSpacing: -0.2,
+                        ),
+                        textAlign: TextAlign.center,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
                 ),
                 if (totalCount != null) ...[
                   SizedBox(height: 2.h),
@@ -655,7 +712,37 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             ),
           ),
           SizedBox(width: 4.w),
-          if (showExport)
+          if (_isMyLikes && showExport)
+            PopupMenuButton<String>(
+              tooltip: 'More',
+              color: context.colors.surface,
+              icon: Icon(
+                Icons.more_vert_rounded,
+                color: context.colors.textPrimary,
+                size: 22.ic,
+              ),
+              onSelected: (value) {
+                if (value == 'export') _handleExportPgn();
+              },
+              itemBuilder:
+                  (context) => [
+                    PopupMenuItem<String>(
+                      value: 'export',
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.file_download_outlined,
+                            color: context.colors.textPrimary,
+                            size: 18.ic,
+                          ),
+                          SizedBox(width: 10.w),
+                          const Text('Export database'),
+                        ],
+                      ),
+                    ),
+                  ],
+            )
+          else if (showExport)
             IconButton(
               onPressed: _handleExportPgn,
               tooltip: 'Export as PGN',
@@ -699,6 +786,8 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
   }
 
   Widget _buildSearchBar() {
+    final toolsLocked =
+        _isMyLikes && !ref.watch(subscriptionProvider).isSubscribed;
     final searchField = Container(
       height: 38.h,
       decoration: BoxDecoration(
@@ -717,6 +806,8 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
           Expanded(
             child: TextField(
               controller: _searchController,
+              readOnly: toolsLocked,
+              onTap: toolsLocked ? _showMyLikesPremiumPaywall : null,
               style: AppTypography.textSmRegular.copyWith(
                 color: context.colors.textPrimary,
               ),
@@ -767,9 +858,11 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
                   ),
                 ),
                 child: Icon(
-                  _sortDirection == GamebaseSortDirection.desc
-                      ? Icons.south_rounded
-                      : Icons.north_rounded,
+                  _isMyLikes
+                      ? Icons.tune_rounded
+                      : (_sortDirection == GamebaseSortDirection.desc
+                          ? Icons.south_rounded
+                          : Icons.north_rounded),
                   size: 18.sp,
                   color: kPrimaryColor,
                 ),
@@ -777,6 +870,81 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
             ),
           ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildTagChips() {
+    final locked = !ref.watch(subscriptionProvider).isSubscribed;
+    return SizedBox(
+      height: 36.h,
+      child: ListView.separated(
+        padding: EdgeInsets.symmetric(horizontal: 16.w),
+        scrollDirection: Axis.horizontal,
+        itemCount: _officialTags.length,
+        separatorBuilder: (_, __) => SizedBox(width: 8.w),
+        itemBuilder: (context, index) {
+          final tag = _officialTags[index];
+          final selected = _selectedTags.contains(tag);
+          return GestureDetector(
+            onTap: () {
+              if (locked) {
+                _showMyLikesPremiumPaywall();
+                return;
+              }
+              setState(() {
+                if (selected) {
+                  _selectedTags.remove(tag);
+                } else {
+                  _selectedTags.add(tag);
+                }
+              });
+            },
+            child: Container(
+              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
+              decoration: BoxDecoration(
+                color:
+                    selected
+                        ? kPrimaryColor.withValues(alpha: 0.18)
+                        : context.colors.textPrimary.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(18.br),
+                border: Border.all(
+                  color:
+                      selected
+                          ? kPrimaryColor.withValues(alpha: 0.55)
+                          : context.colors.textPrimary.withValues(alpha: 0.08),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    locked ? Icons.lock_outline_rounded : Icons.sell_outlined,
+                    size: 13.ic,
+                    color:
+                        selected
+                            ? kPrimaryColor
+                            : context.colors.textPrimary.withValues(
+                              alpha: 0.65,
+                            ),
+                  ),
+                  SizedBox(width: 5.w),
+                  Text(
+                    tag,
+                    style: AppTypography.textXsMedium.copyWith(
+                      color:
+                          selected
+                              ? kPrimaryColor
+                              : context.colors.textPrimary.withValues(
+                                alpha: 0.75,
+                              ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
       ),
     );
   }
@@ -856,6 +1024,10 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
               _isDatabase ? bookState.games : const <SavedAnalysis>[];
           final filteredAnalyses = _sortAnalyses(
             analyses.where((analysis) {
+              if (_selectedTags.isNotEmpty &&
+                  !_selectedTags.any(analysis.tags.contains)) {
+                return false;
+              }
               if (query.isEmpty) return true;
               final md = analysis.chessGame.metadata;
               final title = analysis.title.toLowerCase();
@@ -923,6 +1095,22 @@ class _FolderContentsScreenState extends ConsumerState<FolderContentsScreen> {
                           filteredAnalyses,
                           analysisIndex,
                           readOnly: true,
+                        );
+                      },
+                    ),
+                  ).animate().fadeIn();
+                }
+
+                if (_isMyLikes) {
+                  return Padding(
+                    padding: EdgeInsets.only(bottom: 12.h),
+                    child: BookSavedGameCard(
+                      analysis: analysis,
+                      onTap: () {
+                        loadSavedAnalysisWithSwiping(
+                          context,
+                          filteredAnalyses,
+                          analysisIndex,
                         );
                       },
                     ),

--- a/lib/screens/library/providers/library_folders_provider.dart
+++ b/lib/screens/library/providers/library_folders_provider.dart
@@ -68,16 +68,29 @@ final childLibraryFoldersProvider = Provider.autoDispose
       return all.where((f) => f.parentId == parentId).toList();
     });
 
+/// True when a folder can be picked by manual save/import flows.
+///
+/// The special Liked Games / My Likes database is system-managed and should
+/// only receive games through the explicit like/unlike action, never through
+/// generic save or PGN import destination pickers.
+bool isManualLibrarySaveTarget(LibraryFolder folder) {
+  return folder.id != kTwicBookId &&
+      !folder.isSubscribed &&
+      !folder.isLikedGames &&
+      folder.isDatabase;
+}
+
+List<LibraryFolder> manualLibrarySaveTargets(Iterable<LibraryFolder> folders) {
+  return folders.where(isManualLibrarySaveTarget).toList();
+}
+
 /// Top 3 most recently updated databases for quick selection
 final recentDatabasesProvider = Provider.autoDispose<List<LibraryFolder>>((
   ref,
 ) {
   final all = ref.watch(combinedLibraryFoldersProvider).valueOrNull ?? [];
-  // Quick-pick is databases only: exclude TWIC, organization folders, and the
-  // special Liked Games folder. Sort by updatedAt desc.
-  final owned = all
-      .where((f) => f.id != kTwicBookId && f.isDatabase && !f.isLikedGames)
-      .toList();
+  // Exclude TWIC, subscribed books, folders, and the system-managed My Likes.
+  final owned = manualLibrarySaveTargets(all);
   owned.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
   return owned.take(3).toList();
 });

--- a/lib/screens/library/utils/load_saved_analysis.dart
+++ b/lib/screens/library/utils/load_saved_analysis.dart
@@ -141,6 +141,7 @@ SavedAnalysisData createSavedAnalysisData(SavedAnalysis analysis) {
     lastViewedPosition: analysis.lastViewedPosition,
     title: analysis.title,
     folderId: analysis.folderId,
+    tags: analysis.tags,
   );
 }
 

--- a/lib/screens/library/widgets/add_to_folder_sheet.dart
+++ b/lib/screens/library/widgets/add_to_folder_sheet.dart
@@ -204,12 +204,7 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
     final isPremium = ref.read(subscriptionProvider).isSubscribed;
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
-      final ownedBookCount =
-          folders
-              .where(
-                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
-              )
-              .length;
+      final ownedBookCount = manualLibrarySaveTargets(folders).length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -406,10 +401,13 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
     final rootFolders = ref.watch(rootLibraryFoldersProvider);
     final allFolders =
         ref.watch(combinedLibraryFoldersProvider).valueOrNull ?? [];
+    final manualSaveFolders = manualLibrarySaveTargets(allFolders);
     final selectedFolders =
-        allFolders
-            .where((f) => _selectedFolderIds.contains(f.id) && f.isDatabase)
+        manualSaveFolders
+            .where((f) => _selectedFolderIds.contains(f.id))
             .toList();
+    final visibleRootFolders =
+        rootFolders.where(isManualLibrarySaveTarget).toList();
 
     return Material(
       type: MaterialType.transparency,
@@ -441,7 +439,7 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
               child: IgnorePointer(
                 ignoring: _isSaving,
                 child:
-                    rootFolders.isEmpty
+                    visibleRootFolders.isEmpty
                         ? Padding(
                           padding: EdgeInsets.all(24.sp),
                           child: Text(
@@ -457,9 +455,9 @@ class _AddToFolderPageState extends ConsumerState<_AddToFolderPage> {
                         : ListView.builder(
                           shrinkWrap: true,
                           padding: EdgeInsets.symmetric(horizontal: 16.w),
-                          itemCount: rootFolders.length,
+                          itemCount: visibleRootFolders.length,
                           itemBuilder: (context, index) {
-                            final folder = rootFolders[index];
+                            final folder = visibleRootFolders[index];
                             return _ExpandableFolderTile(
                               folder: folder,
                               isSelected: _selectedFolderIds.contains(
@@ -682,7 +680,11 @@ class _ExpandableFolderTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final children = ref.watch(childLibraryFoldersProvider(folder.id));
+    final children =
+        ref
+            .watch(childLibraryFoldersProvider(folder.id))
+            .where(isManualLibrarySaveTarget)
+            .toList();
     final hasChildren = children.isNotEmpty;
 
     return Column(
@@ -782,10 +784,12 @@ class _FolderSelectionTile extends StatelessWidget {
                   : (folder.parentId == null
                       ? Icons.folder_rounded
                       : Icons.folder_open_rounded),
-              color: folder.isLikedGames
-                  ? context.colors.danger
-                  : context.colors.textPrimary
-                      .withValues(alpha: isSmall ? 0.6 : 1.0),
+              color:
+                  folder.isLikedGames
+                      ? context.colors.danger
+                      : context.colors.textPrimary.withValues(
+                        alpha: isSmall ? 0.6 : 1.0,
+                      ),
               size: isSmall ? 20.sp : 24.sp,
             ),
             SizedBox(width: 12.w),

--- a/lib/screens/library/widgets/bulk_add_to_folder_sheet.dart
+++ b/lib/screens/library/widgets/bulk_add_to_folder_sheet.dart
@@ -207,12 +207,7 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
     final isPremium = ref.read(subscriptionProvider).isSubscribed;
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
-      final ownedBookCount =
-          folders
-              .where(
-                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
-              )
-              .length;
+      final ownedBookCount = manualLibrarySaveTargets(folders).length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -571,12 +566,9 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
         foldersAsync.whenOrNull(
           data:
               (folders) =>
-                  folders
-                      .where(
-                        (f) =>
-                            _selectedFolderIds.contains(f.id) && f.isDatabase,
-                      )
-                      .toList(),
+                  manualLibrarySaveTargets(
+                    folders,
+                  ).where((f) => _selectedFolderIds.contains(f.id)).toList(),
         ) ??
         [];
 
@@ -615,7 +607,8 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                 ignoring: _isSaving,
                 child: foldersAsync.when(
                   data: (folders) {
-                    if (folders.isEmpty) {
+                    final writable = manualLibrarySaveTargets(folders);
+                    if (writable.isEmpty) {
                       return Padding(
                         padding: EdgeInsets.all(20.sp),
                         child: Text(
@@ -629,7 +622,7 @@ class _BulkAddToFolderPageState extends ConsumerState<_BulkAddToFolderPage> {
                         ),
                       );
                     }
-                    final sortedFolders = _sortFoldersHierarchically(folders);
+                    final sortedFolders = _sortFoldersHierarchically(writable);
                     return ListView.separated(
                       shrinkWrap: true,
                       padding: EdgeInsets.symmetric(horizontal: 16.w),

--- a/lib/screens/library/widgets/folder_card.dart
+++ b/lib/screens/library/widgets/folder_card.dart
@@ -63,6 +63,9 @@ class FolderCard extends ConsumerWidget {
   }
 
   Widget _buildCompactCard(BuildContext context) {
+    final isLiked = folder.isLikedGames;
+    final displayName = isLiked ? 'My Likes' : folder.name;
+
     return GestureDetector(
       onTap: onTap ?? () => _navigateToFolder(context),
       child: Container(
@@ -85,22 +88,29 @@ class FolderCard extends ConsumerWidget {
                   borderRadius: BorderRadius.circular(10.br),
                 ),
                 child: Center(
-                  child: SvgWidget(
-                    SvgAsset.folderOutline,
-                    width: 18.sp,
-                    height: 18.sp,
-                    colorFilter:
-                        context.isLightTheme
-                            ? ColorFilter.mode(
-                              context.colors.iconPrimary,
-                              BlendMode.srcIn,
-                            )
-                            : null,
-                  ),
+                  child:
+                      isLiked
+                          ? Icon(
+                            Icons.favorite_rounded,
+                            size: 18.sp,
+                            color: context.colors.danger,
+                          )
+                          : SvgWidget(
+                            SvgAsset.folderOutline,
+                            width: 18.sp,
+                            height: 18.sp,
+                            colorFilter:
+                                context.isLightTheme
+                                    ? ColorFilter.mode(
+                                      context.colors.iconPrimary,
+                                      BlendMode.srcIn,
+                                    )
+                                    : null,
+                          ),
                 ),
               ),
               Text(
-                folder.name,
+                displayName,
                 style: AppTypography.textSmMedium.copyWith(
                   color: context.colors.textPrimary,
                 ),
@@ -119,6 +129,7 @@ class FolderCard extends ConsumerWidget {
     final isLiked = folder.isLikedGames;
     // Synthetic / special, permanent collections — no rename/delete/share menu.
     final isProtected = isTwic || isLiked;
+    final displayName = isLiked ? 'My Likes' : folder.name;
 
     // CSS specs: featured = 64x64 icon, ~18px radius; regular = 36x36 icon, 10px radius
     final iconSize = isFeatured ? 64.0.h : 36.0.h;
@@ -213,23 +224,25 @@ class FolderCard extends ConsumerWidget {
                     borderRadius: BorderRadius.circular(iconRadius),
                   ),
                   child: Center(
-                    child: isLiked
-                        ? Icon(
-                            Icons.favorite,
-                            size: svgSize,
-                            color: context.colors.danger,
-                          )
-                        : SvgWidget(
-                            SvgAsset.folderOutline,
-                            width: svgSize,
-                            height: svgSize,
-                            colorFilter: context.isLightTheme
-                                ? ColorFilter.mode(
-                                    context.colors.iconPrimary,
-                                    BlendMode.srcIn,
-                                  )
-                                : null,
-                          ),
+                    child:
+                        isLiked
+                            ? Icon(
+                              Icons.favorite,
+                              size: svgSize,
+                              color: context.colors.danger,
+                            )
+                            : SvgWidget(
+                              SvgAsset.folderOutline,
+                              width: svgSize,
+                              height: svgSize,
+                              colorFilter:
+                                  context.isLightTheme
+                                      ? ColorFilter.mode(
+                                        context.colors.iconPrimary,
+                                        BlendMode.srcIn,
+                                      )
+                                      : null,
+                            ),
                   ),
                 ),
                 // Shared link badge for subscribed books
@@ -269,7 +282,7 @@ class FolderCard extends ConsumerWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    folder.name,
+                    displayName,
                     style: AppTypography.textSmMedium.copyWith(
                       color: context.colors.textPrimary,
                     ),

--- a/lib/screens/library/widgets/import_pgn_to_folder_sheet.dart
+++ b/lib/screens/library/widgets/import_pgn_to_folder_sheet.dart
@@ -173,12 +173,7 @@ class _ImportPgnToFolderPageState
     final isPremium = ref.read(subscriptionProvider).isSubscribed;
     if (!isPremium) {
       final folders = await ref.read(libraryFoldersStreamProvider.future);
-      final ownedBookCount =
-          folders
-              .where(
-                (f) => !f.isSubscribed && f.id != kTwicBookId && f.isDatabase,
-              )
-              .length;
+      final ownedBookCount = manualLibrarySaveTargets(folders).length;
       if (ownedBookCount >= kFreeBookCreationLimit) {
         if (!mounted) return;
         await showPremiumPaywallSheet(context: context);
@@ -392,7 +387,7 @@ class _ImportPgnToFolderPageState
               (folders) =>
                   folders
                       .where((f) => _selectedFolderIds.contains(f.id))
-                      .where((f) => !f.isSubscribed && f.isDatabase)
+                      .where(isManualLibrarySaveTarget)
                       .toList(),
         ) ??
         [];
@@ -434,11 +429,8 @@ class _ImportPgnToFolderPageState
                 ignoring: _isSaving,
                 child: foldersAsync.when(
                   data: (folders) {
-                    // Only owned (not subscribed) folders can receive writes.
-                    final writable =
-                        folders
-                            .where((f) => !f.isSubscribed && f.isDatabase)
-                            .toList();
+                    // Only normal user databases can receive manual imports.
+                    final writable = manualLibrarySaveTargets(folders);
                     if (writable.isEmpty) {
                       return Padding(
                         padding: EdgeInsets.all(20.sp),

--- a/test/library_folder_node_type_test.dart
+++ b/test/library_folder_node_type_test.dart
@@ -1,4 +1,5 @@
 import 'package:chessever2/repository/library/models/library_folder.dart';
+import 'package:chessever2/screens/library/providers/library_folders_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Map<String, dynamic> _folderJson({String? nodeType}) {
@@ -41,5 +42,28 @@ void main() {
     final renamed = folder.copyWith(name: 'Openings');
     expect(renamed.nodeType, LibraryFolder.nodeTypeFolder);
     expect(renamed.isDatabase, isFalse);
+  });
+
+  test('manual save targets exclude system and non-database folders', () {
+    final normal = LibraryFolder.fromSupabase(_folderJson());
+    final liked = LibraryFolder.fromSupabase({
+      ..._folderJson(),
+      'id': 'liked-1',
+      'name': 'My Likes',
+      'is_liked_games': true,
+    });
+    final twic = normal.copyWith(id: kTwicBookId);
+    final subscribed = normal.copyWith(id: 'subscribed-1', isSubscribed: true);
+    final folderNode = normal.copyWith(
+      id: 'folder-node-1',
+      nodeType: LibraryFolder.nodeTypeFolder,
+    );
+
+    expect(isManualLibrarySaveTarget(normal), isTrue);
+    expect(isManualLibrarySaveTarget(liked), isFalse);
+    expect(isManualLibrarySaveTarget(twic), isFalse);
+    expect(isManualLibrarySaveTarget(subscribed), isFalse);
+    expect(isManualLibrarySaveTarget(folderNode), isFalse);
+    expect(manualLibrarySaveTargets([normal, liked, twic]), [normal]);
   });
 }


### PR DESCRIPTION
## Summary
- Rename the special liked-games database presentation to **My Likes** with a heart icon and no manual add/rename controls.
- Add premium-gated search/filter/sort/tag/export tools for My Likes, with export moved into the 3-dot menu.
- Add official personal tags to the Save Analysis / edit sheet and persist them through saved analysis reload/update flows.
- Preserve My Likes as an automatic like/unlike database by disabling swipe-delete inside that protected view.
- Update the board save action icon toward the save-sheet/bookmark style.

## Verification
- `dart format --set-exit-if-changed lib/repository/library/library_repository.dart lib/screens/chessboard/chess_board_screen_new.dart lib/screens/chessboard/provider/chess_board_screen_provider_new.dart lib/screens/chessboard/widgets/save_analysis_sheet.dart lib/screens/library/folder_contents_screen.dart lib/screens/library/utils/load_saved_analysis.dart lib/screens/library/widgets/folder_card.dart`
- `flutter analyze --no-pub lib/screens/library/folder_contents_screen.dart lib/screens/library/widgets/folder_card.dart lib/repository/library/library_repository.dart lib/screens/chessboard/widgets/save_analysis_sheet.dart lib/screens/chessboard/provider/chess_board_screen_provider_new.dart lib/screens/library/utils/load_saved_analysis.dart lib/screens/chessboard/chess_board_screen_new.dart` — exits 0; reports existing warnings/infos in `chess_board_screen_new.dart` only.
- `flutter test --no-pub` — not clean on this branch; observed existing unrelated failures in `gamebase_explorer_filter_paywall_test.dart`, `notation_token_builder_test.dart`, and `widget_test.dart`.

## QA notes for Berkay
- Open Library -> My Likes: title should show **My Likes**, heart icon, no plus/add and no rename/edit action.
- Free user: tapping search/tag/filter/export should show paywall; search should not filter the list.
- Premium user: search, tag chips, sort/filter, and export should work inside My Likes.
- Like/unlike a game from board: membership should still be automatic; My Likes entries should not be manually swipe-deleted.
- Save Analysis/edit saved game: Tags row appears under Game Details, supports the official tags, and persists after reopening the saved analysis.
