### PR TITLE
chore(pip): disable PiP + hide settings; walkthrough show-once

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -895,22 +895,19 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
   Future<void> _checkAndShowWalkthrough(BuildContext context) async {
     final prefs = ref.read(sharedPreferencesRepository);
     final dontShow = await prefs.getBool(_kWalkthroughDontShowKey) ?? false;
-    if (dontShow) return;
-
     final lastShownMs = await prefs.getInt(_kWalkthroughShownDateKey);
-    final now = DateTime.now();
 
-    bool shouldShow = false;
-    if (lastShownMs == null) {
-      shouldShow = true;
-    } else {
-      final lastShownDate = DateTime.fromMillisecondsSinceEpoch(lastShownMs);
-      if (now.difference(lastShownDate).inDays >= 7) {
-        shouldShow = true;
-      }
+    // Show each instruction once. Display step 1 only if it has never been seen
+    // and isn't opted out. Otherwise hand off to step 2 so any later unseen
+    // steps still appear — in order, one at a time (each self-gates on its key).
+    if (dontShow || lastShownMs != null) {
+      _requestSwitchViewsTutorial();
+      return;
     }
 
-    if (shouldShow && context.mounted) {
+    final now = DateTime.now();
+
+    if (context.mounted) {
       // Trigger local overlay instead of ShowcaseView
       setState(() {
         _showTutorialOverlay = true;
@@ -985,11 +982,9 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     final dontShow = await prefs.getBool(kLikeWalkthroughDontShowKey) ?? false;
     if (dontShow || !mounted) return;
 
+    // Show once: if it's ever been seen, don't show it again.
     final lastShownMs = await prefs.getInt(kLikeWalkthroughShownDateKey);
-    if (lastShownMs != null) {
-      final lastShown = DateTime.fromMillisecondsSinceEpoch(lastShownMs);
-      if (DateTime.now().difference(lastShown).inDays < 7) return;
-    }
+    if (lastShownMs != null) return;
     if (!mounted) return;
 
     _showLikeTutorial = true;
@@ -1466,7 +1461,11 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
   }
 
   bool _isPipEligible(GamesTourModel game) {
+    // PiP is temporarily disabled for everyone (the settings entry is hidden,
+    // see board_settings_body.dart). Remove this early return to re-enable.
+    return false;
     // PiP is a premium-only feature.
+    // ignore: dead_code
     if (!ref.read(subscriptionProvider).isSubscribed) return false;
     final mode =
         ref.read(boardSettingsProviderNew).valueOrNull?.pipMode ?? PipMode.live;
@@ -8455,16 +8454,12 @@ class _AnalysisSwipePanelsState extends ConsumerState<_AnalysisSwipePanels>
       return;
     }
 
-    // Respect the shared 7-day cadence — if the user already saw this
-    // teaching in the standalone gamebase explorer recently, don't nag
-    // them with it again in the chained flow.
+    // Show once: if this teaching has ever been seen (here or in the standalone
+    // gamebase explorer), skip it but still hand off to step 3.
     final lastShownMs = await prefs.getInt(kSwitchViewsWalkthroughShownDateKey);
     if (lastShownMs != null) {
-      final lastShown = DateTime.fromMillisecondsSinceEpoch(lastShownMs);
-      if (DateTime.now().difference(lastShown).inDays < 7) {
-        _requestLikeTutorial();
-        return;
-      }
+      _requestLikeTutorial();
+      return;
     }
     if (!mounted) return;
 

--- a/lib/screens/settings/widgets/board_settings_body.dart
+++ b/lib/screens/settings/widgets/board_settings_body.dart
@@ -1,9 +1,9 @@
 import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
 import 'package:chessever2/providers/board_settings_provider_new.dart';
-import 'package:chessever2/providers/pip_mode_provider.dart';
+// import 'package:chessever2/providers/pip_mode_provider.dart'; // PiP disabled
 import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
-import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
-import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
+// import 'package:chessever2/revenue_cat_service/subscribe_state.dart'; // PiP disabled
+// import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart'; // PiP disabled
 import 'package:chessever2/screens/settings/widgets/settings_primitives.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -163,6 +163,8 @@ class BoardSettingsBody extends ConsumerWidget {
         ),
         SizedBox(height: 18.h),
 
+        // Picture-in-Picture is temporarily disabled; settings entry hidden.
+        /*
         SettingCard(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -229,7 +231,7 @@ class BoardSettingsBody extends ConsumerWidget {
           ),
         ),
         SizedBox(height: 18.h),
-
+        */
         SettingCard(
           child: Row(
             children: [
@@ -1320,6 +1322,8 @@ class _PieceSetGridItem extends StatelessWidget {
   }
 }
 
+// Picture-in-Picture selector — hidden while PiP is disabled.
+/*
 class _PipModeSelector extends StatelessWidget {
   const _PipModeSelector({required this.selected, required this.onSelected});
 
@@ -1415,6 +1419,7 @@ class _PipModeSelector extends StatelessWidget {
     );
   }
 }
+*/
 
 class _ViewModeSelector extends StatelessWidget {
   const _ViewModeSelector({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 19.4.5+1538
+version: 19.5.0+1539
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
## Changes
- **PiP disabled for everyone**: `_isPipEligible` returns false (kill switch); the Picture-in-Picture settings card + `_PipModeSelector` are commented out, their imports disabled. Fully reversible (remove the early return + uncomment).
- **Walkthrough teaching → show-once**: the three board instructions (swipe → switch-views → like) now show once each if unseen, in order, no overlap; skipped steps forward to the next so later unseen steps still appear. Fixes the like teaching never reaching existing users. Reuses existing `*_shown_date` keys as the seen flag — no migration.
- `.env` asset re-commented in pubspec.
- Minor version bump → **19.5.0+1539**.

## Notes
- `pip_mode` column + native PiP code remain in place (just gated off) for a future re-enable.
- `flutter analyze` clean on both touched files (no new issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)