### PR TITLE
Fix subscription account settings UX

### DIFF
--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:chessever2/e2e/e2e_ids.dart';
+import 'package:chessever2/screens/settings/widgets/account_settings_body.dart';
 import 'package:chessever2/screens/settings/widgets/board_settings_body.dart';
 import 'package:chessever2/screens/settings/widgets/engine_settings_body.dart';
 import 'package:chessever2/screens/settings/widgets/notification_settings_body.dart';
@@ -8,12 +9,11 @@ import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/svg_asset.dart';
-import 'package:chessever2/widgets/hamburger_menu/hamburger_menu_dialogs.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-enum SettingsSection { board, engine, notification }
+enum SettingsSection { account, board, engine, notification }
 
 class SettingsPage extends ConsumerStatefulWidget {
   const SettingsPage({super.key, this.initiallyExpanded});
@@ -105,6 +105,18 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               ),
               children: [
                 _CollapsibleSection(
+                  title: 'Account Settings',
+                  leading: Icon(
+                    Icons.person_outline_rounded,
+                    color: context.colors.iconPrimary,
+                    size: 22.ic,
+                  ),
+                  expanded: _expanded == SettingsSection.account,
+                  onTap: () => _toggle(SettingsSection.account),
+                  child: const AccountSettingsBody(),
+                ),
+                SizedBox(height: 14.h),
+                _CollapsibleSection(
                   title: 'Board Settings',
                   leading: SvgWidget(
                     SvgAsset.boardSettings,
@@ -140,79 +152,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   onTap: () => _toggle(SettingsSection.notification),
                   child: NotificationSettingsBody(trackPersist: _trackPersist),
                 ),
-                SizedBox(height: 24.h),
-                _DeleteAccountRow(
-                  onTap: () {
-                    HapticFeedbackService.navigation();
-                    showDeleteAccountDialog(context);
-                  },
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _DeleteAccountRow extends StatelessWidget {
-  const _DeleteAccountRow({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final danger = context.colors.danger;
-    return Material(
-      color: context.colors.surface,
-      borderRadius: BorderRadius.circular(20.br),
-      child: InkWell(
-        key: e2eKey(E2eIds.settingsDeleteAccount),
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(20.br),
-        splashColor: danger.withValues(alpha: 0.08),
-        highlightColor: danger.withValues(alpha: 0.04),
-        child: Ink(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(20.br),
-            border: Border.all(color: danger.withValues(alpha: 0.45)),
-          ),
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16.sp, vertical: 14.sp),
-            child: Row(
-              children: [
-                Container(
-                  width: 40.w,
-                  height: 40.h,
-                  decoration: BoxDecoration(
-                    color: danger.withValues(alpha: 0.14),
-                    borderRadius: BorderRadius.circular(12.br),
-                    border: Border.all(color: danger.withValues(alpha: 0.35)),
-                  ),
-                  child: Icon(
-                    Icons.delete_forever_outlined,
-                    color: danger,
-                    size: 22.ic,
-                  ),
-                ),
-                SizedBox(width: 14.w),
-                Expanded(
-                  child: Text(
-                    'Delete Account',
-                    style: AppTypography.textMdMedium.copyWith(
-                      color: danger,
-                      fontSize: 14.f,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                SizedBox(width: 8.w),
-                Icon(
-                  Icons.chevron_right_rounded,
-                  color: danger,
-                  size: 24.ic,
-                ),
               ],
             ),
           ),
@@ -240,9 +179,10 @@ class _CollapsibleSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accent = kPrimaryColor;
-    final borderColor = expanded
-        ? accent.withValues(alpha: 0.45)
-        : context.colors.divider.withValues(alpha: 0.4);
+    final borderColor =
+        expanded
+            ? accent.withValues(alpha: 0.45)
+            : context.colors.divider.withValues(alpha: 0.4);
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 240),
@@ -251,23 +191,24 @@ class _CollapsibleSection extends StatelessWidget {
         color: context.colors.surface,
         borderRadius: BorderRadius.circular(20.br),
         border: Border.all(color: borderColor),
-        boxShadow: expanded
-            ? [
-                BoxShadow(
-                  color: accent.withValues(alpha: 0.18),
-                  blurRadius: 18,
-                  spreadRadius: -4,
-                  offset: const Offset(0, 6),
-                ),
-              ]
-            : context.isLightTheme
+        boxShadow:
+            expanded
                 ? [
-                    BoxShadow(
-                      color: context.colors.shadow,
-                      blurRadius: 8,
-                      offset: const Offset(0, 1),
-                    ),
-                  ]
+                  BoxShadow(
+                    color: accent.withValues(alpha: 0.18),
+                    blurRadius: 18,
+                    spreadRadius: -4,
+                    offset: const Offset(0, 6),
+                  ),
+                ]
+                : context.isLightTheme
+                ? [
+                  BoxShadow(
+                    color: context.colors.shadow,
+                    blurRadius: 8,
+                    offset: const Offset(0, 1),
+                  ),
+                ]
                 : null,
       ),
       child: ClipRRect(
@@ -293,14 +234,16 @@ class _CollapsibleSection extends StatelessWidget {
                         width: 40.w,
                         height: 40.h,
                         decoration: BoxDecoration(
-                          color: expanded
-                              ? accent.withValues(alpha: 0.16)
-                              : context.colors.surfaceRecessed,
+                          color:
+                              expanded
+                                  ? accent.withValues(alpha: 0.16)
+                                  : context.colors.surfaceRecessed,
                           borderRadius: BorderRadius.circular(12.br),
                           border: Border.all(
-                            color: expanded
-                                ? accent.withValues(alpha: 0.35)
-                                : Colors.transparent,
+                            color:
+                                expanded
+                                    ? accent.withValues(alpha: 0.35)
+                                    : Colors.transparent,
                           ),
                         ),
                         child: Center(
@@ -331,9 +274,8 @@ class _CollapsibleSection extends StatelessWidget {
                         turns: expanded ? 0.25 : 0.0,
                         child: Icon(
                           Icons.chevron_right_rounded,
-                          color: expanded
-                              ? accent
-                              : context.colors.textTertiary,
+                          color:
+                              expanded ? accent : context.colors.textTertiary,
                           size: 24.ic,
                         ),
                       ),

--- a/lib/screens/settings/widgets/account_settings_body.dart
+++ b/lib/screens/settings/widgets/account_settings_body.dart
@@ -1,0 +1,297 @@
+import 'dart:io';
+
+import 'package:app_settings/app_settings.dart';
+import 'package:chessever2/e2e/e2e_ids.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
+import 'package:chessever2/screens/settings/widgets/settings_primitives.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/haptic_feedback_service.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/auth/auth_upgrade_sheet.dart';
+import 'package:chessever2/widgets/hamburger_menu/hamburger_menu_dialogs.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class AccountSettingsBody extends ConsumerWidget {
+  const AccountSettingsBody({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final subscription = ref.watch(subscriptionProvider);
+    final statusText =
+        subscription.isLoading
+            ? 'Checking...'
+            : subscription.isSubscribed
+            ? 'PRO active'
+            : 'Free account';
+    final renewalText =
+        subscription.isSubscribed && !subscription.willRenew
+            ? 'Access remains active until the current period ends.'
+            : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SettingCard(
+          child: Row(
+            children: [
+              _IconTile(
+                icon: Icons.workspace_premium_outlined,
+                color:
+                    subscription.isSubscribed
+                        ? kPrimaryColor
+                        : context.colors.iconPrimary,
+              ),
+              SizedBox(width: 12.w),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Subscription Status',
+                      style: AppTypography.textMdMedium.copyWith(
+                        color: context.colors.textPrimary,
+                        fontSize: 13.f,
+                      ),
+                    ),
+                    SizedBox(height: 4.h),
+                    Text(
+                      renewalText ?? statusText,
+                      style: AppTypography.textSmRegular.copyWith(
+                        color:
+                            subscription.isSubscribed
+                                ? kPrimaryColor
+                                : context.colors.textSecondary,
+                        fontSize: 11.f,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 12.h),
+        _AccountActionRow(
+          icon: Icons.settings_outlined,
+          title: 'Manage Subscription',
+          subtitle:
+              subscription.isSubscribed
+                  ? 'Open Apple or Google subscription settings.'
+                  : 'Upgrade or manage your plan.',
+          onTap: () => _handleManageSubscription(context, ref, subscription),
+        ),
+        SizedBox(height: 10.h),
+        _AccountActionRow(
+          icon: Icons.restore_rounded,
+          title: 'Restore Purchases',
+          subtitle: 'Recover an existing App Store or Google Play purchase.',
+          onTap: () => _handleRestorePurchases(context, ref),
+        ),
+        SizedBox(height: 16.h),
+        _AccountActionRow(
+          key: e2eKey(E2eIds.settingsDeleteAccount),
+          icon: Icons.delete_forever_outlined,
+          title: 'Delete Account',
+          subtitle: 'Permanently remove your ChessEver account.',
+          destructive: true,
+          onTap: () {
+            HapticFeedbackService.navigation();
+            showDeleteAccountDialog(context);
+          },
+        ),
+      ],
+    );
+  }
+
+  Future<void> _handleManageSubscription(
+    BuildContext context,
+    WidgetRef ref,
+    SubscriptionState subscription,
+  ) async {
+    HapticFeedbackService.buttonPress();
+
+    if (!subscription.isSubscribed) {
+      final authOk = await requireFullAuthGuard(context);
+      if (!authOk || !context.mounted) return;
+      await showPremiumPaywallSheet(context: context);
+      return;
+    }
+
+    final opened = await _openSubscriptionManagement(
+      subscription.managementUrl,
+    );
+    if (!context.mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          opened
+              ? 'Opening subscription settings...'
+              : 'Could not open subscription settings. Please manage it from the App Store or Google Play.',
+        ),
+        backgroundColor:
+            opened ? context.colors.surfaceRecessed : context.colors.danger,
+      ),
+    );
+  }
+
+  Future<void> _handleRestorePurchases(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    HapticFeedbackService.buttonPress();
+    final success =
+        await ref.read(subscriptionProvider.notifier).restorePurchases();
+
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          success
+              ? 'Purchases restored successfully!'
+              : 'No purchases found to restore',
+        ),
+        backgroundColor:
+            success
+                ? context.colors.successStrong
+                : context.colors.surfaceRecessed,
+      ),
+    );
+  }
+
+  Future<bool> _openSubscriptionManagement(String? managementUrl) async {
+    final url = managementUrl;
+    if (url != null && url.isNotEmpty) {
+      final uri = Uri.tryParse(url);
+      if (uri != null && await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+        return true;
+      }
+    }
+
+    try {
+      await AppSettings.openAppSettings(type: AppSettingsType.subscriptions);
+      return true;
+    } catch (_) {
+      final fallback = Uri.parse(
+        Platform.isIOS
+            ? 'https://apps.apple.com/account/subscriptions'
+            : 'https://play.google.com/store/account/subscriptions',
+      );
+      if (await canLaunchUrl(fallback)) {
+        await launchUrl(fallback, mode: LaunchMode.externalApplication);
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+class _AccountActionRow extends StatelessWidget {
+  const _AccountActionRow({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final color =
+        destructive ? context.colors.danger : context.colors.textPrimary;
+
+    return Material(
+      color: context.colors.surface,
+      borderRadius: BorderRadius.circular(18.br),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(18.br),
+        splashColor: color.withValues(alpha: 0.08),
+        highlightColor: color.withValues(alpha: 0.04),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18.br),
+            border: Border.all(
+              color:
+                  destructive
+                      ? context.colors.danger.withValues(alpha: 0.45)
+                      : context.colors.divider.withValues(alpha: 0.4),
+            ),
+          ),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 14.sp, vertical: 12.sp),
+            child: Row(
+              children: [
+                _IconTile(icon: icon, color: color),
+                SizedBox(width: 12.w),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: AppTypography.textMdMedium.copyWith(
+                          color: color,
+                          fontSize: 13.f,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      SizedBox(height: 3.h),
+                      Text(
+                        subtitle,
+                        style: AppTypography.textSmRegular.copyWith(
+                          color:
+                              destructive
+                                  ? color.withValues(alpha: 0.72)
+                                  : context.colors.textSecondary,
+                          fontSize: 11.f,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(width: 8.w),
+                Icon(Icons.chevron_right_rounded, color: color, size: 22.ic),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IconTile extends StatelessWidget {
+  const _IconTile({required this.icon, required this.color});
+
+  final IconData icon;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 38.w,
+      height: 38.h,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(12.br),
+        border: Border.all(color: color.withValues(alpha: 0.28)),
+      ),
+      child: Icon(icon, color: color, size: 20.ic),
+    );
+  }
+}

--- a/lib/widgets/hamburger_menu/hamburger_menu.dart
+++ b/lib/widgets/hamburger_menu/hamburger_menu.dart
@@ -4,8 +4,8 @@ import 'package:chessever2/e2e/e2e_ids.dart';
 import 'package:in_app_review/in_app_review.dart';
 import 'package:chessever2/providers/app_version_provider.dart';
 import 'package:chessever2/providers/auth_state_provider.dart';
-import 'package:chessever2/repository/authentication/model/app_user.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:chessever2/screens/settings/settings_page.dart';
 import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -15,14 +15,12 @@ import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/widgets/auth/auth_upgrade_sheet.dart';
 import 'package:chessever2/widgets/hamburger_menu/hamburger_menu_dialogs.dart';
-import 'package:chessever2/widgets/paywall/premium_celebration_overlay.dart';
 import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
 import 'package:chessever2/widgets/user_avatar.dart';
 import 'package:chessever2/services/review_prompt_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:logarte/logarte.dart';
 import 'package:chessever2/main.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -106,12 +104,16 @@ class HamburgerMenu extends HookConsumerWidget {
               if (logarte.isOverlayAttached) {
                 logarte.detachOverlay();
                 ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Logarte Debug Console Disabled')),
+                  const SnackBar(
+                    content: Text('Logarte Debug Console Disabled'),
+                  ),
                 );
               } else {
                 logarte.attach(context: context, visible: true);
                 ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Logarte Debug Console Enabled')),
+                  const SnackBar(
+                    content: Text('Logarte Debug Console Enabled'),
+                  ),
                 );
               }
             }
@@ -120,268 +122,269 @@ class HamburgerMenu extends HookConsumerWidget {
             bottom: true,
             child: Column(
               children: [
-              Expanded(
-                child: ListView(
-                  padding: EdgeInsets.zero,
-                  children: [
-                    if (isTablet)
-                      Padding(
-                        padding: EdgeInsets.only(
-                          left: 8.sp,
-                          top: 8.h,
-                          bottom: 8.h,
-                        ),
-                        child: Align(
-                          alignment: Alignment.centerLeft,
-                          child: InkWell(
-                            onTap: () {
-                              HapticFeedbackService.buttonPress();
-                              Navigator.of(context).pop();
-                            },
-                            borderRadius: BorderRadius.circular(12.br),
-                            child: Container(
-                              width: 44.w,
-                              height: 44.h,
-                              decoration: BoxDecoration(
-                                color: context.colors.surfaceRecessed,
-                                borderRadius: BorderRadius.circular(12.br),
-                              ),
-                              child: Icon(
-                                Icons.menu_rounded,
-                                color: context.colors.iconPrimary,
-                                size: 24.0,
+                Expanded(
+                  child: ListView(
+                    padding: EdgeInsets.zero,
+                    children: [
+                      if (isTablet)
+                        Padding(
+                          padding: EdgeInsets.only(
+                            left: 8.sp,
+                            top: 8.h,
+                            bottom: 8.h,
+                          ),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: InkWell(
+                              onTap: () {
+                                HapticFeedbackService.buttonPress();
+                                Navigator.of(context).pop();
+                              },
+                              borderRadius: BorderRadius.circular(12.br),
+                              child: Container(
+                                width: 44.w,
+                                height: 44.h,
+                                decoration: BoxDecoration(
+                                  color: context.colors.surfaceRecessed,
+                                  borderRadius: BorderRadius.circular(12.br),
+                                ),
+                                child: Icon(
+                                  Icons.menu_rounded,
+                                  color: context.colors.iconPrimary,
+                                  size: 24.0,
+                                ),
                               ),
                             ),
                           ),
+                        )
+                      else
+                        SizedBox(height: 16.h),
+
+                      // User profile header (avatar + name + PRO badge)
+                      const _UserProfileHeader(),
+                      SizedBox(height: 8.h),
+
+                      // Menu items
+                      //
+                      // Each utility SVG is shipped with white-ish tints baked
+                      // in (looks correct on the dark drawer). In light theme
+                      // that bakes a white-on-light-grey contrast bug, so we
+                      // recolour to `iconPrimary` only when the theme is light;
+                      // dark theme renders the asset unchanged.
+                      _MenuItem(
+                        key: e2eKey(E2eIds.drawerOpeningExplorer),
+                        customIcon: SvgWidget(
+                          SvgAsset.openingExplorer,
+                          semanticsLabel: 'Opening Explorer Icon',
+                          height: 20.h,
+                          width: 20.w,
+                          colorFilter:
+                              context.isLightTheme
+                                  ? ColorFilter.mode(
+                                    context.colors.iconPrimary,
+                                    BlendMode.srcIn,
+                                  )
+                                  : null,
                         ),
-                      )
-                    else
-                      SizedBox(height: 16.h),
-
-                    // User profile header (avatar + name + PRO badge)
-                    const _UserProfileHeader(),
-                    SizedBox(height: 8.h),
-
-                    // Menu items
-                    //
-                    // Each utility SVG is shipped with white-ish tints baked
-                    // in (looks correct on the dark drawer). In light theme
-                    // that bakes a white-on-light-grey contrast bug, so we
-                    // recolour to `iconPrimary` only when the theme is light;
-                    // dark theme renders the asset unchanged.
-                    _MenuItem(
-                      key: e2eKey(E2eIds.drawerOpeningExplorer),
-                      customIcon: SvgWidget(
-                        SvgAsset.openingExplorer,
-                        semanticsLabel: 'Opening Explorer Icon',
-                        height: 20.h,
-                        width: 20.w,
-                        colorFilter: context.isLightTheme
-                            ? ColorFilter.mode(
-                                context.colors.iconPrimary,
-                                BlendMode.srcIn,
-                              )
-                            : null,
+                        icon: Icons.explore_outlined,
+                        title: 'Opening Explorer',
+                        textStyle: AppTypography.textSmMedium.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 1.0,
+                          letterSpacing: -0.14,
+                        ),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          callbacks.onOpeningExplorerPressed();
+                        },
+                        showChevron: true,
                       ),
-                      icon: Icons.explore_outlined,
-                      title: 'Opening Explorer',
-                      textStyle: AppTypography.textSmMedium.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 1.0,
-                        letterSpacing: -0.14,
+                      _MenuItem(
+                        key: e2eKey(E2eIds.drawerAnalysisBoard),
+                        customIcon: SvgWidget(
+                          SvgAsset.analysisBoard,
+                          semanticsLabel: 'Analysis Board Icon',
+                          height: 20.h,
+                          width: 20.w,
+                          // Multi-colour mini-chessboard artwork — must keep
+                          // its baked white/grey/dark squares in both themes.
+                          // Tinting collapses it into a single solid blob.
+                          preserveOriginalColors: true,
+                        ),
+                        icon: Icons.grid_view_rounded,
+                        title: 'Board Editor',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          callbacks.onAnalysisBoardPressed();
+                        },
+                        showChevron: true,
                       ),
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        callbacks.onOpeningExplorerPressed();
-                      },
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      key: e2eKey(E2eIds.drawerAnalysisBoard),
-                      customIcon: SvgWidget(
-                        SvgAsset.analysisBoard,
-                        semanticsLabel: 'Analysis Board Icon',
-                        height: 20.h,
-                        width: 20.w,
-                        // Multi-colour mini-chessboard artwork — must keep
-                        // its baked white/grey/dark squares in both themes.
-                        // Tinting collapses it into a single solid blob.
-                        preserveOriginalColors: true,
+                      _MenuItem(
+                        icon: Icons.favorite_border,
+                        title: 'Favorites',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          callbacks.onFavoritesPressed();
+                        },
+                        showChevron: true,
                       ),
-                      icon: Icons.grid_view_rounded,
-                      title: 'Board Editor',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
+                      _MenuItem(
+                        key: e2eKey(E2eIds.drawerSettings),
+                        customIcon: SvgWidget(
+                          SvgAsset.settings,
+                          semanticsLabel: 'Settings Icon',
+                          height: 20.h,
+                          width: 20.w,
+                          colorFilter:
+                              context.isLightTheme
+                                  ? ColorFilter.mode(
+                                    context.colors.iconPrimary,
+                                    BlendMode.srcIn,
+                                  )
+                                  : null,
+                        ),
+                        title: 'Settings',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () => showSettingsDialog(context),
+                        showChevron: true,
                       ),
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        callbacks.onAnalysisBoardPressed();
-                      },
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      icon: Icons.favorite_border,
-                      title: 'Favorites',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
+                      _MenuItem(
+                        icon: Icons.desktop_mac_outlined,
+                        title: 'ChessEver Desktop',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () async {
+                          final uri = Uri.parse('https://chessever.com');
+                          if (await canLaunchUrl(uri)) {
+                            await launchUrl(
+                              uri,
+                              mode: LaunchMode.externalApplication,
+                            );
+                          }
+                        },
+                        showChevron: true,
                       ),
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        callbacks.onFavoritesPressed();
-                      },
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      key: e2eKey(E2eIds.drawerSettings),
-                      customIcon: SvgWidget(
-                        SvgAsset.settings,
-                        semanticsLabel: 'Settings Icon',
-                        height: 20.h,
-                        width: 20.w,
-                        colorFilter: context.isLightTheme
-                            ? ColorFilter.mode(
-                                context.colors.iconPrimary,
-                                BlendMode.srcIn,
-                              )
-                            : null,
-                      ),
-                      title: 'Settings',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
-                      ),
-                      onPressed: () => showSettingsDialog(context),
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      icon: Icons.desktop_mac_outlined,
-                      title: 'ChessEver Desktop',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
-                      ),
-                      onPressed: () async {
-                        final uri = Uri.parse('https://chessever.com');
-                        if (await canLaunchUrl(uri)) {
-                          await launchUrl(
-                            uri,
-                            mode: LaunchMode.externalApplication,
+                      _MenuItem(
+                        customIcon: SvgWidget(
+                          SvgAsset.leaveFeedback,
+                          semanticsLabel: 'Leave Feedback Icon',
+                          height: 20.h,
+                          width: 20.w,
+                          colorFilter:
+                              context.isLightTheme
+                                  ? ColorFilter.mode(
+                                    context.colors.iconPrimary,
+                                    BlendMode.srcIn,
+                                  )
+                                  : null,
+                        ),
+                        icon: Icons.rate_review_outlined,
+                        title: 'Leave Feedback',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                          ReviewPromptService.instance.maybePrompt(
+                            context: context,
+                            trigger: ReviewPromptTrigger.sidebar,
+                            force: true,
                           );
-                        }
-                      },
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      customIcon: SvgWidget(
-                        SvgAsset.leaveFeedback,
-                        semanticsLabel: 'Leave Feedback Icon',
-                        height: 20.h,
-                        width: 20.w,
-                        colorFilter: context.isLightTheme
-                            ? ColorFilter.mode(
-                                context.colors.iconPrimary,
-                                BlendMode.srcIn,
-                              )
-                            : null,
+                        },
+                        showChevron: true,
                       ),
-                      icon: Icons.rate_review_outlined,
-                      title: 'Leave Feedback',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
+                      _MenuItem(
+                        icon: Icons.star_outline,
+                        title: 'Rate this app',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () {
+                          _openStoreListing();
+                        },
+                        showChevron: true,
                       ),
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        ReviewPromptService.instance.maybePrompt(
-                          context: context,
-                          trigger: ReviewPromptTrigger.sidebar,
-                          force: true,
-                        );
-                      },
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      icon: Icons.star_outline,
-                      title: 'Rate this app',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
+                      _MenuItem(
+                        customIcon: SvgWidget(
+                          SvgAsset.versionIcon,
+                          semanticsLabel: 'Info Icon',
+                          height: 20.h,
+                          width: 20.w,
+                          colorFilter:
+                              context.isLightTheme
+                                  ? ColorFilter.mode(
+                                    context.colors.iconPrimary,
+                                    BlendMode.srcIn,
+                                  )
+                                  : null,
+                        ),
+                        title:
+                            versionString.isNotEmpty
+                                ? 'Version $versionString'
+                                : 'Version',
+                        textStyle: AppTypography.textSmRegular.copyWith(
+                          color: context.colors.iconPrimary,
+                          height: 20.h / 14.h,
+                        ),
+                        onPressed: () {
+                          _showAboutDialog(context, versionString);
+                        },
+                        showChevron: true,
                       ),
-                      onPressed: () {
-                        _openStoreListing();
-                      },
-                      showChevron: true,
-                    ),
-                    _MenuItem(
-                      customIcon: SvgWidget(
-                        SvgAsset.versionIcon,
-                        semanticsLabel: 'Info Icon',
-                        height: 20.h,
-                        width: 20.w,
-                        colorFilter: context.isLightTheme
-                            ? ColorFilter.mode(
-                                context.colors.iconPrimary,
-                                BlendMode.srcIn,
-                              )
-                            : null,
-                      ),
-                      title:
-                          versionString.isNotEmpty
-                              ? 'Version $versionString'
-                              : 'Version',
-                      textStyle: AppTypography.textSmRegular.copyWith(
-                        color: context.colors.iconPrimary,
-                        height: 20.h / 14.h,
-                      ),
-                      onPressed: () {
-                        _showAboutDialog(context, versionString);
-                      },
-                      showChevron: true,
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
 
-              // Footer: Get Premium card + Restore Purchases + Divider + Log Out
-              ConstrainedBox(
-                constraints: BoxConstraints(
-                  minHeight: ResponsiveHelper.isTablet ? 280.0 : 0,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // "Get Premium" card — shown only for non-premium users
-                    _GetPremiumCard(),
+                // Footer: Get Premium card + Restore Purchases + Divider + Log Out
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: ResponsiveHelper.isTablet ? 280.0 : 0,
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      // "Get Premium" card — shown only for non-premium users
+                      _GetPremiumCard(),
 
-                    // Restore Purchases
-                    _RestorePurchasesRow(),
-
-                    // Divider
-                    Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16.sp),
-                      child: Container(
-                        height: 1,
-                        color: context.colors.divider,
+                      // Divider
+                      Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 16.sp),
+                        child: Container(
+                          height: 1,
+                          color: context.colors.divider,
+                        ),
                       ),
-                    ),
 
-                    _LogOutButton(
-                      key: e2eKey(E2eIds.drawerLogout),
-                      onLogoutPressed: () {
-                        callbacks.onLogoutPressed();
-                      },
-                    ),
+                      _LogOutButton(
+                        key: e2eKey(E2eIds.drawerLogout),
+                        onLogoutPressed: () {
+                          callbacks.onLogoutPressed();
+                        },
+                      ),
 
-                    if (ResponsiveHelper.isTablet) SizedBox(height: 16.0),
-                  ],
+                      if (ResponsiveHelper.isTablet) SizedBox(height: 16.0),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
       ),
     );
   }
@@ -396,22 +399,18 @@ class _UserProfileHeader extends ConsumerWidget {
     final user = ref.watch(currentUserProvider);
     final subscriptionState = ref.watch(subscriptionProvider);
     final isPremium = subscriptionState.isSubscribed;
-    final managementUrl = subscriptionState.managementUrl;
     final name = user?.displayName?.trim();
     final displayName = (name?.isNotEmpty ?? false) ? name! : 'Anonymous';
 
     return GestureDetector(
-      onTap:
-          isPremium
-              ? () async {
-                Navigator.of(context).pop();
-                if (!context.mounted) return;
-                await showPremiumCelebration(
-                  context,
-                  managementUrl: managementUrl,
-                );
-              }
-              : null,
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        HapticFeedbackService.navigation();
+        Navigator.of(context).pop();
+        Navigator.of(
+          context,
+        ).push(SettingsPage.route(initiallyExpanded: SettingsSection.account));
+      },
       child: Padding(
         padding: EdgeInsets.symmetric(horizontal: 16.sp, vertical: 12.sp),
         child: Row(
@@ -457,7 +456,10 @@ class _ProBadge extends StatelessWidget {
       decoration: BoxDecoration(
         color: kPrimaryColor,
         borderRadius: BorderRadius.circular(16.br),
-        border: Border.all(color: kPrimaryColor.withValues(alpha: 0.4), width: 1),
+        border: Border.all(
+          color: kPrimaryColor.withValues(alpha: 0.4),
+          width: 1,
+        ),
       ),
       child: Text(
         'PRO',
@@ -495,10 +497,7 @@ class _GetPremiumCardState extends ConsumerState<_GetPremiumCard> {
         decoration: BoxDecoration(
           color: context.colors.surfaceRecessed,
           borderRadius: BorderRadius.circular(12.br),
-          border: Border.all(
-            color: context.colors.divider,
-            width: 1,
-          ),
+          border: Border.all(color: context.colors.divider, width: 1),
         ),
         padding: EdgeInsets.fromLTRB(12.sp, 8.sp, 6.sp, 8.sp),
         child: Row(
@@ -573,61 +572,6 @@ class _GetPremiumCardState extends ConsumerState<_GetPremiumCard> {
   }
 }
 
-/// Restore Purchases row — kept for App Store compliance
-class _RestorePurchasesRow extends ConsumerWidget {
-  const _RestorePurchasesRow();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return InkWell(
-      onTap: () async {
-        HapticFeedbackService.buttonPress();
-        final success =
-            await ref.read(subscriptionProvider.notifier).restorePurchases();
-
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                success
-                    ? 'Purchases restored successfully!'
-                    : 'No purchases found to restore',
-              ),
-              backgroundColor: success
-                  ? context.colors.successStrong
-                  : context.colors.surfaceRecessed,
-            ),
-          );
-        }
-      },
-      child: Container(
-        padding: EdgeInsets.only(
-          left: 16.sp,
-          top: 10.sp,
-          bottom: 10.sp,
-          right: 8.sp,
-        ),
-        child: Row(
-          children: [
-            Icon(
-              Icons.restore_rounded,
-              size: 24.ic,
-              color: context.colors.iconPrimary.withValues(alpha:0.5),
-            ),
-            SizedBox(width: 12.w),
-            Text(
-              'Restore Purchases',
-              style: AppTypography.textSmRegular.copyWith(
-                color: context.colors.iconPrimary.withValues(alpha:0.5),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _LogOutButton extends StatelessWidget {
   const _LogOutButton({required this.onLogoutPressed, super.key});
 
@@ -660,7 +604,10 @@ class _LogOutButton extends StatelessWidget {
             Text(
               isAnonymous ? 'Sign up' : 'Log out',
               style: AppTypography.textSmMedium.copyWith(
-                color: isAnonymous ? context.colors.iconPrimary : context.colors.danger,
+                color:
+                    isAnonymous
+                        ? context.colors.iconPrimary
+                        : context.colors.danger,
                 height: 20.h / 14.h,
               ),
             ),
@@ -679,11 +626,9 @@ class _MenuItem extends StatelessWidget {
     this.showChevron = false,
     this.onPressed,
     this.textStyle,
-    this.maxLines = 1,
     super.key,
   });
 
-  final int? maxLines;
   final IconData? icon;
   final Widget? customIcon;
   final String title;
@@ -713,7 +658,7 @@ class _MenuItem extends StatelessWidget {
         Expanded(
           child: Text(
             title,
-            maxLines: maxLines,
+            maxLines: 1,
             style:
                 textStyle ??
                 AppTypography.textSmRegular.copyWith(
@@ -782,10 +727,7 @@ class _AboutDialog extends StatelessWidget {
             decoration: BoxDecoration(
               color: context.colors.surfaceElevated,
               borderRadius: BorderRadius.circular(24),
-              border: Border.all(
-                color: context.colors.divider,
-                width: 1,
-              ),
+              border: Border.all(color: context.colors.divider, width: 1),
               boxShadow: [
                 BoxShadow(
                   color: context.colors.shadow,
@@ -806,8 +748,8 @@ class _AboutDialog extends StatelessWidget {
                       begin: Alignment.topLeft,
                       end: Alignment.bottomRight,
                       colors: [
-                        context.colors.iconPrimary.withValues(alpha:0.05),
-                        context.colors.iconPrimary.withValues(alpha:0.02),
+                        context.colors.iconPrimary.withValues(alpha: 0.05),
+                        context.colors.iconPrimary.withValues(alpha: 0.02),
                       ],
                     ),
                     borderRadius: const BorderRadius.only(
@@ -821,10 +763,14 @@ class _AboutDialog extends StatelessWidget {
                             width: 56.w,
                             height: 56.h,
                             decoration: BoxDecoration(
-                              color: context.colors.iconPrimary.withValues(alpha:0.1),
+                              color: context.colors.iconPrimary.withValues(
+                                alpha: 0.1,
+                              ),
                               borderRadius: BorderRadius.circular(16),
                               border: Border.all(
-                                color: context.colors.iconPrimary.withValues(alpha:0.2),
+                                color: context.colors.iconPrimary.withValues(
+                                  alpha: 0.2,
+                                ),
                                 width: 1,
                               ),
                             ),
@@ -872,7 +818,9 @@ class _AboutDialog extends StatelessWidget {
                       Text(
                         'Version $version',
                         style: AppTypography.textSmRegular.copyWith(
-                          color: context.colors.iconPrimary.withValues(alpha:0.5),
+                          color: context.colors.iconPrimary.withValues(
+                            alpha: 0.5,
+                          ),
                         ),
                       ).animate().fadeIn(delay: 300.ms, duration: 400.ms),
                     ],
@@ -936,7 +884,8 @@ class _AboutDialog extends StatelessWidget {
                           },
                           style: TextButton.styleFrom(
                             padding: EdgeInsets.symmetric(vertical: 14.h),
-                            backgroundColor: context.colors.iconPrimary.withValues(alpha:0.05),
+                            backgroundColor: context.colors.iconPrimary
+                                .withValues(alpha: 0.05),
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(12),
                             ),
@@ -944,7 +893,9 @@ class _AboutDialog extends StatelessWidget {
                           child: Text(
                             'Close',
                             style: AppTypography.textSmMedium.copyWith(
-                              color: context.colors.iconPrimary.withValues(alpha:0.7),
+                              color: context.colors.iconPrimary.withValues(
+                                alpha: 0.7,
+                              ),
                             ),
                           ),
                         ),
@@ -991,10 +942,10 @@ class _LinkButton extends StatelessWidget {
           child: Container(
             padding: EdgeInsets.all(16.sp),
             decoration: BoxDecoration(
-              color: context.colors.iconPrimary.withValues(alpha:0.03),
+              color: context.colors.iconPrimary.withValues(alpha: 0.03),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: context.colors.iconPrimary.withValues(alpha:0.08),
+                color: context.colors.iconPrimary.withValues(alpha: 0.08),
                 width: 1,
               ),
             ),
@@ -1004,13 +955,13 @@ class _LinkButton extends StatelessWidget {
                   width: 40.w,
                   height: 40.h,
                   decoration: BoxDecoration(
-                    color: context.colors.iconPrimary.withValues(alpha:0.08),
+                    color: context.colors.iconPrimary.withValues(alpha: 0.08),
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: Icon(
                     icon,
                     size: 20.ic,
-                    color: context.colors.iconPrimary.withValues(alpha:0.8),
+                    color: context.colors.iconPrimary.withValues(alpha: 0.8),
                   ),
                 ),
                 SizedBox(width: 12.w),
@@ -1021,14 +972,18 @@ class _LinkButton extends StatelessWidget {
                       Text(
                         label,
                         style: AppTypography.textSmMedium.copyWith(
-                          color: context.colors.iconPrimary.withValues(alpha:0.9),
+                          color: context.colors.iconPrimary.withValues(
+                            alpha: 0.9,
+                          ),
                         ),
                       ),
                       SizedBox(height: 2.h),
                       Text(
                         subtitle,
                         style: AppTypography.textXsRegular.copyWith(
-                          color: context.colors.iconPrimary.withValues(alpha:0.5),
+                          color: context.colors.iconPrimary.withValues(
+                            alpha: 0.5,
+                          ),
                         ),
                       ),
                     ],
@@ -1037,7 +992,7 @@ class _LinkButton extends StatelessWidget {
                 Icon(
                   Icons.arrow_forward_ios,
                   size: 14.ic,
-                  color: context.colors.iconPrimary.withValues(alpha:0.4),
+                  color: context.colors.iconPrimary.withValues(alpha: 0.4),
                 ),
               ],
             ),

--- a/lib/widgets/paywall/premium_celebration_overlay.dart
+++ b/lib/widgets/paywall/premium_celebration_overlay.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
-import 'package:app_settings/app_settings.dart';
+import 'package:chessever2/screens/settings/settings_page.dart';
 import 'package:chessever2/services/review_prompt_service.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -9,22 +9,18 @@ import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// Shows a beautiful celebration overlay when user subscribes to premium.
 /// Call this after a successful subscription purchase.
-/// Pass [managementUrl] to show a "Manage subscription" button.
-Future<void> showPremiumCelebration(
-  BuildContext context, {
-  String? managementUrl,
-}) async {
+/// The Account Settings button opens subscription/account controls.
+Future<void> showPremiumCelebration(BuildContext context) async {
   await showGeneralDialog(
     context: context,
     barrierDismissible: false,
     barrierColor: Colors.black.withValues(alpha: 0.85),
     transitionDuration: const Duration(milliseconds: 400),
     pageBuilder: (context, animation, secondaryAnimation) {
-      return _PremiumCelebrationOverlay(managementUrl: managementUrl);
+      return const _PremiumCelebrationOverlay();
     },
     transitionBuilder: (context, animation, secondaryAnimation, child) {
       return FadeTransition(opacity: animation, child: child);
@@ -43,9 +39,7 @@ Future<void> showPremiumCelebration(
 }
 
 class _PremiumCelebrationOverlay extends StatefulWidget {
-  const _PremiumCelebrationOverlay({this.managementUrl});
-
-  final String? managementUrl;
+  const _PremiumCelebrationOverlay();
 
   @override
   State<_PremiumCelebrationOverlay> createState() =>
@@ -228,7 +222,9 @@ class _PremiumCelebrationOverlayState extends State<_PremiumCelebrationOverlay>
                   Text(
                         'You now have access to all features',
                         style: AppTypography.textMdMedium.copyWith(
-                          color: context.colors.textPrimary.withValues(alpha: 0.7),
+                          color: context.colors.textPrimary.withValues(
+                            alpha: 0.7,
+                          ),
                         ),
                       )
                       .animate()
@@ -237,24 +233,15 @@ class _PremiumCelebrationOverlayState extends State<_PremiumCelebrationOverlay>
 
                   SizedBox(height: 32.h),
 
-                  // Manage subscription button
+                  // Account settings button
                   GestureDetector(
-                        onTap: () async {
+                        onTap: () {
                           HapticFeedbackService.buttonPress();
-
-                          final url = widget.managementUrl;
-                          if (url != null && url.isNotEmpty) {
-                            final uri = Uri.tryParse(url);
-                            if (uri != null && await canLaunchUrl(uri)) {
-                              await launchUrl(
-                                uri,
-                                mode: LaunchMode.externalApplication,
-                              );
-                              return;
-                            }
-                          }
-                          await AppSettings.openAppSettings(
-                            type: AppSettingsType.subscriptions,
+                          Navigator.of(context).pop();
+                          Navigator.of(context).push(
+                            SettingsPage.route(
+                              initiallyExpanded: SettingsSection.account,
+                            ),
                           );
                         },
                         child: Container(
@@ -263,10 +250,14 @@ class _PremiumCelebrationOverlayState extends State<_PremiumCelebrationOverlay>
                             vertical: 12.sp,
                           ),
                           decoration: BoxDecoration(
-                            color: context.colors.textPrimary.withValues(alpha: 0.1),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.1,
+                            ),
                             borderRadius: BorderRadius.circular(8.br),
                             border: Border.all(
-                              color: context.colors.textPrimary.withValues(alpha: 0.2),
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.2,
+                              ),
                               width: 1,
                             ),
                           ),
@@ -275,14 +266,18 @@ class _PremiumCelebrationOverlayState extends State<_PremiumCelebrationOverlay>
                             children: [
                               Icon(
                                 Icons.settings_outlined,
-                                color: context.colors.textPrimary.withValues(alpha: 0.8),
+                                color: context.colors.textPrimary.withValues(
+                                  alpha: 0.8,
+                                ),
                                 size: 18.ic,
                               ),
                               SizedBox(width: 8.w),
                               Text(
-                                'Manage subscription',
+                                'Account Settings',
                                 style: AppTypography.textSmMedium.copyWith(
-                                  color: context.colors.textPrimary.withValues(alpha: 0.8),
+                                  color: context.colors.textPrimary.withValues(
+                                    alpha: 0.8,
+                                  ),
                                 ),
                               ),
                             ],
@@ -299,7 +294,9 @@ class _PremiumCelebrationOverlayState extends State<_PremiumCelebrationOverlay>
                   Text(
                         'Tap anywhere to continue',
                         style: AppTypography.textSmRegular.copyWith(
-                          color: context.colors.textPrimary.withValues(alpha: 0.4),
+                          color: context.colors.textPrimary.withValues(
+                            alpha: 0.4,
+                          ),
                         ),
                       )
                       .animate(


### PR DESCRIPTION
## Summary
- opens Account Settings from the profile header instead of replaying the Premium celebration
- moves Restore Purchases and Delete Account into Account Settings
- changes the Premium celebration button to Account Settings
- fixes Manage Subscription flow from Account Settings with RevenueCat management URL plus native store/settings fallbacks

## Test Plan
- `dart format --set-exit-if-changed lib/screens/settings/settings_page.dart lib/screens/settings/widgets/account_settings_body.dart lib/widgets/hamburger_menu/hamburger_menu.dart lib/widgets/paywall/premium_celebration_overlay.dart`
- `flutter analyze --no-pub lib/screens/settings/settings_page.dart lib/screens/settings/widgets/account_settings_body.dart lib/widgets/hamburger_menu/hamburger_menu.dart lib/widgets/paywall/premium_celebration_overlay.dart`
- `flutter test --no-pub test/board_settings_coordinates_test.dart`

## QA
- Tap profile header: Settings opens with Account Settings expanded; no repeated celebration.
- Premium celebration still appears after a successful purchase/restore transition, but its button opens Account Settings.
- Account Settings: Manage Subscription opens Apple/Google subscription management for subscribers; Restore Purchases shows success/no-purchase feedback; Delete Account remains destructive/red.
