### PR TITLE
feat(pip): native move SFX + premium gating + server-synced PiP setting

### DIFF
--- a/android/app/src/main/kotlin/com/chessEver/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/chessEver/app/MainActivity.kt
@@ -10,6 +10,8 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.media.AudioAttributes
+import android.media.SoundPool
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -32,6 +34,8 @@ import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
 import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 import java.time.Instant
 import java.time.LocalDateTime
@@ -47,6 +51,12 @@ class MainActivity : FlutterActivity() {
   private var pollRunnable: Runnable? = null
   private var clockRunnable: Runnable? = null
   private var activePollCall: Call? = null
+  // Native move SFX for PiP (mirrors iOS). Flutter SFX is suppressed while in PiP
+  // so these don't double up; capture vs move chosen by FEN piece-count drop.
+  private var soundPool: SoundPool? = null
+  private var moveSoundId = 0
+  private var captureSoundId = 0
+  private var lastSoundedMove: String? = null
 
   override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
     super.configureFlutterEngine(flutterEngine)
@@ -60,6 +70,8 @@ class MainActivity : FlutterActivity() {
             clearPipState()
           } else {
             pipPayload = args.toMutableMap()
+            // Foreground baseline so the first PiP poll doesn't replay this move.
+            if (!isCurrentlyInPip()) lastSoundedMove = args["lastMoveUci"] as? String
             pipOverlay?.payload = pipPayload
             pipOverlay?.invalidate()
             if (isCurrentlyInPip()) {
@@ -76,6 +88,8 @@ class MainActivity : FlutterActivity() {
             clearPipState()
           } else {
             mergePayload(args)
+            // Foreground pushes update the baseline; Flutter handles foreground SFX.
+            if (!isCurrentlyInPip()) lastSoundedMove = args["lastMoveUci"] as? String
             pipOverlay?.payload = pipPayload
             pipOverlay?.invalidate()
             if (isCurrentlyInPip()) {
@@ -97,6 +111,52 @@ class MainActivity : FlutterActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    initSounds()
+  }
+
+  private fun initSounds() {
+    if (soundPool != null) return
+    val attrs = AudioAttributes.Builder()
+      .setUsage(AudioAttributes.USAGE_MEDIA)
+      .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+      .build()
+    val pool = SoundPool.Builder().setMaxStreams(4).setAudioAttributes(attrs).build()
+    extractAsset("flutter_assets/assets/sfx/piece_move.wav", "pip_move.wav")?.let {
+      moveSoundId = pool.load(it, 1)
+    }
+    extractAsset("flutter_assets/assets/sfx/piece_takeover.wav", "pip_capture.wav")?.let {
+      captureSoundId = pool.load(it, 1)
+    }
+    soundPool = pool
+  }
+
+  // .wav assets in flutter_assets may be stored compressed, so SoundPool can't
+  // open them via AssetFileDescriptor — copy to cache once and load from file.
+  private fun extractAsset(assetPath: String, outName: String): String? {
+    return try {
+      val outFile = File(cacheDir, outName)
+      if (!outFile.exists() || outFile.length() == 0L) {
+        assets.open(assetPath).use { input ->
+          FileOutputStream(outFile).use { output -> input.copyTo(output) }
+        }
+      }
+      outFile.absolutePath
+    } catch (e: Exception) {
+      Log.w("ChessPip", "Failed to extract $assetPath: $e")
+      null
+    }
+  }
+
+  private fun playPipMoveSound(captured: Boolean) {
+    val pool = soundPool ?: return
+    val id = if (captured && captureSoundId != 0) captureSoundId else moveSoundId
+    if (id == 0) return
+    pool.play(id, 1f, 1f, 1, 0, 1f)
+  }
+
+  private fun fenPieceCount(fen: String?): Int {
+    val placement = fen?.substringBefore(' ') ?: return 0
+    return placement.count { it.isLetter() }
   }
 
   override fun onUserLeaveHint() {
@@ -127,6 +187,8 @@ class MainActivity : FlutterActivity() {
   override fun onDestroy() {
     stopClockTicker()
     stopNativePolling()
+    soundPool?.release()
+    soundPool = null
     super.onDestroy()
   }
 
@@ -311,6 +373,9 @@ class MainActivity : FlutterActivity() {
     // Frozen on an earlier move: keep the viewed position, ignore newer live data.
     if (payload["followLive"] == false) return
 
+    val previousMove = (payload["lastMoveUci"] ?: payload["lastMove"]) as? String
+    val previousFen = payload["fen"] as? String
+
     if (row.has("fen") && !row.isNull("fen")) {
       row.optString("fen").takeIf { it.isNotBlank() }?.let { payload["fen"] = it }
     }
@@ -341,6 +406,14 @@ class MainActivity : FlutterActivity() {
 
     pipOverlay?.payload = payload
     pipOverlay?.invalidate()
+
+    // Native move SFX while in PiP (Flutter SFX is suppressed during PiP).
+    val newMove = payload["lastMoveUci"] as? String
+    if (isCurrentlyInPip() && !newMove.isNullOrBlank() &&
+        newMove != previousMove && newMove != lastSoundedMove) {
+      lastSoundedMove = newMove
+      playPipMoveSound(fenPieceCount(payload["fen"] as? String) < fenPieceCount(previousFen))
+    }
   }
 
   private fun formatClock(seconds: Int): String {

--- a/ios/Runner/ChessPipController.swift
+++ b/ios/Runner/ChessPipController.swift
@@ -19,6 +19,11 @@ final class ChessPipController: NSObject {
   // 720x720 board when content changed or PiP is actually visible (ticking clock).
   private var cachedImage: CGImage?
   private var renderDirty = true
+  // Native move SFX for PiP: Dart/SoLoud is suspended in the background, so the
+  // poll plays these directly when a new move arrives while PiP is active.
+  private var moveSoundPlayer: AVAudioPlayer?
+  private var captureSoundPlayer: AVAudioPlayer?
+  private var lastSoundedMove: String?
 
   private override init() {
     super.init()
@@ -47,6 +52,8 @@ final class ChessPipController: NSObject {
         }
         self.payload = args
         self.renderDirty = true
+        // Foreground baseline so the first PiP poll doesn't replay this move.
+        self.lastSoundedMove = args["lastMoveUci"] as? String
         self.prepareIfNeeded()
         self.enqueueFrame()
         // Keep the sample-buffer layer actively streaming while foreground so
@@ -67,6 +74,10 @@ final class ChessPipController: NSObject {
           return
         }
         self.mergePayload(args)
+        // Foreground pushes update the baseline; SoLoud handles foreground SFX.
+        if self.pipController?.isPictureInPictureActive != true {
+          self.lastSoundedMove = args["lastMoveUci"] as? String
+        }
         self.prepareIfNeeded()
         self.enqueueFrame()
         // Keep the sample-buffer layer actively streaming while foreground so
@@ -96,6 +107,7 @@ final class ChessPipController: NSObject {
     // Audio session must be active and use a category that supports PiP
     // BEFORE the controller is created and while we are still foreground.
     configureAudioSession()
+    preloadSounds()
 
     let layer = AVSampleBufferDisplayLayer()
     layer.videoGravity = .resizeAspect
@@ -183,6 +195,7 @@ final class ChessPipController: NSObject {
 
   private func clear() {
     payload = nil
+    lastSoundedMove = nil
     stopNativePolling()
     stopRenderLoop()
     if pipController?.isPictureInPictureActive == true {
@@ -223,6 +236,71 @@ final class ChessPipController: NSObject {
     } catch {
       print("[PiP] Failed to restore ambient audio session: \(error)")
     }
+  }
+
+  private func preloadSounds() {
+    if moveSoundPlayer == nil {
+      moveSoundPlayer = Self.loadSound("assets/sfx/piece_move.wav")
+    }
+    if captureSoundPlayer == nil {
+      captureSoundPlayer = Self.loadSound("assets/sfx/piece_takeover.wav")
+    }
+  }
+
+  private static func loadSound(_ assetSubpath: String) -> AVAudioPlayer? {
+    let candidates = [
+      "flutter_assets/\(assetSubpath)",
+      "Frameworks/App.framework/flutter_assets/\(assetSubpath)",
+    ]
+    var url: URL?
+    for candidate in candidates {
+      if let path = Bundle.main.path(forResource: candidate, ofType: nil) {
+        url = URL(fileURLWithPath: path)
+        break
+      }
+      if let resourcePath = Bundle.main.resourcePath {
+        let path = (resourcePath as NSString).appendingPathComponent(candidate)
+        if FileManager.default.fileExists(atPath: path) {
+          url = URL(fileURLWithPath: path)
+          break
+        }
+      }
+    }
+    guard let url, let player = try? AVAudioPlayer(contentsOf: url) else {
+      print("[PiP] Failed to load sound \(assetSubpath)")
+      return nil
+    }
+    player.prepareToPlay()
+    return player
+  }
+
+  // Play the move/capture SFX natively while in PiP (Dart/SoLoud is suspended in
+  // the background). Foreground keeps using SoLoud, so this is gated to PiP-active
+  // to avoid double sounds.
+  private func playMoveSoundIfNeeded(
+    previousMove: String?,
+    newMove: String?,
+    previousFen: String?,
+    newFen: String?
+  ) {
+    guard pipController?.isPictureInPictureActive == true else { return }
+    guard
+      let newMove,
+      !newMove.isEmpty,
+      newMove != previousMove,
+      newMove != lastSoundedMove
+    else { return }
+    lastSoundedMove = newMove
+
+    let captured = Self.pieceCount(newFen) < Self.pieceCount(previousFen)
+    let player = (captured ? captureSoundPlayer : moveSoundPlayer) ?? moveSoundPlayer
+    player?.currentTime = 0
+    player?.play()
+  }
+
+  private static func pieceCount(_ fen: String?) -> Int {
+    guard let placement = fen?.split(separator: " ").first else { return 0 }
+    return placement.reduce(0) { $0 + ($1.isLetter ? 1 : 0) }
   }
 
   private func enqueueFrame() {
@@ -445,6 +523,9 @@ final class ChessPipController: NSObject {
     // Frozen on an earlier move: keep the viewed position, ignore newer live data.
     if (payload["followLive"] as? Bool) == false { return }
 
+    let previousMove = payload["lastMoveUci"] as? String ?? payload["lastMove"] as? String
+    let previousFen = payload["fen"] as? String
+
     if let fen = row["fen"] as? String, !fen.isEmpty {
       payload["fen"] = fen
     }
@@ -470,6 +551,12 @@ final class ChessPipController: NSObject {
     self.payload = payload
     renderDirty = true
     enqueueFrame()
+    playMoveSoundIfNeeded(
+      previousMove: previousMove,
+      newMove: payload["lastMoveUci"] as? String,
+      previousFen: previousFen,
+      newFen: payload["fen"] as? String
+    )
   }
 
   private static func formatClock(seconds: Int) -> String {

--- a/lib/providers/board_settings_provider_new.dart
+++ b/lib/providers/board_settings_provider_new.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:chessever2/providers/pip_mode_provider.dart';
 import 'package:chessever2/repository/board_settings/models/board_settings_model.dart';
 import 'package:chessever2/repository/sqlite/app_database.dart';
 import 'package:chessever2/utils/board_customization_utils.dart';
@@ -35,6 +36,7 @@ class BoardSettingsNew {
         true, // Use chess piece symbols (♔♕♖♗♘) instead of letters
     this.showCoordinates = true,
     this.rawPgnMode = false,
+    this.pipModeIndex = 2, // PipMode.live (default)
   });
 
   /// DEPRECATED: Kept for backwards compatibility migration only
@@ -61,6 +63,13 @@ class BoardSettingsNew {
   /// Hide auto symbols (NAGs / Lichess annotations) and PGN comments in the
   /// move-list notation. Renders the moves as clean PGN.
   final bool rawPgnMode;
+
+  /// Picture-in-Picture eligibility, stored as the PipMode index
+  /// (0=off, 1=completed, 2=live, 3=both). Premium-gated.
+  final int pipModeIndex;
+
+  /// Picture-in-Picture mode as an enum.
+  PipMode get pipMode => PipModeInfo.fromIndex(pipModeIndex);
 
   /// Get the current piece set from chessground
   PieceSet get pieceSet => getPieceSetByIndex(pieceStyleIndex);
@@ -131,6 +140,7 @@ class BoardSettingsNew {
     bool? useFigurine,
     bool? showCoordinates,
     bool? rawPgnMode,
+    int? pipModeIndex,
   }) {
     return BoardSettingsNew(
       boardColorIndex: boardColorIndex ?? this.boardColorIndex,
@@ -144,6 +154,7 @@ class BoardSettingsNew {
       useFigurine: useFigurine ?? this.useFigurine,
       showCoordinates: showCoordinates ?? this.showCoordinates,
       rawPgnMode: rawPgnMode ?? this.rawPgnMode,
+      pipModeIndex: pipModeIndex ?? this.pipModeIndex,
     );
   }
 }
@@ -220,6 +231,9 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         useFigurine: model.useFigurine,
         showCoordinates: model.showCoordinates,
         rawPgnMode: model.rawPgnMode,
+        // pip_mode isn't part of BoardSettingsModel's mapper; read it straight
+        // from the row so we don't need to regenerate the dart_mappable code.
+        pipModeIndex: (response['pip_mode'] as int?) ?? 2,
       );
 
       // Cache locally
@@ -327,6 +341,15 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
     await _persist(newSettings);
   }
 
+  /// Set Picture-in-Picture mode (premium-gated by the caller).
+  Future<void> setPipMode(PipMode mode) async {
+    final currentState = state.valueOrNull ?? const BoardSettingsNew();
+    final newSettings = currentState.copyWith(pipModeIndex: mode.index);
+    debugPrint('📺 BoardSettings: PiP mode changed to ${mode.label}');
+    state = AsyncValue.data(newSettings);
+    await _persist(newSettings);
+  }
+
   /// Toggle figurine notation (chess piece symbols instead of letters)
   Future<void> toggleFigurine(bool value) async {
     final currentState = state.valueOrNull ?? const BoardSettingsNew();
@@ -417,6 +440,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
           'use_figurine': settings.useFigurine,
           'show_coordinates': settings.showCoordinates,
           'raw_pgn_mode': settings.rawPgnMode,
+          'pip_mode': settings.pipModeIndex,
           'updated_at': DateTime.now().toUtc().toIso8601String(),
         },
         onConflict: 'user_id', // Specify conflict column
@@ -442,6 +466,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         'useFigurine': settings.useFigurine,
         'showCoordinates': settings.showCoordinates,
         'rawPgnMode': settings.rawPgnMode,
+        'pipModeIndex': settings.pipModeIndex,
       });
       await db.setString(_cacheKey, json);
       debugPrint('[BoardSettings] Cached settings locally');
@@ -483,6 +508,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         useFigurine: map['useFigurine'] as bool? ?? true,
         showCoordinates: map['showCoordinates'] as bool? ?? true,
         rawPgnMode: map['rawPgnMode'] as bool? ?? false,
+        pipModeIndex: map['pipModeIndex'] as int? ?? 2,
       );
       debugPrint('[BoardSettings] Loaded settings from cache');
       return settings;

--- a/lib/providers/pip_mode_provider.dart
+++ b/lib/providers/pip_mode_provider.dart
@@ -1,0 +1,22 @@
+/// Which games may pop out into Picture-in-Picture.
+///
+/// Persisted in board settings (`user_engine_settings.pip_mode`, synced) and
+/// premium-gated at the eligibility check + settings UI. Enum order is the
+/// stored integer: off=0, completed=1, live=2 (default), both=3.
+enum PipMode { off, completed, live, both }
+
+extension PipModeInfo on PipMode {
+  String get label => switch (this) {
+    PipMode.off => 'Off',
+    PipMode.completed => 'Completed',
+    PipMode.live => 'Live',
+    PipMode.both => 'Both',
+  };
+
+  static PipMode fromIndex(int? index) {
+    if (index == null || index < 0 || index >= PipMode.values.length) {
+      return PipMode.live; // default: live games only
+    }
+    return PipMode.values[index];
+  }
+}

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -50,6 +50,8 @@ import 'package:chessever2/repository/supabase/game/game_repository.dart';
 import 'package:chessever2/utils/audio_player_service.dart';
 import 'package:chessever2/utils/foreground_task_scheduler.dart';
 import 'package:chessever2/services/pip_service.dart';
+import 'package:chessever2/providers/pip_mode_provider.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 // import 'package:chessever2/utils/keyboard_animation_builder.dart'; // UNUSED: Removed with old dialog
 // import 'package:chessever2/providers/keyboard_total_height_provider.dart'; // UNUSED: Removed with old dialog
 import 'package:chessever2/utils/figurine_notation.dart';
@@ -1464,10 +1466,21 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
   }
 
   bool _isPipEligible(GamesTourModel game) {
-    if (kDebugMode) {
-      return true;
+    // PiP is a premium-only feature.
+    if (!ref.read(subscriptionProvider).isSubscribed) return false;
+    final mode =
+        ref.read(boardSettingsProviderNew).valueOrNull?.pipMode ?? PipMode.live;
+    switch (mode) {
+      case PipMode.off:
+        return false;
+      case PipMode.live:
+        return GameFilterHelper.isLiveNow(game);
+      case PipMode.completed:
+        return game.effectiveGameStatus.isFinished;
+      case PipMode.both:
+        return GameFilterHelper.isLiveNow(game) ||
+            game.effectiveGameStatus.isFinished;
     }
-    return GameFilterHelper.isLiveNow(game);
   }
 
   Map<String, dynamic> _buildPipPayload(

--- a/lib/screens/settings/widgets/board_settings_body.dart
+++ b/lib/screens/settings/widgets/board_settings_body.dart
@@ -1,6 +1,9 @@
 import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
 import 'package:chessever2/providers/board_settings_provider_new.dart';
+import 'package:chessever2/providers/pip_mode_provider.dart';
 import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:chessever2/screens/settings/widgets/settings_primitives.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -153,6 +156,73 @@ class BoardSettingsBody extends ConsumerWidget {
                 ),
                 onChanged: (value) {
                   trackPersist(boardNotifier.toggleSound(value));
+                },
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 18.h),
+
+        SettingCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    'Picture in Picture',
+                    style: AppTypography.textMdMedium.copyWith(
+                      color: context.colors.textPrimary,
+                      fontSize: 13.f,
+                    ),
+                  ),
+                  if (!ref.watch(subscriptionProvider).isSubscribed) ...[
+                    SizedBox(width: 8.w),
+                    Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 8.sp,
+                        vertical: 2.sp,
+                      ),
+                      decoration: BoxDecoration(
+                        color: kPrimaryColor.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(6.br),
+                        border: Border.all(
+                          color: kPrimaryColor.withValues(alpha: 0.3),
+                        ),
+                      ),
+                      child: Text(
+                        'PRO',
+                        style: AppTypography.textXsMedium.copyWith(
+                          color: kPrimaryColor,
+                          fontSize: 9.f,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              SizedBox(height: 4.h),
+              Text(
+                'Pop a mini board out when you leave the app. Choose which games can float.',
+                style: AppTypography.textSmRegular.copyWith(
+                  color: context.colors.textSecondary,
+                  fontSize: 11.f,
+                ),
+              ),
+              SizedBox(height: 14.h),
+              _PipModeSelector(
+                selected: boardSettings.pipMode,
+                onSelected: (mode) async {
+                  // Premium-gated: choosing any active mode by a free user opens
+                  // the paywall; "Off" is always allowed.
+                  if (mode != PipMode.off &&
+                      !ref.read(subscriptionProvider).isSubscribed) {
+                    final subscribed = await showPremiumPaywallSheet(
+                      context: context,
+                    );
+                    if (!subscribed) return;
+                  }
+                  trackPersist(boardNotifier.setPipMode(mode));
                 },
               ),
             ],
@@ -1244,6 +1314,102 @@ class _PieceSetGridItem extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PipModeSelector extends StatelessWidget {
+  const _PipModeSelector({required this.selected, required this.onSelected});
+
+  final PipMode selected;
+  final ValueChanged<PipMode> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(4.sp),
+      decoration: BoxDecoration(
+        color: context.colors.surfaceRecessed,
+        borderRadius: BorderRadius.circular(12.br),
+      ),
+      child: Row(
+        children: [
+          _buildOption(context, mode: PipMode.off, icon: Icons.block_rounded),
+          SizedBox(width: 4.w),
+          _buildOption(
+            context,
+            mode: PipMode.completed,
+            icon: Icons.flag_rounded,
+          ),
+          SizedBox(width: 4.w),
+          _buildOption(context, mode: PipMode.live, icon: Icons.sensors_rounded),
+          SizedBox(width: 4.w),
+          _buildOption(
+            context,
+            mode: PipMode.both,
+            icon: Icons.all_inclusive_rounded,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOption(
+    BuildContext context, {
+    required PipMode mode,
+    required IconData icon,
+  }) {
+    final isSelected = selected == mode;
+    return Expanded(
+      child: GestureDetector(
+        onTap: () => onSelected(mode),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: EdgeInsets.symmetric(vertical: 8.sp),
+          decoration: BoxDecoration(
+            color: isSelected
+                ? kPrimaryColor.withValues(alpha: 0.08)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(8.br),
+            border: Border.all(
+              color: isSelected ? kPrimaryColor : Colors.transparent,
+              width: isSelected ? 1.5 : 1.0,
+            ),
+            boxShadow: isSelected
+                ? [
+                    BoxShadow(
+                      color: kPrimaryColor.withValues(alpha: 0.18),
+                      blurRadius: 8,
+                      spreadRadius: 0,
+                    ),
+                  ]
+                : null,
+          ),
+          child: Column(
+            children: [
+              Icon(
+                icon,
+                color: isSelected
+                    ? context.colors.textPrimary
+                    : context.colors.textTertiary,
+                size: 20.ic,
+              ),
+              SizedBox(height: 4.h),
+              Text(
+                mode.label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.textXsMedium.copyWith(
+                  color: isSelected
+                      ? context.colors.textPrimary
+                      : context.colors.textTertiary,
+                  fontSize: 10.f,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/utils/audio_player_service.dart
+++ b/lib/utils/audio_player_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_soloud/flutter_soloud.dart';
+import 'package:chessever2/services/pip_service.dart';
 
 /// Sound effect types — used instead of raw AudioSource to avoid stale native
 /// handles after the SoLoud engine is torn down and reinitialized.
@@ -116,6 +117,10 @@ class AudioPlayerService with WidgetsBindingObserver {
   /// couples every sound to the slowest/previous native op and lets a single
   /// stalled init/recovery silence all subsequent moves.
   void playSound(SfxType type) {
+    // While in PiP the move SFX is played natively (iOS/Android) from the poll,
+    // so suppress the Flutter path to avoid double sounds. On iOS the Dart
+    // isolate is suspended in PiP anyway, making this a no-op there.
+    if (PipService.instance.isInPip) return;
     unawaited(_playWithRecovery(type));
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 19.4.4+1537
+version: 19.4.5+1538
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
Builds on the merged PiP work (#212).

## Changes
- **Native move SFX in PiP** (iOS + Android). Dart/SoLoud is suspended in the iOS background, so the native poll plays bundled `assets/sfx/*` on a new move. Android plays via `SoundPool`; Flutter SFX suppressed while `PipService.isInPip` to avoid doubling. Capture vs move from FEN piece-count drop.
- **iOS PiP start fixes**: hold `AVAudioSession.playback` while a board is armed (was `.ambient`, stomped by flutter_soloud) and stream the sample-buffer layer in the foreground so iOS can auto-start PiP.
- **PiP setting** (Off / Completed / Live / Both), default **Live**, in Board settings. Server-synced via `user_engine_settings.pip_mode` (additive migration already applied to prod, backward-compatible) + local cache.
- **Premium-gated**: PiP only arms when subscribed; settings selector shows a PRO badge and opens the paywall for free users on any non-Off choice.
- Version bump `19.4.5+1538`.

## Test
- Real iPhone (Simulator can't do sample-buffer PiP): premium account, live game, Home → PiP + move sounds.
- Android emulator API 26+: same.
- Free account: PiP card shows PRO badge → paywall on Live/Completed/Both; PiP never arms.
- Setting persists across restart + syncs across devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)