### PR TITLE
fix: show opening game count cue on player Games tab

### DIFF
--- a/lib/screens/player_profile/player_profile_screen.dart
+++ b/lib/screens/player_profile/player_profile_screen.dart
@@ -104,6 +104,7 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
   late PlayerProfileDataSource _currentDataSource;
   String? _currentGamebasePlayerId;
   bool _didPrefetchExplorerRoot = false;
+  int? _gamesTabCueCount;
 
   bool _showHeaderExtras = true;
   double _scrollAccumulator = 0.0;
@@ -182,13 +183,17 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
         _currentGamebasePlayerId = normalizedId;
       }
       _currentDataSource = source;
+      _gamesTabCueCount = null;
     });
   }
 
   void _handleTabSelection(int index) {
     HapticFeedbackService.buttonPress();
-    ref.read(selectedPlayerProfileTabProvider.notifier).state =
-        PlayerProfileTab.values[index];
+    final nextTab = PlayerProfileTab.values[index];
+    ref.read(selectedPlayerProfileTabProvider.notifier).state = nextTab;
+    if (nextTab == PlayerProfileTab.games && _gamesTabCueCount != null) {
+      setState(() => _gamesTabCueCount = null);
+    }
     _pageController.animateToPage(
       index,
       duration: const Duration(milliseconds: 300),
@@ -197,10 +202,13 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
   }
 
   void _handlePageChanged(int index) {
+    final nextTab = PlayerProfileTab.values[index];
     final currentTab = ref.read(selectedPlayerProfileTabProvider);
     if (PlayerProfileTab.values.indexOf(currentTab) != index) {
-      ref.read(selectedPlayerProfileTabProvider.notifier).state =
-          PlayerProfileTab.values[index];
+      ref.read(selectedPlayerProfileTabProvider.notifier).state = nextTab;
+    }
+    if (nextTab == PlayerProfileTab.games && _gamesTabCueCount != null) {
+      setState(() => _gamesTabCueCount = null);
     }
   }
 
@@ -218,6 +226,7 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
     GameOnlineFilter? online,
     PlayerResultFilter? playerResultFilter,
     String? searchQuery,
+    int? gamesTabCueCount,
   }) async {
     final allowed = await requireFullAuthGuard(context);
     if (!allowed) return;
@@ -253,9 +262,19 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
     if (newActiveCount > 1) {
       final isPremium = ref.read(subscriptionProvider).isSubscribed;
       if (!isPremium) {
+        if (!mounted) return;
         final subscribed = await requirePremiumGuard(context, ref);
         if (!subscribed || !mounted) return;
       }
+    }
+
+    if (gamesTabCueCount != null || eco == GameEcoFilter.all) {
+      if (!mounted) return;
+      setState(() {
+        _gamesTabCueCount = gamesTabCueCount != null && gamesTabCueCount > 0
+            ? gamesTabCueCount
+            : null;
+      });
     }
 
     // Apply the filter
@@ -803,12 +822,22 @@ countryCode,
       tablet: 32.sp,
     );
 
+    final tabOptions = PlayerProfileTab.values.map((tab) {
+      if (tab == PlayerProfileTab.games &&
+          selectedTab != PlayerProfileTab.games &&
+          _gamesTabCueCount != null &&
+          _gamesTabCueCount! > 0) {
+        return 'Games ${formatCompactCount(_gamesTabCueCount!)}';
+      }
+      return playerProfileTabNames[tab]!;
+    }).toList(growable: false);
+
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
       child: SegmentedSwitcher(
         backgroundColor: context.colors.popup,
         selectedBackgroundColor: context.colors.popup,
-        options: playerProfileTabNames.values.toList(),
+        options: tabOptions,
         initialSelection: PlayerProfileTab.values.indexOf(selectedTab),
         currentSelection: PlayerProfileTab.values.indexOf(selectedTab),
         onSelectionChanged: _handleTabSelection,

--- a/lib/screens/player_profile/tabs/player_about_tab.dart
+++ b/lib/screens/player_profile/tabs/player_about_tab.dart
@@ -36,6 +36,7 @@ typedef PlayerGamesOpenCallback =
       GameOnlineFilter? online,
       PlayerResultFilter? playerResultFilter,
       String? searchQuery,
+      int? gamesTabCueCount,
     });
 
 /// About tab showing comprehensive player information and analytics
@@ -2352,8 +2353,8 @@ class _OpeningRepertoireSectionState
     final isCurrentlySelected = _isOpeningSelected(opening);
 
     if (isCurrentlySelected) {
-      // Deselect: clear just the eco filter
-      widget.onOpenGames?.call(eco: GameEcoFilter.all);
+      // Deselect: clear just the eco filter and remove the Games-tab cue.
+      widget.onOpenGames?.call(eco: GameEcoFilter.all, gamesTabCueCount: 0);
     } else {
       // Select: apply the ECO filter only (no searchQuery — ECO is the unique key)
       final eco = opening.eco.trim();
@@ -2370,6 +2371,7 @@ class _OpeningRepertoireSectionState
       widget.onOpenGames?.call(
         eco: hasEco ? GameEcoFilter.forCode(eco) : null,
         color: colorToSet,
+        gamesTabCueCount: opening.count,
       );
     }
   }

--- a/lib/screens/player_profile/tabs/player_about_tab.dart
+++ b/lib/screens/player_profile/tabs/player_about_tab.dart
@@ -970,7 +970,13 @@ class _PlayerHeaderSectionState extends ConsumerState<_PlayerHeaderSection> {
                                     GameTimeControlFilter.classical
                                 ? GameTimeControlFilter.all
                                 : GameTimeControlFilter.classical;
-                        widget.onOpenGames?.call(timeControl: newTimeControl);
+                        widget.onOpenGames?.call(
+                          timeControl: newTimeControl,
+                          gamesTabCueCount:
+                              newTimeControl == GameTimeControlFilter.classical
+                                  ? (widget.profileData?.classicalGames ?? 0)
+                                  : 0,
+                        );
                       },
                     ),
                   ),
@@ -988,7 +994,13 @@ class _PlayerHeaderSectionState extends ConsumerState<_PlayerHeaderSection> {
                             currentTimeControl == GameTimeControlFilter.rapid
                                 ? GameTimeControlFilter.all
                                 : GameTimeControlFilter.rapid;
-                        widget.onOpenGames?.call(timeControl: newTimeControl);
+                        widget.onOpenGames?.call(
+                          timeControl: newTimeControl,
+                          gamesTabCueCount:
+                              newTimeControl == GameTimeControlFilter.rapid
+                                  ? (widget.profileData?.rapidGames ?? 0)
+                                  : 0,
+                        );
                       },
                     ),
                   ),
@@ -1006,7 +1018,13 @@ class _PlayerHeaderSectionState extends ConsumerState<_PlayerHeaderSection> {
                             currentTimeControl == GameTimeControlFilter.blitz
                                 ? GameTimeControlFilter.all
                                 : GameTimeControlFilter.blitz;
-                        widget.onOpenGames?.call(timeControl: newTimeControl);
+                        widget.onOpenGames?.call(
+                          timeControl: newTimeControl,
+                          gamesTabCueCount:
+                              newTimeControl == GameTimeControlFilter.blitz
+                                  ? (widget.profileData?.blitzGames ?? 0)
+                                  : 0,
+                        );
                       },
                     ),
                   ),
@@ -1333,7 +1351,12 @@ class _OverallStatsSection extends StatelessWidget {
                           currentResultFilter == PlayerResultFilter.win
                               ? PlayerResultFilter.all
                               : PlayerResultFilter.win;
-                      onOpenGames?.call(playerResultFilter: newFilter);
+                      onOpenGames?.call(
+                        playerResultFilter: newFilter,
+                        gamesTabCueCount: newFilter == PlayerResultFilter.win
+                            ? resultStats.wins
+                            : 0,
+                      );
                     },
                   ),
                   SizedBox(width: 12.w),
@@ -1349,7 +1372,12 @@ class _OverallStatsSection extends StatelessWidget {
                           currentResultFilter == PlayerResultFilter.draw
                               ? PlayerResultFilter.all
                               : PlayerResultFilter.draw;
-                      onOpenGames?.call(playerResultFilter: newFilter);
+                      onOpenGames?.call(
+                        playerResultFilter: newFilter,
+                        gamesTabCueCount: newFilter == PlayerResultFilter.draw
+                            ? resultStats.draws
+                            : 0,
+                      );
                     },
                   ),
                   SizedBox(width: 12.w),
@@ -1365,7 +1393,12 @@ class _OverallStatsSection extends StatelessWidget {
                           currentResultFilter == PlayerResultFilter.loss
                               ? PlayerResultFilter.all
                               : PlayerResultFilter.loss;
-                      onOpenGames?.call(playerResultFilter: newFilter);
+                      onOpenGames?.call(
+                        playerResultFilter: newFilter,
+                        gamesTabCueCount: newFilter == PlayerResultFilter.loss
+                            ? resultStats.losses
+                            : 0,
+                      );
                     },
                   ),
                 ],
@@ -1652,6 +1685,9 @@ class _ColorPerformanceSection extends StatelessWidget {
                   onOpenGames?.call(
                     color: newFilter,
                     eco: shouldClearOpening ? GameEcoFilter.all : null,
+                    gamesTabCueCount: newFilter == GameColorFilter.white
+                        ? colorStats.whiteGames
+                        : 0,
                   );
                 },
               ),
@@ -1679,6 +1715,9 @@ class _ColorPerformanceSection extends StatelessWidget {
                   onOpenGames?.call(
                     color: newFilter,
                     eco: shouldClearOpening ? GameEcoFilter.all : null,
+                    gamesTabCueCount: newFilter == GameColorFilter.black
+                        ? colorStats.blackGames
+                        : 0,
                   );
                 },
               ),
@@ -2327,6 +2366,15 @@ class _OpeningRepertoireSectionState
     return _filteredOpenings.map((o) => o.eco.toUpperCase()).toSet();
   }
 
+  int _openingCountForFilter(_OpeningRepertoireFilter filter) {
+    final openings = switch (filter) {
+      _OpeningRepertoireFilter.white => widget.baseOpeningStatsWhite,
+      _OpeningRepertoireFilter.black => widget.baseOpeningStatsBlack,
+      _OpeningRepertoireFilter.all => widget.baseOpeningStats,
+    };
+    return openings.fold<int>(0, (sum, opening) => sum + opening.count);
+  }
+
   /// Check if an opening is active (has games matching current filters)
   bool _isOpeningActive(OpeningStatistic opening) {
     if (!widget.hasNonEcoFilters) return true;
@@ -2418,6 +2466,10 @@ class _OpeningRepertoireSectionState
     widget.onOpenGames?.call(
       color: newColorFilter,
       eco: shouldClearOpening ? GameEcoFilter.all : null,
+      gamesTabCueCount:
+          newFilter == _OpeningRepertoireFilter.all
+              ? 0
+              : _openingCountForFilter(newFilter),
     );
   }
 


### PR DESCRIPTION
## Summary
- Shows a temporary game-count cue on the player profile Games tab after selecting an opening from About, e.g. `Games 56`.
- Clears the cue when the Games tab is opened or the opening filter is removed.
- Keeps the existing in-Games filter/count UI as the primary detail view.

## Validation
- `flutter analyze lib/screens/player_profile/player_profile_screen.dart lib/screens/player_profile/tabs/player_about_tab.dart`
- `git diff --check`

Note: `dart format --output=none --set-exit-if-changed` on these large legacy files reports formatter changes outside this narrow patch; broad formatter churn was not committed.