### PR TITLE
feat: add For You smart game databases

### DIFF
--- a/.ai/todo.md
+++ b/.ai/todo.md
@@ -2,33 +2,29 @@
 
 Spec: 3-tab Library (Studies / My Database / Discovery), board tag flow, My Likes tags, Miniatures.
 
-## Scope split
-- **Pure UI (no migration)** — doing now.
-- **Backend-blocked (needs additive migration, awaiting permission)** — Studies data, Miniatures RPC + community like-count.
+## DONE (pure UI, no migration) — committed to dev
+- [x] **Phase 1** board save/edit tag flow — `425b612f`
+  - `lib/constants/game_tags.dart` (10 official tags + icons)
+  - save sheet: always-visible tag chips, preload existing tags, persist on insert/update
+  - threaded tags through SavedAnalysisData → auto-save/manual-update no longer wipe tags
+- [x] **Phase 2** three-tab Library — `a1297401`
+  - SegmentedSwitcher (Studies / My Database / Discovery), default My Database
+  - per-tab search text + scroll preserved (IndexedStack + _tabQueries)
+  - TWIC moved My Database → Discovery, relabeled "ChessEver Master Database" (FolderCard.titleOverride)
+  - Studies + Miniatures = honest "Soon" panels
+- [x] **Phase 3** My Likes tag chips — `8b80be0c`
+  - tag chip row, tap-to-filter = premium (requirePremiumGuard), union semantics
+  - MyLikesFilterState.selectedTags + provider apply
+- [x] liked card tag display — `90642472`
 
-## Phase 1 — Board save/edit tag flow (explicit gap)  [in progress]
-- [ ] `lib/constants/game_tags.dart` — 10 official tags constant
-- [ ] save_analysis_sheet.dart: preload existing tags (liked path + getSavedAnalysis fetch)
-- [ ] save_analysis_sheet.dart: tag chips row (always visible), toggle select
-- [ ] save_analysis_sheet.dart: persist `tags` on insert + update (replace `const []`)
-- [ ] flutter analyze clean
-
-## Phase 2 — Library 3 tabs
-- [ ] SegmentedSwitcher at top (Studies / My Database / Discovery), default My Database
-- [ ] My Database tab = current library content MINUS TWIC
-- [ ] Move TWIC card into Discovery tab
-- [ ] Per-tab scroll position + search input preserved
-- [ ] Studies tab scaffold (coming-soon state — backend absent)
-- [ ] Discovery tab = Miniatures scaffold (coming-soon — backend absent)
-
-## Phase 3 — My Likes tag chips
-- [ ] Tag chips row at top of My Likes
-- [ ] Free: attach tags. Tap-to-FILTER opens paywall (premium)
-
-## Backend (awaiting permission — additive only)
-- [ ] Studies: store table + Lichess sync (substantial, recommend defer)
-- [ ] Miniatures: RPC/view over games (decisive + <20 moves, sort avg rating)
-- [ ] community game like-count table + increment on like
+## BLOCKED — needs backend (additive migration), awaiting permission
+- [ ] **Studies real data**: `lichess_studies` + `_chapters` tables + sync edge fn (company Lichess token, filter junk, quality rank). Bigger than a migration.
+- [ ] **Miniatures real list**: indexed derived columns on `games` (move_count / is_decisive / is_miniature) OR RPC/matview (decisive + <20 moves, sort avg rating). 990k rows → needs index, not client-side.
+- [ ] **Community like-count**: additive table/counter aggregating likes per game; increment on like; feeds Miniatures like-sort.
 
 ## Test notes
-- Append per phase.
+- `flutter analyze` clean on all 9 touched files.
+- Manual (device):
+  1. Board → double-tap like, open save sheet → tag chips visible, toggle, save. Reopen game → tags still selected. Move a piece (auto-save) → reopen → tags still there.
+  2. Library → segmented control: lands on My Database; TWIC gone from My Database, now in Discovery as "ChessEver Master Database"; Studies/Discovery show Soon panels; switch tabs → search text + scroll preserved.
+  3. My Likes → tag chip row; free user taps chip → paywall; premium taps → list filters by tag (union); liked cards show tag pills.

--- a/.ai/todo.md
+++ b/.ai/todo.md
@@ -1,30 +1,32 @@
-# Library UI Overhaul — todo
+# Library UI Overhaul + Discovery — todo
 
-Spec: 3-tab Library (Studies / My Database / Discovery), board tag flow, My Likes tags, Miniatures.
+## DONE — pushed to dev
+- [x] Board save/edit tag flow — `425b612f`
+- [x] Three-tab Library (Studies / My Database / Discovery) — `a1297401`
+- [x] My Likes tag filter chips — `8b80be0c`
+- [x] Liked card tag display — `90642472`
+- [x] **Roulette tag picker** (spring physics wheel) for liked games — `115655fe`
+  - detented wheel, countdown ring, reduced-motion fallback
+  - fires after a like; liked-game save sheet shows roulette trigger
+  - additive Supabase: GIN index on tags + generated `primary_tag` (+btree)
+- [x] **Studies + Miniatures** wired from gamebase_openapi.yaml — `42cf29b6`
+  - models + repo methods + providers (discovery/*)
+  - Studies tab (sort/search/pull-to-refresh) + chapter screen (open PGN on board)
+  - Discovery = ChessEver master DB pinned + Miniatures (Today/Week/All, sort)
 
-## DONE (pure UI, no migration) — committed to dev
-- [x] **Phase 1** board save/edit tag flow — `425b612f`
-  - `lib/constants/game_tags.dart` (10 official tags + icons)
-  - save sheet: always-visible tag chips, preload existing tags, persist on insert/update
-  - threaded tags through SavedAnalysisData → auto-save/manual-update no longer wipe tags
-- [x] **Phase 2** three-tab Library — `a1297401`
-  - SegmentedSwitcher (Studies / My Database / Discovery), default My Database
-  - per-tab search text + scroll preserved (IndexedStack + _tabQueries)
-  - TWIC moved My Database → Discovery, relabeled "ChessEver Master Database" (FolderCard.titleOverride)
-  - Studies + Miniatures = honest "Soon" panels
-- [x] **Phase 3** My Likes tag chips — `8b80be0c`
-  - tag chip row, tap-to-filter = premium (requirePremiumGuard), union semantics
-  - MyLikesFilterState.selectedTags + provider apply
-- [x] liked card tag display — `90642472`
+## PENDING — backend production deploy
+- [ ] `/api/studies` + `/api/miniatures` return **404 in production** (contract in
+      yaml shipped, deploy lagging). Base URL + X-API-Key verified against an
+      existing endpoint (search/metadata → 200). Once live:
+      - smoke-test real JSON, confirm `discovery_models.dart` field names match
+      - verify study chapter PGN opens on board; miniature opens on board
 
-## BLOCKED — needs backend (additive migration), awaiting permission
-- [ ] **Studies real data**: `lichess_studies` + `_chapters` tables + sync edge fn (company Lichess token, filter junk, quality rank). Bigger than a migration.
-- [ ] **Miniatures real list**: indexed derived columns on `games` (move_count / is_decisive / is_miniature) OR RPC/matview (decisive + <20 moves, sort avg rating). 990k rows → needs index, not client-side.
-- [ ] **Community like-count**: additive table/counter aggregating likes per game; increment on like; feeds Miniatures like-sort.
-
-## Test notes
-- `flutter analyze` clean on all 9 touched files.
-- Manual (device):
-  1. Board → double-tap like, open save sheet → tag chips visible, toggle, save. Reopen game → tags still selected. Move a piece (auto-save) → reopen → tags still there.
-  2. Library → segmented control: lands on My Database; TWIC gone from My Database, now in Discovery as "ChessEver Master Database"; Studies/Discovery show Soon panels; switch tabs → search text + scroll preserved.
-  3. My Likes → tag chip row; free user taps chip → paywall; premium taps → list filters by tag (union); liked cards show tag pills.
+## Test (device)
+- Library segmented control: My Database default; Discovery shows master DB +
+  Miniatures; Studies lists studies.
+- Like a game → roulette appears → spin/stop → tag attaches; reopen save sheet →
+  roulette trigger shows current tag.
+- My Likes tag chips filter (premium); liked cards show tag pills.
+- Studies: sort menu, search (debounced backend q), pull-to-refresh; tap study →
+  chapters → tap chapter opens on board.
+- Miniatures: window tabs + sort; tap row opens master game on board.

--- a/.ai/todo.md
+++ b/.ai/todo.md
@@ -1,29 +1,34 @@
-# PiP fixes (feat/pip → test/pip) — DONE
+# Library UI Overhaul — todo
 
-Shared contract: payload key `followLive` (bool). true = at live head → native polls + ticks. false = frozen on viewed move.
+Spec: 3-tab Library (Studies / My Database / Discovery), board tag flow, My Likes tags, Miniatures.
 
-## Bug 1 — board/piece theme parity ✅
-- [x] iOS `drawBoard`: 25-entry chessground theme table (boardSquareColors), default 9. Pieces already correct.
-- [x] Android `boardThemeColors`: full 25-entry chessground table (ARGB), default 9.
-- [x] Android pieces: load from flutter_assets piece_sets/<set>/<code>.png by pieceStyleIndex (39-set list), drawable fallback. Threaded drawBoard→drawPiece→loadPieceBitmap.
+## Scope split
+- **Pure UI (no migration)** — doing now.
+- **Backend-blocked (needs additive migration, awaiting permission)** — Studies data, Miniatures RPC + community like-count.
 
-## Bug 2 — live position updates ✅
-- [x] native polls games(fen,last_move,…) @4s; now gated on followLive.
+## Phase 1 — Board save/edit tag flow (explicit gap)  [in progress]
+- [ ] `lib/constants/game_tags.dart` — 10 official tags constant
+- [ ] save_analysis_sheet.dart: preload existing tags (liked path + getSavedAnalysis fetch)
+- [ ] save_analysis_sheet.dart: tag chips row (always visible), toggle select
+- [ ] save_analysis_sheet.dart: persist `tags` on insert + update (replace `const []`)
+- [ ] flutter analyze clean
 
-## Bug 3 — countdown parity ✅
-- [x] native displayClock already matches live-card algo (active side only, baseSeconds - elapsedSince(lastMoveTime)).
-- [x] padding `%d:%02d`→`%02d:%02d` (iOS x2, Android x2) + Dart `_formatPipClock`.
+## Phase 2 — Library 3 tabs
+- [ ] SegmentedSwitcher at top (Studies / My Database / Discovery), default My Database
+- [ ] My Database tab = current library content MINUS TWIC
+- [ ] Move TWIC card into Discovery tab
+- [ ] Per-tab scroll position + search input preserved
+- [ ] Studies tab scaffold (coming-soon state — backend absent)
+- [ ] Discovery tab = Miniatures scaffold (coming-soon — backend absent)
 
-## Bug 4 — preserve focused (non-latest) move ✅
-- [x] Dart followLive = !isInAnalysisVariation && isAtEnd (snapshot=true).
-- [x] iOS mergeLiveRow early-return + displayClock static when !followLive.
-- [x] Android mergeLiveRow early-return + displayClock static when !followLive.
+## Phase 3 — My Likes tag chips
+- [ ] Tag chips row at top of My Likes
+- [ ] Free: attach tags. Tap-to-FILTER opens paywall (premium)
 
-## Validate
-- [x] flutter analyze touched dart — no new errors (19 pre-existing lints only).
-- [ ] manual: iOS device + Android emu (debug = any game eligible). Live game needed to fully see Bug 2/3/4-follow.
+## Backend (awaiting permission — additive only)
+- [ ] Studies: store table + Lichess sync (substantial, recommend defer)
+- [ ] Miniatures: RPC/view over games (decisive + <20 moves, sort avg rating)
+- [ ] community game like-count table + increment on like
 
-## Files
-- lib/screens/chessboard/chess_board_screen_new.dart (_buildPipPayload, _formatPipClock)
-- ios/Runner/ChessPipController.swift (boardSquareColors, drawBoard, mergeLiveRow, displayClock, formatClock x2)
-- android/.../MainActivity.kt (boardThemeColors, piece asset loader, drawBoard/drawPiece, mergeLiveRow, displayClock, formatClock x2)
+## Test notes
+- Append per phase.

--- a/android/app/src/main/kotlin/com/chessEver/app/NotificationServiceExtension.kt
+++ b/android/app/src/main/kotlin/com/chessEver/app/NotificationServiceExtension.kt
@@ -197,7 +197,6 @@ class NotificationServiceExtension : INotificationServiceExtension {
     }
 
     // Request promoted ongoing for Android 15+ (Live Updates on lock screen)
-    /*
     if (eventType != "end" && Build.VERSION.SDK_INT >= 35) {
       builder.addExtras(Bundle().apply {
         putBoolean("android.requestPromotedOngoing", true)
@@ -207,7 +206,6 @@ class NotificationServiceExtension : INotificationServiceExtension {
         builder.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
       }
     }
-    */
 
     // Add action to end updates
     if (eventType != "end") {

--- a/android/app/src/main/kotlin/com/chessEver/app/NotificationServiceExtension.kt
+++ b/android/app/src/main/kotlin/com/chessEver/app/NotificationServiceExtension.kt
@@ -196,15 +196,20 @@ class NotificationServiceExtension : INotificationServiceExtension {
       )
     }
 
-    // Request promoted ongoing for Android 15+ (Live Updates on lock screen)
+    // Android 16 (API 36) "Live Updates": promote this ongoing notification so it
+    // surfaces as a live activity on the lock screen / status-bar chip.
+    //
+    // We set the raw EXTRA_REQUEST_PROMOTED_ONGOING key
+    // ("android.requestPromotedOngoing") rather than
+    // NotificationCompat.Builder#setRequestPromotedOngoing(true): that helper only
+    // exists in androidx.core 1.17+, while the extra works on every version and is
+    // simply ignored on older OS levels. Requires the POST_PROMOTED_NOTIFICATIONS
+    // permission (declared in the manifest) and a promotable style — we use
+    // BigTextStyle above on API 35+ (BigPictureStyle does NOT qualify for promotion).
     if (eventType != "end" && Build.VERSION.SDK_INT >= 35) {
       builder.addExtras(Bundle().apply {
         putBoolean("android.requestPromotedOngoing", true)
       })
-      // Ensure the notification is seen as prominent
-      if (Build.VERSION.SDK_INT >= 35) {
-        builder.setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
-      }
     }
 
     // Add action to end updates

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -8,3 +8,7 @@ systemProp.http.socketTimeout=180000
 systemProp.https.connectionTimeout=180000
 systemProp.https.socketTimeout=180000
 
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/gamebase_openapi.yaml
+++ b/gamebase_openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Chess Database API
   description: API for querying chess game positions and player data
-  version: 1.2.0
+  version: 1.3.0
 
 servers:
   - url: http://localhost:3232
@@ -1619,6 +1619,72 @@ paths:
           description: Case-insensitive substring search on study name
           schema:
             type: string
+        - name: eco
+          in: query
+          required: false
+          description: Filter to studies containing any of these exact ECO codes (comma-separated or repeated). e.g. B12,C44
+          schema:
+            type: string
+        - name: ecoCategory
+          in: query
+          required: false
+          description: Filter by ECO category letter(s) A-E (comma-separated or repeated)
+          schema:
+            type: string
+        - name: opening
+          in: query
+          required: false
+          description: Filter to studies containing any of these exact opening names (comma-separated or repeated)
+          schema:
+            type: string
+        - name: variant
+          in: query
+          required: false
+          description: Filter by variant(s), e.g. Standard, Chess960 (comma-separated or repeated)
+          schema:
+            type: string
+        - name: chapterMode
+          in: query
+          required: false
+          description: Filter by chapter mode(s), e.g. gamebook, normal, practice (comma-separated or repeated)
+          schema:
+            type: string
+        - name: player
+          in: query
+          required: false
+          description: Filter to studies featuring any of these exact player names (comma-separated or repeated)
+          schema:
+            type: string
+        - name: gamebook
+          in: query
+          required: false
+          description: true = only interactive (gamebook) studies; false = exclude them
+          schema:
+            type: boolean
+        - name: customPositions
+          in: query
+          required: false
+          description: true = only studies with custom start positions (e.g. endgame/tactics)
+          schema:
+            type: boolean
+        - name: hasAnnotations
+          in: query
+          required: false
+          description: true = only studies with comments/variations/NAGs
+          schema:
+            type: boolean
+        - name: minViews
+          in: query
+          required: false
+          description: Minimum Lichess view count
+          schema:
+            type: integer
+        - name: minChapters
+          in: query
+          required: false
+          description: Minimum chapter count
+          schema:
+            type: integer
       responses:
         "200":
           description: List of studies
@@ -1643,6 +1709,35 @@ paths:
                         type: integer
                       offset:
                         type: integer
+        "401":
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/studies/facets:
+    get:
+      summary: Distinct study filter values
+      description: |
+        Returns the distinct filter values across served (gated, active) studies
+        so the frontend can populate filter dropdowns dynamically.
+      operationId: getStudyFacets
+      tags:
+        - Studies
+      responses:
+        "200":
+          description: Available facet values
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [success]
+                  data:
+                    $ref: "#/components/schemas/StudyFacets"
         "401":
           description: Missing or invalid API key
           content:
@@ -1873,6 +1968,42 @@ components:
           type: integer
         hasAnnotations:
           type: boolean
+        ecos:
+          type: array
+          description: Distinct ECO codes across the study's chapters
+          items:
+            type: string
+        ecoCategories:
+          type: array
+          description: Distinct ECO category letters (A-E)
+          items:
+            type: string
+        openings:
+          type: array
+          description: Distinct opening names across chapters
+          items:
+            type: string
+        variants:
+          type: array
+          description: Distinct variants (e.g. Standard, Chess960)
+          items:
+            type: string
+        chapterModes:
+          type: array
+          description: Distinct chapter modes (gamebook, normal, practice, conceal)
+          items:
+            type: string
+        players:
+          type: array
+          description: Distinct featured player names (for game-based chapters)
+          items:
+            type: string
+        isGamebook:
+          type: boolean
+          description: True if any chapter is an interactive (gamebook) lesson
+        hasCustomPositions:
+          type: boolean
+          description: True if any chapter starts from a custom position (SetUp)
         credibilityScore:
           type: number
           description: 0-100 quality score; studies below the tunable threshold are not served
@@ -1884,6 +2015,30 @@ components:
         syncedAt:
           type: string
           format: date-time
+    StudyFacets:
+      type: object
+      description: Distinct filter values across served studies
+      properties:
+        ecoCategories:
+          type: array
+          items:
+            type: string
+        openings:
+          type: array
+          items:
+            type: string
+        variants:
+          type: array
+          items:
+            type: string
+        chapterModes:
+          type: array
+          items:
+            type: string
+        players:
+          type: array
+          items:
+            type: string
     LichessStudyChapterMeta:
       type: object
       properties:
@@ -1899,6 +2054,37 @@ components:
           type: integer
         orderIndex:
           type: integer
+        eco:
+          type: string
+          nullable: true
+        opening:
+          type: string
+          nullable: true
+        variant:
+          type: string
+          nullable: true
+        result:
+          type: string
+          nullable: true
+        chapterMode:
+          type: string
+          nullable: true
+        isSetup:
+          type: boolean
+        whiteName:
+          type: string
+          nullable: true
+        blackName:
+          type: string
+          nullable: true
+        whiteElo:
+          type: integer
+          nullable: true
+        blackElo:
+          type: integer
+          nullable: true
+        hasAnnotations:
+          type: boolean
     LichessStudyDetail:
       type: object
       properties:

--- a/gamebase_openapi.yaml
+++ b/gamebase_openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Chess Database API
   description: API for querying chess game positions and player data
-  version: 1.3.0
+  version: 1.4.0
 
 servers:
   - url: http://localhost:3232
@@ -1902,6 +1902,85 @@ paths:
             type: integer
             minimum: 0
             default: 0
+        - name: result
+          in: query
+          required: false
+          description: Filter by result(s) W (white win) / B (black win). Comma-separated or repeated.
+          schema:
+            type: string
+        - name: eco
+          in: query
+          required: false
+          description: Filter by exact ECO code(s), comma-separated or repeated (e.g. B12,C44)
+          schema:
+            type: string
+        - name: ecoCategory
+          in: query
+          required: false
+          description: Filter by ECO category letter(s) A-E, comma-separated or repeated
+          schema:
+            type: string
+        - name: timeControl
+          in: query
+          required: false
+          description: Filter by time control(s) CLASSICAL/RAPID/BLITZ, comma-separated or repeated
+          schema:
+            type: string
+        - name: isOnline
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: minRating
+          in: query
+          required: false
+          description: Minimum average rating of the two players
+          schema:
+            type: integer
+        - name: maxRating
+          in: query
+          required: false
+          description: Maximum average rating of the two players
+          schema:
+            type: integer
+        - name: minMoves
+          in: query
+          required: false
+          description: Minimum final move number
+          schema:
+            type: integer
+        - name: maxMoves
+          in: query
+          required: false
+          description: Maximum final move number
+          schema:
+            type: integer
+        - name: dateFrom
+          in: query
+          required: false
+          description: Inclusive lower bound on game date (YYYY-MM-DD)
+          schema:
+            type: string
+            format: date
+        - name: dateTo
+          in: query
+          required: false
+          description: Inclusive upper bound on game date (YYYY-MM-DD)
+          schema:
+            type: string
+            format: date
+        - name: player
+          in: query
+          required: false
+          description: Case-insensitive substring match on either player's name
+          schema:
+            type: string
+        - name: playerId
+          in: query
+          required: false
+          description: Exact player UUID match on either side
+          schema:
+            type: string
       responses:
         "200":
           description: List of miniatures
@@ -2124,6 +2203,16 @@ components:
         eco:
           type: string
           nullable: true
+        ecoCategory:
+          type: string
+          nullable: true
+          description: ECO category letter (A-E)
+        opening:
+          type: string
+          nullable: true
+        variation:
+          type: string
+          nullable: true
         whiteName:
           type: string
           nullable: true
@@ -2135,6 +2224,18 @@ components:
           nullable: true
         blackElo:
           type: integer
+          nullable: true
+        whitePlayerId:
+          type: string
+          nullable: true
+        blackPlayerId:
+          type: string
+          nullable: true
+        whiteFed:
+          type: string
+          nullable: true
+        blackFed:
+          type: string
           nullable: true
     PositionAggregatesQueryRequest:
       type: object

--- a/gamebase_openapi.yaml
+++ b/gamebase_openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Chess Database API
   description: API for querying chess game positions and player data
-  version: 1.1.0
+  version: 1.2.0
 
 servers:
   - url: http://localhost:3232
@@ -1573,6 +1573,271 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /api/studies:
+    get:
+      summary: List Lichess studies
+      description: |
+        Returns credibility-gated, active Lichess studies. Studies are
+        auto-discovered daily from Lichess's public trending list and pulled via
+        the Lichess API. Sorted by credibility score by default. No premium gate (v1).
+      operationId: listStudies
+      tags:
+        - Studies
+      parameters:
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [score, recent, name, chapters, created]
+            default: score
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive substring search on study name
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of studies
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [success]
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/LichessStudyListItem"
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+        "401":
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/studies/refresh:
+    post:
+      summary: Trigger a studies re-sync (pull-to-refresh)
+      description: Enqueues a background Lichess study sync. Returns immediately.
+      operationId: refreshStudies
+      tags:
+        - Studies
+      responses:
+        "200":
+          description: Sync enqueued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [success]
+                  data:
+                    type: object
+                    properties:
+                      enqueued:
+                        type: boolean
+        "401":
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/studies/{id}:
+    get:
+      summary: Get a study with its chapters
+      operationId: getStudy
+      tags:
+        - Studies
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Lichess study ID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Study detail with chapter list (no PGN bodies)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [success]
+                  data:
+                    $ref: "#/components/schemas/LichessStudyDetail"
+        "401":
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Study not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/studies/{id}/chapters/{chapterId}/pgn:
+    get:
+      summary: Get a chapter's PGN
+      description: Returns the cached PGN of a single study chapter as text.
+      operationId: getStudyChapterPgn
+      tags:
+        - Studies
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Lichess study ID
+          schema:
+            type: string
+        - name: chapterId
+          in: path
+          required: true
+          description: Chapter ID
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Chapter PGN
+          content:
+            application/x-chess-pgn:
+              schema:
+                type: string
+        "401":
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Chapter not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/miniatures:
+    get:
+      summary: List miniatures
+      description: |
+        Decisive short games (more than two full moves, ended by move 19) derived
+        from the master database. Default sort is by average rating (strongest
+        first). Premium gating is not enforced in v1.
+      operationId: listMiniatures
+      tags:
+        - Miniatures
+      parameters:
+        - name: window
+          in: query
+          required: false
+          description: Time window over the game date
+          schema:
+            type: string
+            enum: [today, week, all]
+            default: all
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [rating, moves, recent]
+            default: rating
+        - name: order
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: List of miniatures
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [success]
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Miniature"
+                      total:
+                        type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+        "401":
+          description: Missing or invalid API key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -1582,6 +1847,109 @@ components:
       description: API key for authentication
 
   schemas:
+    LichessStudyListItem:
+      type: object
+      properties:
+        id:
+          type: string
+        authorUsername:
+          type: string
+          nullable: true
+        name:
+          type: string
+        views:
+          type: integer
+          description: View count scraped from Lichess's trending list (popularity signal)
+        lichessCreatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lichessUpdatedAt:
+          type: string
+          format: date-time
+        chapterCount:
+          type: integer
+        plyTotal:
+          type: integer
+        hasAnnotations:
+          type: boolean
+        credibilityScore:
+          type: number
+          description: 0-100 quality score; studies below the tunable threshold are not served
+        passedGate:
+          type: boolean
+        status:
+          type: string
+          enum: [active, gone]
+        syncedAt:
+          type: string
+          format: date-time
+    LichessStudyChapterMeta:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        chapterId:
+          type: string
+        name:
+          type: string
+          nullable: true
+        plyCount:
+          type: integer
+        orderIndex:
+          type: integer
+    LichessStudyDetail:
+      type: object
+      properties:
+        study:
+          $ref: "#/components/schemas/LichessStudyListItem"
+        chapters:
+          type: array
+          items:
+            $ref: "#/components/schemas/LichessStudyChapterMeta"
+    Miniature:
+      type: object
+      properties:
+        gameId:
+          type: string
+          format: uuid
+        avgRating:
+          type: integer
+          nullable: true
+        plyCount:
+          type: integer
+        finalMoveNumber:
+          type: integer
+        result:
+          type: string
+          enum: [W, B]
+        timeControl:
+          type: string
+          enum: [CLASSICAL, RAPID, BLITZ]
+        isOnline:
+          type: boolean
+        date:
+          type: string
+          format: date-time
+        event:
+          type: string
+          nullable: true
+        eco:
+          type: string
+          nullable: true
+        whiteName:
+          type: string
+          nullable: true
+        blackName:
+          type: string
+          nullable: true
+        whiteElo:
+          type: integer
+          nullable: true
+        blackElo:
+          type: integer
+          nullable: true
     PositionAggregatesQueryRequest:
       type: object
       required:

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,10 +41,10 @@ target 'Runner' do
   end
 end
 
-# target 'ChessEverLiveActivity' do
-#   use_frameworks!
-#   pod 'OneSignalXCFramework/OneSignalLiveActivities', '>= 5.0.0', '< 6.0'
-# end
+target 'ChessEverLiveActivity' do
+  use_frameworks!
+  pod 'OneSignalXCFramework/OneSignalLiveActivities', '>= 5.0.0', '< 6.0'
+end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -230,6 +230,7 @@ DEPENDENCIES:
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - onesignal_flutter (from `.symlinks/plugins/onesignal_flutter/ios`)
+  - OneSignalXCFramework/OneSignalLiveActivities (< 6.0, >= 5.0.0)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - patrol (from `.symlinks/plugins/patrol/darwin`)
@@ -385,6 +386,6 @@ SPEC CHECKSUMS:
   terminate_restart: 0fc748d0a297afebc179251b11b8d47771918601
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
-PODFILE CHECKSUM: 6ff84d74c8496973511c796126c1e1614464add8
+PODFILE CHECKSUM: 8fe0368807a7b70a372d905d35802729fbda55bf
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		004DBC670B7E0A1845615452 /* ChessEverLiveActivity.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6DBABF8D2E626C2B27CFE37 /* ChessEverLiveActivity.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0B90995DDD394290F64E9D2A /* Pods_ChessEverLiveActivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733FBED002413F49445A8B67 /* Pods_ChessEverLiveActivity.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		37F9A268DF1EECE998F2AE36 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2E6DBF2B1D7003C108CC99 /* Pods_RunnerTests.framework */; };
@@ -15,8 +17,16 @@
 		401D9F098BFD1E290A2C1902 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB82E4D68B8F3F5DE670AC3E /* Pods_Runner.framework */; };
 		45CCDA2771EDC15EA07CAADB /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A53B1D3EDCCC5635B4ECC77 /* Pods_Runner_RunnerUITests.framework */; };
 		4F6D2CDB58A0C621714D9B93 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 042B0171DE39616BE971A0DE /* GoogleService-Info.plist */; };
+<<<<<<< ours
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		8C24C4D42F0A4A949798A101 /* ChessPipController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C24C4D32F0A4A949798A101 /* ChessPipController.swift */; };
+=======
+		5D4403C92333E225545DF29A /* ChessEverLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB274B8A3127F9D5D4046021 /* ChessEverLiveActivityWidget.swift */; };
+		64C7E03E33F3788C1507B76D /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 277E5CD3CEBD52EC6F1AAD43 /* Pods_RunnerTests.framework */; };
+		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		8F2C9E9A1D3B4A5C6E7F8091 /* Pieces in Resources */ = {isa = PBXBuildFile; fileRef = 7A6B5C4D3E2F1A0B9C8D7E6F /* Pieces */; };
+		9737C7A3833AEE17D064E925 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05189606D970620E0B345F04 /* Pods_Runner_RunnerUITests.framework */; };
+>>>>>>> theirs
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -32,6 +42,13 @@
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
 		};
+		63871A65645ED9D84F7D1A27 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 449EAB555035D89FF5F23864;
+			remoteInfo = ChessEverLiveActivity;
+		};
 		95D724562BC5DDC59B3A7745 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -42,6 +59,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8DEDFE7AB18364916CCB2082 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				004DBC670B7E0A1845615452 /* ChessEverLiveActivity.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -120,6 +148,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				401D9F098BFD1E290A2C1902 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BC5F648A735731E092A08A42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B90995DDD394290F64E9D2A /* Pods_ChessEverLiveActivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -265,6 +301,24 @@
 			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		449EAB555035D89FF5F23864 /* ChessEverLiveActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8342239D7DCF062DB9386712 /* Build configuration list for PBXNativeTarget "ChessEverLiveActivity" */;
+			buildPhases = (
+				5FBEBBA9F896E2A8AA0C1794 /* [CP] Check Pods Manifest.lock */,
+				7503C02A3A736A93AB5BD184 /* Sources */,
+				BC5F648A735731E092A08A42 /* Frameworks */,
+				0EA0285693FBC2AAE40F60EA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChessEverLiveActivity;
+			productName = ChessEverLiveActivity;
+			productReference = B6DBABF8D2E626C2B27CFE37 /* ChessEverLiveActivity.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		4789523DDB3D71DA92BC6F90 /* RunnerUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6FAA7B97E5F818DAC71F2DDA /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
@@ -295,6 +349,7 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
+				8DEDFE7AB18364916CCB2082 /* Embed App Extensions */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				CE4D5249FCA333E7C933F57D /* [CP] Embed Pods Frameworks */,
@@ -303,6 +358,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9F4FFD5115FB800EBC6C2165 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
@@ -322,6 +378,9 @@
 					331C8080294A63A400263BE5 = {
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 97C146ED1CF9000F007C117D;
+					};
+					449EAB555035D89FF5F23864 = {
+						CreatedOnToolsVersion = 15.1;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -343,6 +402,7 @@
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
+				449EAB555035D89FF5F23864 /* ChessEverLiveActivity */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
 				4789523DDB3D71DA92BC6F90 /* RunnerUITests */,
 			);
@@ -350,6 +410,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0EA0285693FBC2AAE40F60EA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F2C9E9A1D3B4A5C6E7F8091 /* Pieces in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1FD15DDF5F8C50F59245E7C9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -454,7 +522,50 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+<<<<<<< ours
 		9740EEB61CF901F6004384FC /* Run Script */ = {
+=======
+		3E586387A54A122781BA87E3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5FBEBBA9F896E2A8AA0C1794 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ChessEverLiveActivity-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		71AC940CA00C9136E970D1C8 /* [CP] Check Pods Manifest.lock */ = {
+>>>>>>> theirs
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -475,9 +586,11 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -490,9 +603,11 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -520,6 +635,7 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
@@ -527,6 +643,7 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
@@ -555,6 +672,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7503C02A3A736A93AB5BD184 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5D4403C92333E225545DF29A /* ChessEverLiveActivityWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -579,6 +704,11 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+		};
+		9F4FFD5115FB800EBC6C2165 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 449EAB555035D89FF5F23864 /* ChessEverLiveActivity */;
+			targetProxy = 63871A65645ED9D84F7D1A27 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -781,6 +911,56 @@
 			};
 			name = Profile;
 		};
+		5D24EDBF695DB9C45A18BB4D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4DBC2ECC332B6DE4D7400CB3 /* Pods-ChessEverLiveActivity.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8J7TUZMYR;
+				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		87AC88EB7CAA503626A624F5 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 189529F9098398DFEBB999B1 /* Pods-ChessEverLiveActivity.profile.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8J7TUZMYR;
+				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Profile;
+		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -969,6 +1149,32 @@
 			};
 			name = Release;
 		};
+		E779D192738E98EEFDDBFECA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 66C0BCD7A562C37B5D1522AE /* Pods-ChessEverLiveActivity.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8J7TUZMYR;
+				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -988,6 +1194,16 @@
 				DF0ED3F932CE073CA2A8F86D /* Release */,
 				09AB94C1FAE9DD0901AC0286 /* Debug */,
 				40426FC57F8300031AAC6F4C /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8342239D7DCF062DB9386712 /* Build configuration list for PBXNativeTarget "ChessEverLiveActivity" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E779D192738E98EEFDDBFECA /* Debug */,
+				5D24EDBF695DB9C45A18BB4D /* Release */,
+				87AC88EB7CAA503626A624F5 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		004DBC670B7E0A1845615452 /* ChessEverLiveActivity.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B6DBABF8D2E626C2B27CFE37 /* ChessEverLiveActivity.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		0B90995DDD394290F64E9D2A /* Pods_ChessEverLiveActivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 733FBED002413F49445A8B67 /* Pods_ChessEverLiveActivity.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		37F9A268DF1EECE998F2AE36 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2E6DBF2B1D7003C108CC99 /* Pods_RunnerTests.framework */; };
@@ -17,16 +15,8 @@
 		401D9F098BFD1E290A2C1902 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB82E4D68B8F3F5DE670AC3E /* Pods_Runner.framework */; };
 		45CCDA2771EDC15EA07CAADB /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A53B1D3EDCCC5635B4ECC77 /* Pods_Runner_RunnerUITests.framework */; };
 		4F6D2CDB58A0C621714D9B93 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 042B0171DE39616BE971A0DE /* GoogleService-Info.plist */; };
-<<<<<<< ours
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		8C24C4D42F0A4A949798A101 /* ChessPipController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C24C4D32F0A4A949798A101 /* ChessPipController.swift */; };
-=======
-		5D4403C92333E225545DF29A /* ChessEverLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB274B8A3127F9D5D4046021 /* ChessEverLiveActivityWidget.swift */; };
-		64C7E03E33F3788C1507B76D /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 277E5CD3CEBD52EC6F1AAD43 /* Pods_RunnerTests.framework */; };
-		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		8F2C9E9A1D3B4A5C6E7F8091 /* Pieces in Resources */ = {isa = PBXBuildFile; fileRef = 7A6B5C4D3E2F1A0B9C8D7E6F /* Pieces */; };
-		9737C7A3833AEE17D064E925 /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05189606D970620E0B345F04 /* Pods_Runner_RunnerUITests.framework */; };
->>>>>>> theirs
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -42,13 +32,6 @@
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
 		};
-		63871A65645ED9D84F7D1A27 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 449EAB555035D89FF5F23864;
-			remoteInfo = ChessEverLiveActivity;
-		};
 		95D724562BC5DDC59B3A7745 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -59,17 +42,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		8DEDFE7AB18364916CCB2082 /* Embed App Extensions */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 13;
-			files = (
-				004DBC670B7E0A1845615452 /* ChessEverLiveActivity.appex in Embed App Extensions */,
-			);
-			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -148,14 +120,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				401D9F098BFD1E290A2C1902 /* Pods_Runner.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BC5F648A735731E092A08A42 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0B90995DDD394290F64E9D2A /* Pods_ChessEverLiveActivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -301,24 +265,6 @@
 			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		449EAB555035D89FF5F23864 /* ChessEverLiveActivity */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8342239D7DCF062DB9386712 /* Build configuration list for PBXNativeTarget "ChessEverLiveActivity" */;
-			buildPhases = (
-				5FBEBBA9F896E2A8AA0C1794 /* [CP] Check Pods Manifest.lock */,
-				7503C02A3A736A93AB5BD184 /* Sources */,
-				BC5F648A735731E092A08A42 /* Frameworks */,
-				0EA0285693FBC2AAE40F60EA /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ChessEverLiveActivity;
-			productName = ChessEverLiveActivity;
-			productReference = B6DBABF8D2E626C2B27CFE37 /* ChessEverLiveActivity.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
 		4789523DDB3D71DA92BC6F90 /* RunnerUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6FAA7B97E5F818DAC71F2DDA /* Build configuration list for PBXNativeTarget "RunnerUITests" */;
@@ -349,7 +295,6 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
-				8DEDFE7AB18364916CCB2082 /* Embed App Extensions */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				CE4D5249FCA333E7C933F57D /* [CP] Embed Pods Frameworks */,
@@ -358,7 +303,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				9F4FFD5115FB800EBC6C2165 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
@@ -378,9 +322,6 @@
 					331C8080294A63A400263BE5 = {
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 97C146ED1CF9000F007C117D;
-					};
-					449EAB555035D89FF5F23864 = {
-						CreatedOnToolsVersion = 15.1;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -402,7 +343,6 @@
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
-				449EAB555035D89FF5F23864 /* ChessEverLiveActivity */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
 				4789523DDB3D71DA92BC6F90 /* RunnerUITests */,
 			);
@@ -410,14 +350,6 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		0EA0285693FBC2AAE40F60EA /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8F2C9E9A1D3B4A5C6E7F8091 /* Pieces in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		1FD15DDF5F8C50F59245E7C9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -522,50 +454,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-<<<<<<< ours
 		9740EEB61CF901F6004384FC /* Run Script */ = {
-=======
-		3E586387A54A122781BA87E3 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5FBEBBA9F896E2A8AA0C1794 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ChessEverLiveActivity-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		71AC940CA00C9136E970D1C8 /* [CP] Check Pods Manifest.lock */ = {
->>>>>>> theirs
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -586,11 +475,9 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -603,11 +490,9 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -635,7 +520,6 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
@@ -643,7 +527,6 @@
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
@@ -672,14 +555,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7503C02A3A736A93AB5BD184 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5D4403C92333E225545DF29A /* ChessEverLiveActivityWidget.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -704,11 +579,6 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
-		};
-		9F4FFD5115FB800EBC6C2165 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 449EAB555035D89FF5F23864 /* ChessEverLiveActivity */;
-			targetProxy = 63871A65645ED9D84F7D1A27 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -911,56 +781,6 @@
 			};
 			name = Profile;
 		};
-		5D24EDBF695DB9C45A18BB4D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4DBC2ECC332B6DE4D7400CB3 /* Pods-ChessEverLiveActivity.release.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N8J7TUZMYR;
-				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Release;
-		};
-		87AC88EB7CAA503626A624F5 /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 189529F9098398DFEBB999B1 /* Pods-ChessEverLiveActivity.profile.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N8J7TUZMYR;
-				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Profile;
-		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1149,32 +969,6 @@
 			};
 			name = Release;
 		};
-		E779D192738E98EEFDDBFECA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 66C0BCD7A562C37B5D1522AE /* Pods-ChessEverLiveActivity.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N8J7TUZMYR;
-				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1194,16 +988,6 @@
 				DF0ED3F932CE073CA2A8F86D /* Release */,
 				09AB94C1FAE9DD0901AC0286 /* Debug */,
 				40426FC57F8300031AAC6F4C /* Profile */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8342239D7DCF062DB9386712 /* Build configuration list for PBXNativeTarget "ChessEverLiveActivity" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E779D192738E98EEFDDBFECA /* Debug */,
-				5D24EDBF695DB9C45A18BB4D /* Release */,
-				87AC88EB7CAA503626A624F5 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -336,10 +336,10 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				3378A20C322A7EBF8FFBD389 /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				CE4D5249FCA333E7C933F57D /* [CP] Embed Pods Frameworks */,
 				0065B991DE2EA1B07B3A37E9 /* [CP] Copy Pods Resources */,
-				3378A20C322A7EBF8FFBD389 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,24 +7,36 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0867846F3DB2419D2346C64B /* ChessEverLiveActivity.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 97C2BA5FFBFD35B03231B740 /* ChessEverLiveActivity.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		327CD0169FC8B1C4B49E78A6 /* ChessEverLiveActivityWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB274B8A3127F9D5D4046021 /* ChessEverLiveActivityWidget.swift */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		37F9A268DF1EECE998F2AE36 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2E6DBF2B1D7003C108CC99 /* Pods_RunnerTests.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3E779A1C07B652E8EE52FB66 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E4DC3D404F7D0575804AC6A /* Foundation.framework */; };
 		401D9F098BFD1E290A2C1902 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB82E4D68B8F3F5DE670AC3E /* Pods_Runner.framework */; };
 		45CCDA2771EDC15EA07CAADB /* Pods_Runner_RunnerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A53B1D3EDCCC5635B4ECC77 /* Pods_Runner_RunnerUITests.framework */; };
+		4BB9CA676C0E2485A595564F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E4DC3D404F7D0575804AC6A /* Foundation.framework */; };
 		4F6D2CDB58A0C621714D9B93 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 042B0171DE39616BE971A0DE /* GoogleService-Info.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		8C24C4D42F0A4A949798A101 /* ChessPipController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C24C4D32F0A4A949798A101 /* ChessPipController.swift */; };
+		963AB148B8E7457FF4B22BED /* Pods_ChessEverLiveActivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44518272C4F4483CEDDB0159 /* Pods_ChessEverLiveActivity.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		9D4E7F0A2C3B4D5E6F708192 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4E7F092C3B4D5E6F708192 /* SceneDelegate.swift */; };
 		AF96305845BAF33C1313795D /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4519BA81E846A5F511D3E83 /* RunnerUITests.m */; };
+		E54CC923CB1C792FF9C892CC /* Pieces in Resources */ = {isa = PBXBuildFile; fileRef = 7A6B5C4D3E2F1A0B9C8D7E6F /* Pieces */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0C99CF2F0FD1CFEF8631FB9E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AB8D2BB890974EDC40666B44;
+			remoteInfo = ChessEverLiveActivity;
+		};
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
@@ -42,6 +54,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3378A20C322A7EBF8FFBD389 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				0867846F3DB2419D2346C64B /* ChessEverLiveActivity.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -60,6 +83,7 @@
 		04868A3A2E8816F4004D27A0 /* RunnerProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerProfile.entitlements; sourceTree = "<group>"; };
 		049743912E87EBEE003D0B56 /* RunnerRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerRelease.entitlements; sourceTree = "<group>"; };
 		0A53B1D3EDCCC5635B4ECC77 /* Pods_Runner_RunnerUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner_RunnerUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E9E2759DA441F26F9001AE8 /* Pods-ChessEverLiveActivity.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChessEverLiveActivity.profile.xcconfig"; path = "Target Support Files/Pods-ChessEverLiveActivity/Pods-ChessEverLiveActivity.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		14B045373B1FB6071A6EBBE4 /* Pods-Runner-RunnerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.debug.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -70,14 +94,15 @@
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3C7C3B0D65B8EF6A1B366DCA /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		44518272C4F4483CEDDB0159 /* Pods_ChessEverLiveActivity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ChessEverLiveActivity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F2E6DBF2B1D7003C108CC99 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6184D25B8FCCEBAC453858BA /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		8C24C4D32F0A4A949798A101 /* ChessPipController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessPipController.swift; sourceTree = "<group>"; };
 		7A6B5C4D3E2F1A0B9C8D7E6F /* Pieces */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Pieces; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		81968B7DC05EC1E3E3B9A597 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8C24C4D32F0A4A949798A101 /* ChessPipController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessPipController.swift; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97584FCE3149A7B91D9EF923 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -86,15 +111,17 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		97C2BA5FFBFD35B03231B740 /* ChessEverLiveActivity.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ChessEverLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D4E7F092C3B4D5E6F708192 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		9FBD8B8645B382AC24173A82 /* Pods-ChessEverLiveActivity.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChessEverLiveActivity.release.xcconfig"; path = "Target Support Files/Pods-ChessEverLiveActivity/Pods-ChessEverLiveActivity.release.xcconfig"; sourceTree = "<group>"; };
 		B4519BA81E846A5F511D3E83 /* RunnerUITests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RunnerUITests.m; path = RunnerUITests/RunnerUITests.m; sourceTree = "<group>"; };
-		B6DBABF8D2E626C2B27CFE37 /* ChessEverLiveActivity.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ChessEverLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB274B8A3127F9D5D4046021 /* ChessEverLiveActivityWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessEverLiveActivityWidget.swift; sourceTree = "<group>"; };
 		BB82E4D68B8F3F5DE670AC3E /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C2679742BF460CAE17569D92 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		CD4896B7584F93D5F895CA50 /* Pods-Runner-RunnerUITests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner-RunnerUITests.profile.xcconfig"; path = "Target Support Files/Pods-Runner-RunnerUITests/Pods-Runner-RunnerUITests.profile.xcconfig"; sourceTree = "<group>"; };
 		EA69E9FBAE973EE20561E3E0 /* RunnerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EABED50A95A9982A37FA2A43 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FB8B835DA596050DC6421558 /* Pods-ChessEverLiveActivity.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChessEverLiveActivity.debug.xcconfig"; path = "Target Support Files/Pods-ChessEverLiveActivity/Pods-ChessEverLiveActivity.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +139,15 @@
 			files = (
 				3E779A1C07B652E8EE52FB66 /* Foundation.framework in Frameworks */,
 				45CCDA2771EDC15EA07CAADB /* Pods_Runner_RunnerUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		333891C982CA2974558ACCA2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4BB9CA676C0E2485A595564F /* Foundation.framework in Frameworks */,
+				963AB148B8E7457FF4B22BED /* Pods_ChessEverLiveActivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,6 +177,7 @@
 				BB82E4D68B8F3F5DE670AC3E /* Pods_Runner.framework */,
 				0A53B1D3EDCCC5635B4ECC77 /* Pods_Runner_RunnerUITests.framework */,
 				5F2E6DBF2B1D7003C108CC99 /* Pods_RunnerTests.framework */,
+				44518272C4F4483CEDDB0159 /* Pods_ChessEverLiveActivity.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -200,9 +237,9 @@
 			isa = PBXGroup;
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
-				B6DBABF8D2E626C2B27CFE37 /* ChessEverLiveActivity.appex */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
 				EA69E9FBAE973EE20561E3E0 /* RunnerUITests.xctest */,
+				97C2BA5FFBFD35B03231B740 /* ChessEverLiveActivity.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -239,6 +276,9 @@
 				EABED50A95A9982A37FA2A43 /* Pods-RunnerTests.debug.xcconfig */,
 				C2679742BF460CAE17569D92 /* Pods-RunnerTests.release.xcconfig */,
 				172AAA6D6B9FF558CEEA212C /* Pods-RunnerTests.profile.xcconfig */,
+				9FBD8B8645B382AC24173A82 /* Pods-ChessEverLiveActivity.release.xcconfig */,
+				FB8B835DA596050DC6421558 /* Pods-ChessEverLiveActivity.debug.xcconfig */,
+				0E9E2759DA441F26F9001AE8 /* Pods-ChessEverLiveActivity.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -299,15 +339,35 @@
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				CE4D5249FCA333E7C933F57D /* [CP] Embed Pods Frameworks */,
 				0065B991DE2EA1B07B3A37E9 /* [CP] Copy Pods Resources */,
+				3378A20C322A7EBF8FFBD389 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				58E55ACE80DB6F6C0ADAD25C /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
+		};
+		AB8D2BB890974EDC40666B44 /* ChessEverLiveActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 64C2078BBBC29C25E50E6DC3 /* Build configuration list for PBXNativeTarget "ChessEverLiveActivity" */;
+			buildPhases = (
+				9D26CD4A58F94529EABAAEE2 /* [CP] Check Pods Manifest.lock */,
+				2888EA1DB7BFD18520EA2A66 /* Sources */,
+				333891C982CA2974558ACCA2 /* Frameworks */,
+				62E1D99EF0260229BDFAA69B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChessEverLiveActivity;
+			productName = ChessEverLiveActivity;
+			productReference = 97C2BA5FFBFD35B03231B740 /* ChessEverLiveActivity.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -345,6 +405,7 @@
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
 				4789523DDB3D71DA92BC6F90 /* RunnerUITests */,
+				AB8D2BB890974EDC40666B44 /* ChessEverLiveActivity */,
 			);
 		};
 /* End PBXProject section */
@@ -361,6 +422,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		62E1D99EF0260229BDFAA69B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E54CC923CB1C792FF9C892CC /* Pieces in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -469,6 +538,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
+		9D26CD4A58F94529EABAAEE2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ChessEverLiveActivity-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		BE3B15BC62197426B142A3EA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -547,6 +638,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2888EA1DB7BFD18520EA2A66 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				327CD0169FC8B1C4B49E78A6 /* ChessEverLiveActivityWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		331C807D294A63A400263BE5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -579,6 +678,12 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+		};
+		58E55ACE80DB6F6C0ADAD25C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ChessEverLiveActivity;
+			target = AB8D2BB890974EDC40666B44 /* ChessEverLiveActivity */;
+			targetProxy = 0C99CF2F0FD1CFEF8631FB9E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -757,6 +862,32 @@
 			};
 			name = Profile;
 		};
+		36662D669FFE66A9A0899B01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FB8B835DA596050DC6421558 /* Pods-ChessEverLiveActivity.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8J7TUZMYR;
+				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
 		40426FC57F8300031AAC6F4C /* Profile */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CD4896B7584F93D5F895CA50 /* Pods-Runner-RunnerUITests.profile.xcconfig */;
@@ -780,6 +911,56 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
+		};
+		5098F4097E412DB39994161A /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0E9E2759DA441F26F9001AE8 /* Pods-ChessEverLiveActivity.profile.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8J7TUZMYR;
+				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Profile;
+		};
+		88F30B7BF4774E75B4120956 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9FBD8B8645B382AC24173A82 /* Pods-ChessEverLiveActivity.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N8J7TUZMYR;
+				INFOPLIST_FILE = ChessEverLiveActivity/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chessever.app.ChessEverLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -978,6 +1159,16 @@
 				331C8088294A63A400263BE5 /* Debug */,
 				331C8089294A63A400263BE5 /* Release */,
 				331C808A294A63A400263BE5 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		64C2078BBBC29C25E50E6DC3 /* Build configuration list for PBXNativeTarget "ChessEverLiveActivity" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				88F30B7BF4774E75B4120956 /* Release */,
+				36662D669FFE66A9A0899B01 /* Debug */,
+				5098F4097E412DB39994161A /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/lib/constants/game_tags.dart
+++ b/lib/constants/game_tags.dart
@@ -1,0 +1,57 @@
+/// Official chess game tags for the personal library (My Likes / saved games).
+///
+/// These are a fixed, curated vocabulary the user can attach to liked/saved
+/// games to organise their own collection. Tags are personal-library only in
+/// v1 — they are NOT used to filter public surfaces (Most Liked, Miniatures).
+///
+/// Stored as plain strings in the `user_saved_analyses.tags` JSONB column, so
+/// the label strings here ARE the persisted values. Keep them stable: renaming
+/// a label orphans any games already tagged with the old value.
+library;
+
+import 'package:flutter/material.dart';
+
+/// A single official tag with its display label and an icon for chips.
+class GameTag {
+  final String label;
+  final IconData icon;
+
+  const GameTag(this.label, this.icon);
+}
+
+/// The canonical, ordered list of official game tags (spec v1).
+const List<GameTag> kOfficialGameTags = [
+  GameTag('Wild Game', Icons.local_fire_department_rounded),
+  GameTag('Beautiful Mate', Icons.auto_awesome_rounded),
+  GameTag('Trap', Icons.gpp_maybe_rounded),
+  GameTag('Good Defense', Icons.shield_rounded),
+  GameTag('Comeback', Icons.trending_up_rounded),
+  GameTag('High Technique', Icons.precision_manufacturing_rounded),
+  GameTag('Positional Masterpiece', Icons.architecture_rounded),
+  GameTag('Sacrifice', Icons.volunteer_activism_rounded),
+  GameTag('Combination', Icons.hub_rounded),
+  GameTag('Blunder', Icons.dangerous_rounded),
+];
+
+/// Just the persisted label strings, in canonical order.
+const List<String> kOfficialGameTagLabels = [
+  'Wild Game',
+  'Beautiful Mate',
+  'Trap',
+  'Good Defense',
+  'Comeback',
+  'High Technique',
+  'Positional Masterpiece',
+  'Sacrifice',
+  'Combination',
+  'Blunder',
+];
+
+/// Resolve the icon for a tag label, falling back to a generic label icon for
+/// any value not in the official set (e.g. legacy/custom tags).
+IconData iconForGameTag(String label) {
+  for (final tag in kOfficialGameTags) {
+    if (tag.label == label) return tag.icon;
+  }
+  return Icons.label_rounded;
+}

--- a/lib/providers/pip_mode_provider.dart
+++ b/lib/providers/pip_mode_provider.dart
@@ -1,9 +1,9 @@
 /// Which games may pop out into Picture-in-Picture.
 ///
 /// Persisted in board settings (`user_engine_settings.pip_mode`, synced) and
-/// premium-gated at the eligibility check + settings UI. Enum order is the
-/// stored integer: off=0 (default), live=1, all=2. "all" covers live +
-/// completed games.
+/// interpreted by the runtime eligibility check. Enum order is the stored
+/// integer: off=0 (default), live=1, all=2. "all" is a legacy value and is now
+/// treated the same as live-only.
 enum PipMode { off, live, all }
 
 extension PipModeInfo on PipMode {

--- a/lib/repository/gamebase/discovery/discovery_models.dart
+++ b/lib/repository/gamebase/discovery/discovery_models.dart
@@ -18,6 +18,14 @@ int _parseInt(Object? raw, [int fallback = 0]) {
   return int.tryParse(raw?.toString() ?? '') ?? fallback;
 }
 
+List<String> _strList(Object? raw) {
+  if (raw is! List) return const [];
+  return [
+    for (final e in raw)
+      if (e != null && e.toString().trim().isNotEmpty) e.toString(),
+  ];
+}
+
 /// A single page of `{ items, total, limit, offset }` envelopes.
 class PagedResult<T> {
   const PagedResult({
@@ -62,6 +70,14 @@ class LichessStudy {
     required this.chapterCount,
     required this.plyTotal,
     required this.hasAnnotations,
+    required this.ecos,
+    required this.ecoCategories,
+    required this.openings,
+    required this.variants,
+    required this.chapterModes,
+    required this.players,
+    required this.isGamebook,
+    required this.hasCustomPositions,
     required this.credibilityScore,
     required this.passedGate,
     required this.status,
@@ -77,6 +93,14 @@ class LichessStudy {
   final int chapterCount;
   final int plyTotal;
   final bool hasAnnotations;
+  final List<String> ecos;
+  final List<String> ecoCategories;
+  final List<String> openings;
+  final List<String> variants;
+  final List<String> chapterModes;
+  final List<String> players;
+  final bool isGamebook;
+  final bool hasCustomPositions;
   final double credibilityScore;
   final bool passedGate;
   final String status;
@@ -93,6 +117,14 @@ class LichessStudy {
       chapterCount: _parseInt(json['chapterCount']),
       plyTotal: _parseInt(json['plyTotal']),
       hasAnnotations: json['hasAnnotations'] == true,
+      ecos: _strList(json['ecos']),
+      ecoCategories: _strList(json['ecoCategories']),
+      openings: _strList(json['openings']),
+      variants: _strList(json['variants']),
+      chapterModes: _strList(json['chapterModes']),
+      players: _strList(json['players']),
+      isGamebook: json['isGamebook'] == true,
+      hasCustomPositions: json['hasCustomPositions'] == true,
       credibilityScore:
           (json['credibilityScore'] is num)
               ? (json['credibilityScore'] as num).toDouble()
@@ -105,6 +137,41 @@ class LichessStudy {
   }
 }
 
+/// Distinct filter values across served studies (`/api/studies/facets`).
+class StudyFacets {
+  const StudyFacets({
+    required this.ecoCategories,
+    required this.openings,
+    required this.variants,
+    required this.chapterModes,
+    required this.players,
+  });
+
+  final List<String> ecoCategories;
+  final List<String> openings;
+  final List<String> variants;
+  final List<String> chapterModes;
+  final List<String> players;
+
+  factory StudyFacets.fromJson(Map<String, dynamic> json) {
+    return StudyFacets(
+      ecoCategories: _strList(json['ecoCategories']),
+      openings: _strList(json['openings']),
+      variants: _strList(json['variants']),
+      chapterModes: _strList(json['chapterModes']),
+      players: _strList(json['players']),
+    );
+  }
+
+  static const empty = StudyFacets(
+    ecoCategories: [],
+    openings: [],
+    variants: [],
+    chapterModes: [],
+    players: [],
+  );
+}
+
 class LichessStudyChapter {
   const LichessStudyChapter({
     required this.id,
@@ -112,6 +179,17 @@ class LichessStudyChapter {
     required this.name,
     required this.plyCount,
     required this.orderIndex,
+    this.eco,
+    this.opening,
+    this.variant,
+    this.result,
+    this.chapterMode,
+    this.isSetup = false,
+    this.whiteName,
+    this.blackName,
+    this.whiteElo,
+    this.blackElo,
+    this.hasAnnotations = false,
   });
 
   final String id;
@@ -119,6 +197,17 @@ class LichessStudyChapter {
   final String? name;
   final int plyCount;
   final int orderIndex;
+  final String? eco;
+  final String? opening;
+  final String? variant;
+  final String? result;
+  final String? chapterMode;
+  final bool isSetup;
+  final String? whiteName;
+  final String? blackName;
+  final int? whiteElo;
+  final int? blackElo;
+  final bool hasAnnotations;
 
   factory LichessStudyChapter.fromJson(Map<String, dynamic> json) {
     return LichessStudyChapter(
@@ -127,7 +216,29 @@ class LichessStudyChapter {
       name: json['name']?.toString(),
       plyCount: _parseInt(json['plyCount']),
       orderIndex: _parseInt(json['orderIndex']),
+      eco: json['eco']?.toString(),
+      opening: json['opening']?.toString(),
+      variant: json['variant']?.toString(),
+      result: json['result']?.toString(),
+      chapterMode: json['chapterMode']?.toString(),
+      isSetup: json['isSetup'] == true,
+      whiteName: json['whiteName']?.toString(),
+      blackName: json['blackName']?.toString(),
+      whiteElo: json['whiteElo'] == null ? null : _parseInt(json['whiteElo']),
+      blackElo: json['blackElo'] == null ? null : _parseInt(json['blackElo']),
+      hasAnnotations: json['hasAnnotations'] == true,
     );
+  }
+
+  /// "1.White vs Black" style subtitle for game chapters, else the opening/eco.
+  String? get gameSubtitle {
+    final w = (whiteName ?? '').trim();
+    final b = (blackName ?? '').trim();
+    if (w.isNotEmpty && b.isNotEmpty) return '$w – $b';
+    final op = (opening ?? '').trim();
+    if (op.isNotEmpty) return op;
+    final e = (eco ?? '').trim();
+    return e.isNotEmpty ? e : null;
   }
 }
 
@@ -163,6 +274,9 @@ class Miniature {
     required this.date,
     required this.event,
     required this.eco,
+    required this.ecoCategory,
+    required this.opening,
+    required this.variation,
     required this.whiteName,
     required this.blackName,
     required this.whiteElo,
@@ -181,6 +295,9 @@ class Miniature {
   final DateTime? date;
   final String? event;
   final String? eco;
+  final String? ecoCategory;
+  final String? opening;
+  final String? variation;
   final String? whiteName;
   final String? blackName;
   final int? whiteElo;
@@ -198,6 +315,9 @@ class Miniature {
       date: _parseDate(json['date']),
       event: json['event']?.toString(),
       eco: json['eco']?.toString(),
+      ecoCategory: json['ecoCategory']?.toString(),
+      opening: json['opening']?.toString(),
+      variation: json['variation']?.toString(),
       whiteName: json['whiteName']?.toString(),
       blackName: json['blackName']?.toString(),
       whiteElo: json['whiteElo'] == null ? null : _parseInt(json['whiteElo']),
@@ -256,6 +376,7 @@ class Miniature {
       pgn: fallbackPgn,
       lastMoveTime: date,
       eco: ecoClean.isNotEmpty ? ecoClean : null,
+      openingName: (opening ?? '').trim().isNotEmpty ? opening!.trim() : null,
       avgElo: avgRating,
       isOnline: isOnline,
     );

--- a/lib/repository/gamebase/discovery/discovery_models.dart
+++ b/lib/repository/gamebase/discovery/discovery_models.dart
@@ -1,0 +1,263 @@
+import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/utils/chess_title_utils.dart';
+
+/// Plain models for the Discovery surfaces (Lichess Studies + Miniatures).
+/// Hand-written `fromJson` (no codegen) to keep the new endpoints lightweight.
+
+DateTime? _parseDate(Object? raw) {
+  if (raw == null) return null;
+  final s = raw.toString();
+  if (s.isEmpty) return null;
+  return DateTime.tryParse(s);
+}
+
+int _parseInt(Object? raw, [int fallback = 0]) {
+  if (raw is int) return raw;
+  if (raw is num) return raw.toInt();
+  return int.tryParse(raw?.toString() ?? '') ?? fallback;
+}
+
+/// A single page of `{ items, total, limit, offset }` envelopes.
+class PagedResult<T> {
+  const PagedResult({
+    required this.items,
+    required this.total,
+    required this.limit,
+    required this.offset,
+  });
+
+  final List<T> items;
+  final int total;
+  final int limit;
+  final int offset;
+
+  bool get hasMore => offset + items.length < total;
+
+  static PagedResult<T> fromData<T>(
+    Map<String, dynamic> data,
+    T Function(Map<String, dynamic>) itemFromJson,
+  ) {
+    final rawItems = (data['items'] as List?) ?? const [];
+    return PagedResult<T>(
+      items: [
+        for (final e in rawItems)
+          itemFromJson(Map<String, dynamic>.from(e as Map)),
+      ],
+      total: _parseInt(data['total']),
+      limit: _parseInt(data['limit']),
+      offset: _parseInt(data['offset']),
+    );
+  }
+}
+
+class LichessStudy {
+  const LichessStudy({
+    required this.id,
+    required this.name,
+    required this.authorUsername,
+    required this.views,
+    required this.lichessCreatedAt,
+    required this.lichessUpdatedAt,
+    required this.chapterCount,
+    required this.plyTotal,
+    required this.hasAnnotations,
+    required this.credibilityScore,
+    required this.passedGate,
+    required this.status,
+    required this.syncedAt,
+  });
+
+  final String id;
+  final String name;
+  final String? authorUsername;
+  final int views;
+  final DateTime? lichessCreatedAt;
+  final DateTime? lichessUpdatedAt;
+  final int chapterCount;
+  final int plyTotal;
+  final bool hasAnnotations;
+  final double credibilityScore;
+  final bool passedGate;
+  final String status;
+  final DateTime? syncedAt;
+
+  factory LichessStudy.fromJson(Map<String, dynamic> json) {
+    return LichessStudy(
+      id: json['id'].toString(),
+      name: (json['name'] ?? 'Untitled study').toString(),
+      authorUsername: json['authorUsername']?.toString(),
+      views: _parseInt(json['views']),
+      lichessCreatedAt: _parseDate(json['lichessCreatedAt']),
+      lichessUpdatedAt: _parseDate(json['lichessUpdatedAt']),
+      chapterCount: _parseInt(json['chapterCount']),
+      plyTotal: _parseInt(json['plyTotal']),
+      hasAnnotations: json['hasAnnotations'] == true,
+      credibilityScore:
+          (json['credibilityScore'] is num)
+              ? (json['credibilityScore'] as num).toDouble()
+              : double.tryParse(json['credibilityScore']?.toString() ?? '') ??
+                  0,
+      passedGate: json['passedGate'] == true,
+      status: (json['status'] ?? 'active').toString(),
+      syncedAt: _parseDate(json['syncedAt']),
+    );
+  }
+}
+
+class LichessStudyChapter {
+  const LichessStudyChapter({
+    required this.id,
+    required this.chapterId,
+    required this.name,
+    required this.plyCount,
+    required this.orderIndex,
+  });
+
+  final String id;
+  final String chapterId;
+  final String? name;
+  final int plyCount;
+  final int orderIndex;
+
+  factory LichessStudyChapter.fromJson(Map<String, dynamic> json) {
+    return LichessStudyChapter(
+      id: json['id'].toString(),
+      chapterId: json['chapterId'].toString(),
+      name: json['name']?.toString(),
+      plyCount: _parseInt(json['plyCount']),
+      orderIndex: _parseInt(json['orderIndex']),
+    );
+  }
+}
+
+class LichessStudyDetail {
+  const LichessStudyDetail({required this.study, required this.chapters});
+
+  final LichessStudy study;
+  final List<LichessStudyChapter> chapters;
+
+  factory LichessStudyDetail.fromJson(Map<String, dynamic> json) {
+    final rawChapters = (json['chapters'] as List?) ?? const [];
+    return LichessStudyDetail(
+      study: LichessStudy.fromJson(
+        Map<String, dynamic>.from(json['study'] as Map),
+      ),
+      chapters: [
+        for (final c in rawChapters)
+          LichessStudyChapter.fromJson(Map<String, dynamic>.from(c as Map)),
+      ]..sort((a, b) => a.orderIndex.compareTo(b.orderIndex)),
+    );
+  }
+}
+
+class Miniature {
+  const Miniature({
+    required this.gameId,
+    required this.avgRating,
+    required this.plyCount,
+    required this.finalMoveNumber,
+    required this.result,
+    required this.timeControl,
+    required this.isOnline,
+    required this.date,
+    required this.event,
+    required this.eco,
+    required this.whiteName,
+    required this.blackName,
+    required this.whiteElo,
+    required this.blackElo,
+  });
+
+  final String gameId;
+  final int? avgRating;
+  final int plyCount;
+  final int finalMoveNumber;
+
+  /// Decisive result only: 'W' (white wins) or 'B' (black wins).
+  final String result;
+  final String timeControl; // CLASSICAL | RAPID | BLITZ
+  final bool isOnline;
+  final DateTime? date;
+  final String? event;
+  final String? eco;
+  final String? whiteName;
+  final String? blackName;
+  final int? whiteElo;
+  final int? blackElo;
+
+  factory Miniature.fromJson(Map<String, dynamic> json) {
+    return Miniature(
+      gameId: json['gameId'].toString(),
+      avgRating: json['avgRating'] == null ? null : _parseInt(json['avgRating']),
+      plyCount: _parseInt(json['plyCount']),
+      finalMoveNumber: _parseInt(json['finalMoveNumber']),
+      result: (json['result'] ?? 'W').toString(),
+      timeControl: (json['timeControl'] ?? 'CLASSICAL').toString(),
+      isOnline: json['isOnline'] == true,
+      date: _parseDate(json['date']),
+      event: json['event']?.toString(),
+      eco: json['eco']?.toString(),
+      whiteName: json['whiteName']?.toString(),
+      blackName: json['blackName']?.toString(),
+      whiteElo: json['whiteElo'] == null ? null : _parseInt(json['whiteElo']),
+      blackElo: json['blackElo'] == null ? null : _parseInt(json['blackElo']),
+    );
+  }
+
+  GameStatus get status =>
+      result == 'B' ? GameStatus.blackWins : GameStatus.whiteWins;
+
+  /// Builds the board-ready model. Source is [GameSource.gamebase] so the board
+  /// lazily fetches the full PGN by [gameId] (these are master-database games),
+  /// mirroring [mapGamebaseGameToGamesTourModel].
+  GamesTourModel toGamesTourModel() {
+    final ecoClean = (eco ?? '').trim();
+    final event0 = (event ?? '').trim();
+    final fallbackPgn =
+        buildPgnFromGamebaseData(<String, dynamic>{
+          'md': {
+            'White': whiteName ?? 'White',
+            'Black': blackName ?? 'Black',
+            'Result': result == 'B' ? '0-1' : '1-0',
+            if (event0.isNotEmpty) 'Event': event0,
+            if (ecoClean.isNotEmpty) 'ECO': ecoClean,
+          },
+        });
+
+    return GamesTourModel(
+      gameId: gameId,
+      source: GameSource.gamebase,
+      whitePlayer: PlayerCard(
+        name: (whiteName ?? 'White').trim().isEmpty ? 'White' : whiteName!,
+        federation: '',
+        title: ChessTitleUtils.normalize(''),
+        rating: whiteElo ?? 0,
+        countryCode: '',
+        team: null,
+      ),
+      blackPlayer: PlayerCard(
+        name: (blackName ?? 'Black').trim().isEmpty ? 'Black' : blackName!,
+        federation: '',
+        title: ChessTitleUtils.normalize(''),
+        rating: blackElo ?? 0,
+        countryCode: '',
+        team: null,
+      ),
+      whiteTimeDisplay: '--:--',
+      blackTimeDisplay: '--:--',
+      whiteClockCentiseconds: 0,
+      blackClockCentiseconds: 0,
+      gameStatus: status,
+      roundId: 'miniature',
+      roundSlug: ecoClean.isNotEmpty ? ecoClean : null,
+      tourId: event0.isNotEmpty ? event0 : 'Miniatures',
+      tourSlug: event0.isNotEmpty ? event0 : null,
+      pgn: fallbackPgn,
+      lastMoveTime: date,
+      eco: ecoClean.isNotEmpty ? ecoClean : null,
+      avgElo: avgRating,
+      isOnline: isOnline,
+    );
+  }
+}

--- a/lib/repository/gamebase/discovery/discovery_providers.dart
+++ b/lib/repository/gamebase/discovery/discovery_providers.dart
@@ -19,33 +19,122 @@ extension StudiesSortX on StudiesSort {
 }
 
 class StudiesQuery {
-  const StudiesQuery({this.sort = StudiesSort.score, this.q = ''});
+  const StudiesQuery({
+    this.sort = StudiesSort.score,
+    this.q = '',
+    this.ecoCategories = const <String>{},
+    this.variants = const <String>{},
+    this.chapterModes = const <String>{},
+    this.gamebook,
+    this.hasAnnotations,
+  });
 
   final StudiesSort sort;
   final String q;
+  final Set<String> ecoCategories;
+  final Set<String> variants;
+  final Set<String> chapterModes;
+  final bool? gamebook;
+  final bool? hasAnnotations;
 
-  StudiesQuery copyWith({StudiesSort? sort, String? q}) =>
-      StudiesQuery(sort: sort ?? this.sort, q: q ?? this.q);
+  int get activeFilterCount =>
+      ecoCategories.length +
+      variants.length +
+      chapterModes.length +
+      (gamebook != null ? 1 : 0) +
+      (hasAnnotations != null ? 1 : 0);
+
+  bool get hasFilters => activeFilterCount > 0;
+
+  /// Backend query params for the v1.4.0 study filters (comma-joined multis).
+  Map<String, dynamic> filterParams() => {
+    if (ecoCategories.isNotEmpty) 'ecoCategory': ecoCategories.join(','),
+    if (variants.isNotEmpty) 'variant': variants.join(','),
+    if (chapterModes.isNotEmpty) 'chapterMode': chapterModes.join(','),
+    if (gamebook != null) 'gamebook': gamebook,
+    if (hasAnnotations != null) 'hasAnnotations': hasAnnotations,
+  };
 
   @override
   bool operator ==(Object other) =>
-      other is StudiesQuery && other.sort == sort && other.q == q;
+      other is StudiesQuery &&
+      other.sort == sort &&
+      other.q == q &&
+      _setEq(other.ecoCategories, ecoCategories) &&
+      _setEq(other.variants, variants) &&
+      _setEq(other.chapterModes, chapterModes) &&
+      other.gamebook == gamebook &&
+      other.hasAnnotations == hasAnnotations;
 
   @override
-  int get hashCode => Object.hash(sort, q);
+  int get hashCode => Object.hash(
+    sort,
+    q,
+    Object.hashAllUnordered(ecoCategories),
+    Object.hashAllUnordered(variants),
+    Object.hashAllUnordered(chapterModes),
+    gamebook,
+    hasAnnotations,
+  );
 }
+
+bool _setEq(Set<String> a, Set<String> b) =>
+    a.length == b.length && a.containsAll(b);
 
 class StudiesQueryNotifier extends StateNotifier<StudiesQuery> {
   StudiesQueryNotifier() : super(const StudiesQuery());
 
-  void setSort(StudiesSort sort) => state = state.copyWith(sort: sort);
-  void setSearch(String q) => state = state.copyWith(q: q);
+  void setSort(StudiesSort sort) => state = StudiesQuery(
+    sort: sort,
+    q: state.q,
+    ecoCategories: state.ecoCategories,
+    variants: state.variants,
+    chapterModes: state.chapterModes,
+    gamebook: state.gamebook,
+    hasAnnotations: state.hasAnnotations,
+  );
+
+  void setSearch(String q) => state = StudiesQuery(
+    sort: state.sort,
+    q: q,
+    ecoCategories: state.ecoCategories,
+    variants: state.variants,
+    chapterModes: state.chapterModes,
+    gamebook: state.gamebook,
+    hasAnnotations: state.hasAnnotations,
+  );
+
+  /// Replaces the whole filter set (used by the filter sheet's Apply).
+  void applyFilters({
+    required Set<String> ecoCategories,
+    required Set<String> variants,
+    required Set<String> chapterModes,
+    required bool? gamebook,
+    required bool? hasAnnotations,
+  }) {
+    state = StudiesQuery(
+      sort: state.sort,
+      q: state.q,
+      ecoCategories: ecoCategories,
+      variants: variants,
+      chapterModes: chapterModes,
+      gamebook: gamebook,
+      hasAnnotations: hasAnnotations,
+    );
+  }
+
+  void clearFilters() => state = StudiesQuery(sort: state.sort, q: state.q);
 }
 
 final studiesQueryProvider =
     StateNotifierProvider<StudiesQueryNotifier, StudiesQuery>(
       (ref) => StudiesQueryNotifier(),
     );
+
+final studyFacetsProvider = FutureProvider.autoDispose<StudyFacets>((ref) async {
+  final repo = ref.watch(gamebaseRepositoryProvider);
+  return repo.getStudyFacets();
+});
 
 /// The studies list for the active query. `score`/`recent` default to desc
 /// (best/newest first); `name` reads better ascending.
@@ -59,6 +148,7 @@ final studiesListProvider =
         order: order,
         q: query.q,
         limit: 50,
+        filters: query.filterParams(),
       );
     });
 
@@ -96,27 +186,82 @@ class MiniaturesQuery {
   const MiniaturesQuery({
     this.window = MiniatureWindow.all,
     this.sort = MiniatureSort.rating,
+    this.results = const <String>{},
+    this.timeControls = const <String>{},
+    this.ecoCategories = const <String>{},
   });
 
   final MiniatureWindow window;
   final MiniatureSort sort;
+  final Set<String> results; // W / B
+  final Set<String> timeControls; // CLASSICAL / RAPID / BLITZ
+  final Set<String> ecoCategories; // A-E
 
-  MiniaturesQuery copyWith({MiniatureWindow? window, MiniatureSort? sort}) =>
-      MiniaturesQuery(window: window ?? this.window, sort: sort ?? this.sort);
+  int get activeFilterCount =>
+      results.length + timeControls.length + ecoCategories.length;
+
+  bool get hasFilters => activeFilterCount > 0;
+
+  Map<String, dynamic> filterParams() => {
+    if (results.isNotEmpty) 'result': results.join(','),
+    if (timeControls.isNotEmpty) 'timeControl': timeControls.join(','),
+    if (ecoCategories.isNotEmpty) 'ecoCategory': ecoCategories.join(','),
+  };
 
   @override
   bool operator ==(Object other) =>
-      other is MiniaturesQuery && other.window == window && other.sort == sort;
+      other is MiniaturesQuery &&
+      other.window == window &&
+      other.sort == sort &&
+      _setEq(other.results, results) &&
+      _setEq(other.timeControls, timeControls) &&
+      _setEq(other.ecoCategories, ecoCategories);
 
   @override
-  int get hashCode => Object.hash(window, sort);
+  int get hashCode => Object.hash(
+    window,
+    sort,
+    Object.hashAllUnordered(results),
+    Object.hashAllUnordered(timeControls),
+    Object.hashAllUnordered(ecoCategories),
+  );
 }
 
 class MiniaturesQueryNotifier extends StateNotifier<MiniaturesQuery> {
   MiniaturesQueryNotifier() : super(const MiniaturesQuery());
 
-  void setWindow(MiniatureWindow window) => state = state.copyWith(window: window);
-  void setSort(MiniatureSort sort) => state = state.copyWith(sort: sort);
+  void setWindow(MiniatureWindow window) => state = MiniaturesQuery(
+    window: window,
+    sort: state.sort,
+    results: state.results,
+    timeControls: state.timeControls,
+    ecoCategories: state.ecoCategories,
+  );
+
+  void setSort(MiniatureSort sort) => state = MiniaturesQuery(
+    window: state.window,
+    sort: sort,
+    results: state.results,
+    timeControls: state.timeControls,
+    ecoCategories: state.ecoCategories,
+  );
+
+  void applyFilters({
+    required Set<String> results,
+    required Set<String> timeControls,
+    required Set<String> ecoCategories,
+  }) {
+    state = MiniaturesQuery(
+      window: state.window,
+      sort: state.sort,
+      results: results,
+      timeControls: timeControls,
+      ecoCategories: ecoCategories,
+    );
+  }
+
+  void clearFilters() =>
+      state = MiniaturesQuery(window: state.window, sort: state.sort);
 }
 
 final miniaturesQueryProvider =
@@ -135,5 +280,6 @@ final miniaturesListProvider =
         sort: query.sort.api,
         order: order,
         limit: 50,
+        filters: query.filterParams(),
       );
     });

--- a/lib/repository/gamebase/discovery/discovery_providers.dart
+++ b/lib/repository/gamebase/discovery/discovery_providers.dart
@@ -1,0 +1,139 @@
+import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
+import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// ── Studies ─────────────────────────────────────────────────────────────
+
+/// Sort key for the Studies list. Matches the API enum.
+enum StudiesSort { score, recent, name, chapters, created }
+
+extension StudiesSortX on StudiesSort {
+  String get api => name; // score|recent|name|chapters|created
+  String get label => switch (this) {
+    StudiesSort.score => 'Best quality',
+    StudiesSort.recent => 'Recently updated',
+    StudiesSort.name => 'Name',
+    StudiesSort.chapters => 'Chapters',
+    StudiesSort.created => 'Newest',
+  };
+}
+
+class StudiesQuery {
+  const StudiesQuery({this.sort = StudiesSort.score, this.q = ''});
+
+  final StudiesSort sort;
+  final String q;
+
+  StudiesQuery copyWith({StudiesSort? sort, String? q}) =>
+      StudiesQuery(sort: sort ?? this.sort, q: q ?? this.q);
+
+  @override
+  bool operator ==(Object other) =>
+      other is StudiesQuery && other.sort == sort && other.q == q;
+
+  @override
+  int get hashCode => Object.hash(sort, q);
+}
+
+class StudiesQueryNotifier extends StateNotifier<StudiesQuery> {
+  StudiesQueryNotifier() : super(const StudiesQuery());
+
+  void setSort(StudiesSort sort) => state = state.copyWith(sort: sort);
+  void setSearch(String q) => state = state.copyWith(q: q);
+}
+
+final studiesQueryProvider =
+    StateNotifierProvider<StudiesQueryNotifier, StudiesQuery>(
+      (ref) => StudiesQueryNotifier(),
+    );
+
+/// The studies list for the active query. `score`/`recent` default to desc
+/// (best/newest first); `name` reads better ascending.
+final studiesListProvider =
+    FutureProvider.autoDispose<PagedResult<LichessStudy>>((ref) async {
+      final query = ref.watch(studiesQueryProvider);
+      final repo = ref.watch(gamebaseRepositoryProvider);
+      final order = query.sort == StudiesSort.name ? 'asc' : 'desc';
+      return repo.listStudies(
+        sort: query.sort.api,
+        order: order,
+        q: query.q,
+        limit: 50,
+      );
+    });
+
+final studyDetailProvider = FutureProvider.autoDispose
+    .family<LichessStudyDetail?, String>((ref, studyId) async {
+      final repo = ref.watch(gamebaseRepositoryProvider);
+      return repo.getStudy(studyId);
+    });
+
+// ── Miniatures ──────────────────────────────────────────────────────────
+
+enum MiniatureWindow { today, week, all }
+
+extension MiniatureWindowX on MiniatureWindow {
+  String get api => name; // today|week|all
+  String get label => switch (this) {
+    MiniatureWindow.today => 'Today',
+    MiniatureWindow.week => 'Week',
+    MiniatureWindow.all => 'All time',
+  };
+}
+
+enum MiniatureSort { rating, moves, recent }
+
+extension MiniatureSortX on MiniatureSort {
+  String get api => name; // rating|moves|recent
+  String get label => switch (this) {
+    MiniatureSort.rating => 'Strongest',
+    MiniatureSort.moves => 'Fewest moves',
+    MiniatureSort.recent => 'Most recent',
+  };
+}
+
+class MiniaturesQuery {
+  const MiniaturesQuery({
+    this.window = MiniatureWindow.all,
+    this.sort = MiniatureSort.rating,
+  });
+
+  final MiniatureWindow window;
+  final MiniatureSort sort;
+
+  MiniaturesQuery copyWith({MiniatureWindow? window, MiniatureSort? sort}) =>
+      MiniaturesQuery(window: window ?? this.window, sort: sort ?? this.sort);
+
+  @override
+  bool operator ==(Object other) =>
+      other is MiniaturesQuery && other.window == window && other.sort == sort;
+
+  @override
+  int get hashCode => Object.hash(window, sort);
+}
+
+class MiniaturesQueryNotifier extends StateNotifier<MiniaturesQuery> {
+  MiniaturesQueryNotifier() : super(const MiniaturesQuery());
+
+  void setWindow(MiniatureWindow window) => state = state.copyWith(window: window);
+  void setSort(MiniatureSort sort) => state = state.copyWith(sort: sort);
+}
+
+final miniaturesQueryProvider =
+    StateNotifierProvider<MiniaturesQueryNotifier, MiniaturesQuery>(
+      (ref) => MiniaturesQueryNotifier(),
+    );
+
+/// `moves` sorts ascending (fewest first) by default; others descending.
+final miniaturesListProvider =
+    FutureProvider.autoDispose<PagedResult<Miniature>>((ref) async {
+      final query = ref.watch(miniaturesQueryProvider);
+      final repo = ref.watch(gamebaseRepositoryProvider);
+      final order = query.sort == MiniatureSort.moves ? 'asc' : 'desc';
+      return repo.listMiniatures(
+        window: query.window.api,
+        sort: query.sort.api,
+        order: order,
+        limit: 50,
+      );
+    });

--- a/lib/repository/gamebase/gamebase_repository.dart
+++ b/lib/repository/gamebase/gamebase_repository.dart
@@ -405,6 +405,7 @@ class GamebaseRepository {
     int limit = 50,
     int offset = 0,
     String? q,
+    Map<String, dynamic>? filters,
   }) async {
     final response = await _dio.get(
       '$_baseUrl/api/studies',
@@ -414,6 +415,7 @@ class GamebaseRepository {
         'limit': limit,
         'offset': offset,
         if (q != null && q.trim().isNotEmpty) 'q': q.trim(),
+        ..._cleanParams(filters),
       },
       options: Options(
         headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},
@@ -421,6 +423,38 @@ class GamebaseRepository {
     );
     final data = Map<String, dynamic>.from(response.data['data'] as Map);
     return PagedResult.fromData(data, LichessStudy.fromJson);
+  }
+
+  /// Distinct filter values for the studies filter UI. Empty on failure.
+  Future<StudyFacets> getStudyFacets() async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl/api/studies/facets',
+        options: Options(
+          headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},
+        ),
+      );
+      final data = response.data['data'];
+      if (data == null) return StudyFacets.empty;
+      return StudyFacets.fromJson(Map<String, dynamic>.from(data));
+    } catch (e) {
+      if (kDebugMode) debugPrint('[GamebaseRepository] getStudyFacets: $e');
+      return StudyFacets.empty;
+    }
+  }
+
+  /// Drops null / empty-string / empty-list values so we never send blank
+  /// query params to the backend.
+  Map<String, dynamic> _cleanParams(Map<String, dynamic>? params) {
+    if (params == null) return const {};
+    final out = <String, dynamic>{};
+    params.forEach((key, value) {
+      if (value == null) return;
+      if (value is String && value.trim().isEmpty) return;
+      if (value is Iterable && value.isEmpty) return;
+      out[key] = value;
+    });
+    return out;
   }
 
   /// Enqueues a background Lichess re-sync (pull-to-refresh). Best-effort.
@@ -485,6 +519,7 @@ class GamebaseRepository {
     String order = 'desc',
     int limit = 50,
     int offset = 0,
+    Map<String, dynamic>? filters,
   }) async {
     final response = await _dio.get(
       '$_baseUrl/api/miniatures',
@@ -494,6 +529,7 @@ class GamebaseRepository {
         'order': order,
         'limit': limit,
         'offset': offset,
+        ..._cleanParams(filters),
       },
       options: Options(
         headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},

--- a/lib/repository/gamebase/gamebase_repository.dart
+++ b/lib/repository/gamebase/gamebase_repository.dart
@@ -9,6 +9,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:chessever2/screens/gamebase/models/models.dart';
+import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
 import 'package:chessever2/repository/gamebase/search/gamebase_search_models.dart';
 import 'package:chessever2/repository/gamebase/search/gamebase_search_models_extra.dart';
 
@@ -394,6 +395,112 @@ class GamebaseRepository {
       }
       return null;
     }
+  }
+
+  // ── Discovery: Lichess Studies ────────────────────────────────────────
+
+  Future<PagedResult<LichessStudy>> listStudies({
+    String sort = 'score',
+    String order = 'desc',
+    int limit = 50,
+    int offset = 0,
+    String? q,
+  }) async {
+    final response = await _dio.get(
+      '$_baseUrl/api/studies',
+      queryParameters: {
+        'sort': sort,
+        'order': order,
+        'limit': limit,
+        'offset': offset,
+        if (q != null && q.trim().isNotEmpty) 'q': q.trim(),
+      },
+      options: Options(
+        headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},
+      ),
+    );
+    final data = Map<String, dynamic>.from(response.data['data'] as Map);
+    return PagedResult.fromData(data, LichessStudy.fromJson);
+  }
+
+  /// Enqueues a background Lichess re-sync (pull-to-refresh). Best-effort.
+  Future<bool> refreshStudies() async {
+    try {
+      final response = await _dio.post(
+        '$_baseUrl/api/studies/refresh',
+        options: Options(
+          headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},
+        ),
+      );
+      final data = response.data['data'];
+      return data is Map && data['enqueued'] == true;
+    } catch (e) {
+      if (kDebugMode) debugPrint('[GamebaseRepository] refreshStudies: $e');
+      return false;
+    }
+  }
+
+  Future<LichessStudyDetail?> getStudy(String id) async {
+    try {
+      final response = await _dio.get(
+        '$_baseUrl/api/studies/$id',
+        options: Options(
+          headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},
+        ),
+      );
+      final data = response.data['data'];
+      if (data == null) return null;
+      return LichessStudyDetail.fromJson(Map<String, dynamic>.from(data));
+    } on DioException catch (e) {
+      if (kDebugMode) debugPrint('[GamebaseRepository] getStudy: ${e.message}');
+      return null;
+    }
+  }
+
+  /// Returns the chapter's PGN body (plain text), or null on failure.
+  Future<String?> getStudyChapterPgn(String studyId, String chapterId) async {
+    try {
+      final response = await _dio.get<String>(
+        '$_baseUrl/api/studies/$studyId/chapters/$chapterId/pgn',
+        options: Options(
+          headers: {'X-API-Key': _apiKey, 'Accept': 'application/x-chess-pgn'},
+          responseType: ResponseType.plain,
+        ),
+      );
+      final body = response.data;
+      return (body != null && body.trim().isNotEmpty) ? body : null;
+    } on DioException catch (e) {
+      if (kDebugMode) {
+        debugPrint('[GamebaseRepository] getStudyChapterPgn: ${e.message}');
+      }
+      return null;
+    }
+  }
+
+  // ── Discovery: Miniatures ─────────────────────────────────────────────
+
+  Future<PagedResult<Miniature>> listMiniatures({
+    String window = 'all',
+    String sort = 'rating',
+    String order = 'desc',
+    int limit = 50,
+    int offset = 0,
+  }) async {
+    final response = await _dio.get(
+      '$_baseUrl/api/miniatures',
+      queryParameters: {
+        'window': window,
+        'sort': sort,
+        'order': order,
+        'limit': limit,
+        'offset': offset,
+      },
+      options: Options(
+        headers: {'X-API-Key': _apiKey, 'Accept': 'application/json'},
+      ),
+    );
+    final data = Map<String, dynamic>.from(response.data['data'] as Map);
+    return PagedResult.fromData(data, Miniature.fromJson);
   }
 
   Future<CloudEval?> getEvalByFen(String fen) async {

--- a/lib/repository/liked_games/liked_games_provider.dart
+++ b/lib/repository/liked_games/liked_games_provider.dart
@@ -214,6 +214,27 @@ class LikedGamesNotifier extends AsyncNotifier<List<SavedAnalysis>> {
     return chessGame.copyWith(metadata: meta);
   }
 
+  /// Sets the official tags on the already-liked game identified by [likeId].
+  /// The roulette assigns a single tag (or none), but tags are stored as a list
+  /// for parity with the My Likes tag-filter UI. Optimistic; reloads on failure.
+  /// No-op if the liked row isn't present/persisted yet.
+  Future<void> setTagsForLikeId(String likeId, List<String> tags) async {
+    final list = List<SavedAnalysis>.from(state.valueOrNull ?? const []);
+    final idx = list.indexWhere(
+      (a) => a.sourceGameId == likeId && a.id.isNotEmpty,
+    );
+    if (idx == -1) return;
+    final updated = list[idx].copyWith(tags: tags, updatedAt: DateTime.now());
+    list[idx] = updated;
+    state = AsyncValue.data(list);
+    try {
+      await _repo.updateSavedAnalysis(updated);
+    } catch (e) {
+      debugPrint('[LikedGames] setTagsForLikeId failed: $e');
+      await _reload();
+    }
+  }
+
   /// Removes a specific liked game by its saved-analysis id (used by the
   /// My Likes list's swipe-to-unlike, which acts on a SavedAnalysis rather
   /// than a GamesTourModel). Optimistic; reloads and returns `false` on failure

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -47,6 +47,7 @@ import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/services/analytics/analytics_service.dart';
 import 'package:chessever2/utils/audio_player_service.dart';
 import 'package:chessever2/utils/foreground_task_scheduler.dart';
 import 'package:chessever2/services/pip_service.dart';
@@ -1466,8 +1467,6 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
   }
 
   bool _isPipEligible(GamesTourModel game) {
-    // PiP is a premium-only feature.
-    if (!ref.read(subscriptionProvider).isSubscribed) return false;
     final mode =
         ref.read(boardSettingsProviderNew).valueOrNull?.pipMode ?? PipMode.off;
     switch (mode) {
@@ -1476,9 +1475,28 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       case PipMode.live:
         return GameFilterHelper.isLiveNow(game);
       case PipMode.all:
-        return GameFilterHelper.isLiveNow(game) ||
-            game.effectiveGameStatus.isFinished;
+        // Legacy persisted value. PiP now only enters for live games.
+        return GameFilterHelper.isLiveNow(game);
     }
+  }
+
+  Map<String, dynamic> _pipAnalyticsProperties(
+    GamesTourModel game, {
+    required PipMode mode,
+    required bool isLive,
+  }) {
+    return {
+      'mode': mode == PipMode.all ? PipMode.live.label : mode.label,
+      'is_live': isLive,
+      'game_id': game.gameId,
+      'game_source': game.source.name,
+      'game_status': game.gameStatus.name,
+      'tour_id': game.tourId,
+      if (game.tourSlug != null) 'tour_slug': game.tourSlug,
+      'round_id': game.roundId,
+      if (game.roundSlug != null) 'round_slug': game.roundSlug,
+      if (game.boardNr != null) 'board_nr': game.boardNr,
+    };
   }
 
   Map<String, dynamic> _buildPipPayload(
@@ -1717,13 +1735,34 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     final currentGame = _resolveGameForIndex(safeIndex);
     final params = _createParams(currentGame, safeIndex);
     final state = ref.read(chessBoardScreenProviderNew(params)).valueOrNull;
+    final game = state?.game ?? currentGame;
+    final mode =
+        ref.read(boardSettingsProviderNew).valueOrNull?.pipMode ?? PipMode.off;
+    final isLive = GameFilterHelper.isLiveNow(game);
+    final isEligible = _isPipEligible(game);
+
+    AnalyticsService.instance.trackEventDetached(
+      'PiP Enter Attempted',
+      properties: {
+        ..._pipAnalyticsProperties(game, mode: mode, isLive: isLive),
+        'eligible': isEligible,
+      },
+    );
+
     if (state != null) {
       await _syncPipState(state);
     } else {
       await _syncPipGameSnapshot(currentGame);
     }
-    if (_isPipEligible(state?.game ?? currentGame)) {
-      await PipService.instance.enterIfEligible();
+    if (isEligible) {
+      final entered = await PipService.instance.enterIfEligible();
+      AnalyticsService.instance.trackEventDetached(
+        entered ? 'PiP Entered' : 'PiP Enter Failed',
+        properties: {
+          ..._pipAnalyticsProperties(game, mode: mode, isLive: isLive),
+          'eligible': true,
+        },
+      );
     }
   }
 

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -87,6 +87,7 @@ import 'package:chessever2/repository/supabase/group_broadcast/group_tour_reposi
 import 'package:motor/motor.dart';
 import 'package:chessever2/repository/liked_games/liked_games_provider.dart';
 import 'package:chessever2/screens/chessboard/widgets/heart_burst.dart';
+import 'package:chessever2/screens/my_likes/widgets/roulette_tag_picker.dart';
 import 'package:chessever2/screens/chessboard/widgets/like_flight.dart';
 import 'package:chessever2/screens/gamebase/widgets/board_opening_explorer_panel.dart';
 import 'package:chessever2/screens/gamebase/widgets/position_games_sheet.dart';
@@ -7623,6 +7624,35 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
             _likeInteractionInProgress = false;
           }),
     );
+
+    // Fresh like → offer the roulette so the user can tag the game. Tags are a
+    // My-Likes-only concept, so this only fires on a like (never an unlike).
+    if (!wasLiked) {
+      unawaited(_offerTagAfterLike(game, toggleFuture, interactionToken));
+    }
+  }
+
+  /// Raises the roulette tag picker shortly after a like lands, then writes the
+  /// chosen tag onto the freshly-liked game. Skipping / letting the spin expire
+  /// resolves to null and leaves the game untagged.
+  Future<void> _offerTagAfterLike(
+    GamesTourModel game,
+    Future<void> toggleFuture,
+    int interactionToken,
+  ) async {
+    // Let the heart burst + flight breathe before the sheet rises.
+    await Future<void>.delayed(const Duration(milliseconds: 700));
+    if (!mounted || interactionToken != _likeInteractionToken) return;
+    final tag = await showRouletteTagPicker(context);
+    if (!mounted || tag == null) return;
+    // Ensure the optimistic insert has reconciled to a real row id first.
+    try {
+      await toggleFuture;
+    } catch (_) {}
+    if (!mounted) return;
+    await ref
+        .read(likedGamesProvider.notifier)
+        .setTagsForLikeId(game.likeId, [tag]);
   }
 
   void _removeFlyingHeartEntry() {

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -106,6 +106,7 @@ import 'package:chessever2/services/lichess_move_annotations_service.dart';
 import 'package:chessever2/services/live_updates_service.dart';
 import 'package:chessever2/main.dart' show routeObserver;
 import 'package:chessever2/providers/auth_state_provider.dart';
+import 'package:chessever2/providers/notification_preferences_provider.dart';
 import 'package:chessever2/providers/notifications_settings_provider.dart';
 import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 
@@ -1734,8 +1735,12 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     final pushEnabled = ref.read(notificationsSettingsProvider).enabled;
     if (!pushEnabled) return;
 
-    // Backgrounding an active board is an explicit opt-in for live tracking,
-    // so don't re-gate it behind the broader live-updates category toggle.
+    // Live Activities are a premium-only feature.
+    if (!ref.read(subscriptionProvider).isSubscribed) return;
+
+    // Respect the user's Live Updates preference (Settings → Notifications).
+    final prefs = ref.read(notificationPreferencesProvider).valueOrNull;
+    if (prefs == null || !prefs.liveGameUpdates) return;
 
     // Don't start if already active for this game
     final liveService = LiveUpdatesService.instance;

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -792,7 +792,6 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
   late Animation<double> _swipeFadeAnimation;
   late Animation<double> _swipeScaleAnimation;
   late Animation<double> _swipeMoveAnimation;
-  final GlobalKey<_SwipeTutorialOverlayState> _tutorialOverlayKey = GlobalKey();
 
   // Step 3/3 ("Double-Tap to Like") — chained after the Switch Views step via
   // [likeTutorialRequestProvider]. Hosted here (not in a nested panel) so the
@@ -1000,16 +999,17 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
 
   void _insertLikeTutorialOverlay() {
     _likeTutorialEntry = OverlayEntry(
-      builder: (_) => LikeTutorialOverlay(
-        currentStep: 3,
-        totalSteps: 3,
-        onDismiss: _onLikeTutorialFinished,
-        onDontShowAgain: () async {
-          final prefs = ref.read(sharedPreferencesRepository);
-          await prefs.setBool(kLikeWalkthroughDontShowKey, true);
-          _onLikeTutorialFinished();
-        },
-      ),
+      builder:
+          (_) => LikeTutorialOverlay(
+            currentStep: 3,
+            totalSteps: 3,
+            onDismiss: _onLikeTutorialFinished,
+            onDontShowAgain: () async {
+              final prefs = ref.read(sharedPreferencesRepository);
+              await prefs.setBool(kLikeWalkthroughDontShowKey, true);
+              _onLikeTutorialFinished();
+            },
+          ),
     );
     Overlay.of(context, rootOverlay: true).insert(_likeTutorialEntry!);
   }
@@ -1148,6 +1148,9 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       initialFen: widget.initialFen,
     );
   }
+
+  String _likeFlightAnchorId(int pageIndex) =>
+      '${identityHashCode(this)}:$pageIndex';
 
   void _ensureLatestMoveSelected({
     required WidgetRef ref,
@@ -2007,6 +2010,7 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       return _LoadingScreen(
         games: widget.games.isNotEmpty ? widget.games : [widget.games.first],
         currentGameIndex: _currentPageIndex.clamp(0, widget.games.length - 1),
+        likeFlightAnchorId: _likeFlightAnchorId(_currentPageIndex),
         onGameChanged: (index) {},
         lastViewedIndex: _lastViewedIndex,
       );
@@ -2042,6 +2046,7 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       return _LoadingScreen(
         games: widget.games.isNotEmpty ? widget.games : [widget.games.first],
         currentGameIndex: _currentPageIndex.clamp(0, widget.games.length - 1),
+        likeFlightAnchorId: _likeFlightAnchorId(_currentPageIndex),
         onGameChanged: (index) {},
         lastViewedIndex: _lastViewedIndex,
       );
@@ -2167,6 +2172,9 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
                                         games: syncedGames,
                                         currentGameIndex: index,
                                         currentPageIndex: _currentPageIndex,
+                                        likeFlightAnchorId: _likeFlightAnchorId(
+                                          index,
+                                        ),
                                         onGameChanged: _navigateToGame,
                                         lastViewedIndex: _lastViewedIndex,
                                         hideEventInfo: widget.hideEventInfo,
@@ -2186,6 +2194,8 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
                                         () => _LoadingScreen(
                                           games: liveGames,
                                           currentGameIndex: index,
+                                          likeFlightAnchorId:
+                                              _likeFlightAnchorId(index),
                                           onGameChanged: _navigateToGame,
                                           lastViewedIndex: _lastViewedIndex,
                                           hideEventInfo: widget.hideEventInfo,
@@ -2197,6 +2207,9 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
                                   return _LoadingScreen(
                                     games: liveGames,
                                     currentGameIndex: index,
+                                    likeFlightAnchorId: _likeFlightAnchorId(
+                                      index,
+                                    ),
                                     onGameChanged: _navigateToGame,
                                     lastViewedIndex: _lastViewedIndex,
                                     hideEventInfo: widget.hideEventInfo,
@@ -2213,7 +2226,6 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
                       if (_showTutorialOverlay)
                         Positioned.fill(
                           child: _SwipeTutorialOverlay(
-                            key: _tutorialOverlayKey,
                             animationController: _swipeController,
                             moveAnimation: _swipeMoveAnimation,
                             fadeAnimation: _swipeFadeAnimation,
@@ -2257,7 +2269,6 @@ class _SwipeTutorialOverlay extends StatefulWidget {
   final int totalSteps;
 
   const _SwipeTutorialOverlay({
-    super.key,
     required this.onDismiss,
     required this.onDontShowAgain,
     required this.animationController,
@@ -2691,6 +2702,7 @@ class _GamePage extends StatelessWidget {
   final List<GamesTourModel> games;
   final int currentGameIndex;
   final int currentPageIndex;
+  final String likeFlightAnchorId;
   final void Function(int) onGameChanged;
   final int? lastViewedIndex;
   final bool hideEventInfo;
@@ -2706,6 +2718,7 @@ class _GamePage extends StatelessWidget {
     required this.games,
     required this.currentGameIndex,
     required this.currentPageIndex,
+    required this.likeFlightAnchorId,
     required this.onGameChanged,
     required this.onToggleGamebase,
     this.lastViewedIndex,
@@ -2732,6 +2745,7 @@ class _GamePage extends StatelessWidget {
         game: game,
         games: games,
         currentGameIndex: currentGameIndex,
+        likeFlightAnchorId: likeFlightAnchorId,
         onGameChanged: onGameChanged,
         lastViewedIndex: lastViewedIndex,
         hideEventInfo: hideEventInfo,
@@ -2740,6 +2754,7 @@ class _GamePage extends StatelessWidget {
       body: _GameBody(
         index: currentGameIndex,
         currentPageIndex: currentPageIndex,
+        likeFlightAnchorId: likeFlightAnchorId,
         game: game,
         state: state,
         playerProfileDataSource: playerProfileDataSource,
@@ -2758,6 +2773,7 @@ class _GamePage extends StatelessWidget {
 class _LoadingScreen extends StatelessWidget {
   final List<GamesTourModel> games;
   final int currentGameIndex;
+  final String likeFlightAnchorId;
   final void Function(int) onGameChanged;
   final int? lastViewedIndex;
   final bool hideEventInfo;
@@ -2765,6 +2781,7 @@ class _LoadingScreen extends StatelessWidget {
   const _LoadingScreen({
     required this.games,
     required this.currentGameIndex,
+    required this.likeFlightAnchorId,
     required this.onGameChanged,
     this.lastViewedIndex,
     this.hideEventInfo = false,
@@ -2800,6 +2817,7 @@ class _LoadingScreen extends StatelessWidget {
         game: games[currentGameIndex],
         games: games,
         currentGameIndex: currentGameIndex,
+        likeFlightAnchorId: likeFlightAnchorId,
         onGameChanged: onGameChanged,
         isLoading: true,
         lastViewedIndex: lastViewedIndex,
@@ -2999,6 +3017,7 @@ class _AppBar extends ConsumerStatefulWidget implements PreferredSizeWidget {
   final GamesTourModel game;
   final List<GamesTourModel> games;
   final int currentGameIndex;
+  final String likeFlightAnchorId;
   final void Function(int) onGameChanged;
   final bool isLoading;
   final int? lastViewedIndex;
@@ -3009,6 +3028,7 @@ class _AppBar extends ConsumerStatefulWidget implements PreferredSizeWidget {
     required this.game,
     required this.games,
     required this.currentGameIndex,
+    required this.likeFlightAnchorId,
     required this.onGameChanged,
     this.isLoading = false,
     this.lastViewedIndex,
@@ -3340,7 +3360,9 @@ class _AppBarState extends ConsumerState<_AppBar> {
       ),
     );
 
-    final anchor = ref.read(likeFlightAnchorProvider);
+    final anchor = ref.read(
+      likeFlightAnchorProvider(widget.likeFlightAnchorId),
+    );
     final isLiked = ref.watch(isGameLikedProvider(widget.game.likeId));
 
     return ValueListenableBuilder<LikeFlightPhase>(
@@ -3413,7 +3435,8 @@ class _AppBarState extends ConsumerState<_AppBar> {
         // (same glyph, same size, same spot). The optimistic `isLiked` flips
         // true early, so gating on phase is what keeps the badge hidden until
         // the flying heart actually arrives.
-        final inFlight = phase == LikeFlightPhase.bursting ||
+        final inFlight =
+            phase == LikeFlightPhase.bursting ||
             phase == LikeFlightPhase.flying;
         final justLanded = phase == LikeFlightPhase.landed;
         final showBadge = isLiked && !inFlight;
@@ -3448,10 +3471,7 @@ class _AppBarState extends ConsumerState<_AppBar> {
               // origin (scale-0 maps every child point to center), giving the
               // flight a wrong dock target. Measuring the un-transformed box
               // here yields the badge's true rect even while it's invisible.
-              child: KeyedSubtree(
-                key: anchor.heartBadgeKey,
-                child: heartBadge,
-              ),
+              child: KeyedSubtree(key: anchor.heartBadgeKey, child: heartBadge),
             ),
           ],
         );
@@ -3462,16 +3482,17 @@ class _AppBarState extends ConsumerState<_AppBar> {
         // Animate state alive across rebuilds inside the same `landed`
         // window so the pulse runs once, not on every rebuild.
         final landed = phase == LikeFlightPhase.landed;
-        final pulsing = landed
-            ? stack
-                .animate(key: const ValueKey('save-button-landed-pulse'))
-                .scaleXY(
-                  begin: 1.28,
-                  end: 1.0,
-                  duration: 360.ms,
-                  curve: Curves.easeOutBack,
-                )
-            : stack;
+        final pulsing =
+            landed
+                ? stack
+                    .animate(key: const ValueKey('save-button-landed-pulse'))
+                    .scaleXY(
+                      begin: 1.28,
+                      end: 1.0,
+                      duration: 360.ms,
+                      curve: Curves.easeOutBack,
+                    )
+                : stack;
 
         // Header action stays the save icon at all times — a double-tap
         // like is represented only by the small red badge above. The
@@ -5998,6 +6019,7 @@ class _GameBody extends StatelessWidget {
   final int currentPageIndex;
   final GamesTourModel game;
   final ChessBoardStateNew state;
+  final String likeFlightAnchorId;
   final PlayerProfileDataSource playerProfileDataSource;
   final bool showGamebaseButton;
   final bool showClock;
@@ -6007,6 +6029,7 @@ class _GameBody extends StatelessWidget {
     required this.currentPageIndex,
     required this.game,
     required this.state,
+    required this.likeFlightAnchorId,
     this.playerProfileDataSource = PlayerProfileDataSource.supabase,
     this.showGamebaseButton = false,
     this.showClock = true,
@@ -6020,6 +6043,7 @@ class _GameBody extends StatelessWidget {
       currentPageIndex: currentPageIndex,
       game: game,
       state: state,
+      likeFlightAnchorId: likeFlightAnchorId,
       playerProfileDataSource: playerProfileDataSource,
       showGamebaseButton: showGamebaseButton,
       showClock: showClock,
@@ -6032,6 +6056,7 @@ class _AnalysisGameBody extends ConsumerWidget {
   final int currentPageIndex;
   final GamesTourModel game;
   final ChessBoardStateNew state;
+  final String likeFlightAnchorId;
   final PlayerProfileDataSource playerProfileDataSource;
   final bool showGamebaseButton;
   final bool showClock;
@@ -6041,6 +6066,7 @@ class _AnalysisGameBody extends ConsumerWidget {
     required this.currentPageIndex,
     required this.game,
     required this.state,
+    required this.likeFlightAnchorId,
     this.playerProfileDataSource = PlayerProfileDataSource.supabase,
     this.showGamebaseButton = false,
     this.showClock = true,
@@ -6114,6 +6140,7 @@ class _AnalysisGameBody extends ConsumerWidget {
           _BoardWithSidebar(
             index: index,
             currentPageIndex: currentPageIndex,
+            likeFlightAnchorId: likeFlightAnchorId,
             state: state,
             game: game,
           ),
@@ -6281,6 +6308,7 @@ class _AnalysisGameBody extends ConsumerWidget {
                       _TabletBoardWithSidebar(
                         index: index,
                         currentPageIndex: currentPageIndex,
+                        likeFlightAnchorId: likeFlightAnchorId,
                         state: state,
                         game: game,
                         boardSize: optimalBoardSize,
@@ -6378,6 +6406,7 @@ class _AnalysisGameBody extends ConsumerWidget {
                     _BoardWithSidebar(
                       index: index,
                       currentPageIndex: currentPageIndex,
+                      likeFlightAnchorId: likeFlightAnchorId,
                       state: state,
                       game: game,
                     ),
@@ -6589,6 +6618,7 @@ class _TabletBoardWithSidebar extends ConsumerWidget {
   final int index;
   final ChessBoardStateNew state;
   final int currentPageIndex;
+  final String likeFlightAnchorId;
   final GamesTourModel game;
   final double boardSize;
   final double evalBarWidth;
@@ -6597,6 +6627,7 @@ class _TabletBoardWithSidebar extends ConsumerWidget {
     required this.index,
     required this.state,
     required this.currentPageIndex,
+    required this.likeFlightAnchorId,
     required this.game,
     required this.boardSize,
     required this.evalBarWidth,
@@ -6654,6 +6685,7 @@ class _TabletBoardWithSidebar extends ConsumerWidget {
           chessBoardState: state,
           isFlipped: state.isBoardFlipped,
           index: index,
+          likeFlightAnchorId: likeFlightAnchorId,
           game: state.game,
         ),
       ],
@@ -6665,12 +6697,14 @@ class _BoardWithSidebar extends ConsumerWidget {
   final int index;
   final ChessBoardStateNew state;
   final int currentPageIndex;
+  final String likeFlightAnchorId;
   final GamesTourModel game;
 
   const _BoardWithSidebar({
     required this.index,
     required this.state,
     required this.currentPageIndex,
+    required this.likeFlightAnchorId,
     required this.game,
   });
 
@@ -6772,6 +6806,7 @@ class _BoardWithSidebar extends ConsumerWidget {
                     chessBoardState: state,
                     isFlipped: state.isBoardFlipped,
                     index: index,
+                    likeFlightAnchorId: likeFlightAnchorId,
                     game: state.game,
                   ),
                   // DISABLED: Move annotation overlay (requires move impact analysis)
@@ -6802,6 +6837,7 @@ class _AnalysisBoard extends ConsumerStatefulWidget {
   final ChessBoardStateNew chessBoardState;
   final bool isFlipped;
   final int index;
+  final String likeFlightAnchorId;
   final GamesTourModel game;
 
   const _AnalysisBoard({
@@ -6809,6 +6845,7 @@ class _AnalysisBoard extends ConsumerStatefulWidget {
     required this.chessBoardState,
     this.isFlipped = false,
     required this.index,
+    required this.likeFlightAnchorId,
     required this.game,
   });
 
@@ -7174,9 +7211,7 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
       final gameId = widget.game.gameId;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        ref
-            .read(eventNoSpoilersRevealedGamesProvider.notifier)
-            .reveal(gameId);
+        ref.read(eventNoSpoilersRevealedGamesProvider.notifier).reveal(gameId);
       });
     }
 
@@ -7223,7 +7258,9 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
   @override
   void initState() {
     super.initState();
-    _likeFlightAnchor = ref.read(likeFlightAnchorProvider);
+    _likeFlightAnchor = ref.read(
+      likeFlightAnchorProvider(widget.likeFlightAnchorId),
+    );
     final analysisState = widget.chessBoardState.analysisState;
     _wasAtEnd = _isAtGameEnd(analysisState);
 
@@ -7650,9 +7687,9 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
       await toggleFuture;
     } catch (_) {}
     if (!mounted) return;
-    await ref
-        .read(likedGamesProvider.notifier)
-        .setTagsForLikeId(game.likeId, [tag]);
+    await ref.read(likedGamesProvider.notifier).setTagsForLikeId(game.likeId, [
+      tag,
+    ]);
   }
 
   void _removeFlyingHeartEntry() {

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -3470,6 +3470,7 @@ class ChessBoardScreenNotifierNew
     required String analysisId,
     required String title,
     String? folderId,
+    List<String>? tags,
   }) {
     final currentState = state.valueOrNull;
     savedAnalysisData = SavedAnalysisData(
@@ -3487,6 +3488,7 @@ class ChessBoardScreenNotifierNew
       lastViewedPosition: currentState?.analysisState.currentMoveIndex ?? 0,
       title: title,
       folderId: folderId,
+      tags: tags ?? savedAnalysisData?.tags ?? const <String>[],
     );
     // Snapshot current game tree so auto-save doesn't immediately re-save
     final analysisGame = currentState?.analysisState.game;
@@ -3546,7 +3548,7 @@ class ChessBoardScreenNotifierNew
         variationComments: currentState.variationComments,
         moveNags: currentState.moveNags,
         lastViewedPosition: currentState.analysisState.currentMoveIndex,
-        tags: const [],
+        tags: savedAnalysisData?.tags ?? const [],
         isFavorite: false,
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),
@@ -3638,7 +3640,7 @@ class ChessBoardScreenNotifierNew
         variationComments: currentState.variationComments,
         moveNags: currentState.moveNags,
         lastViewedPosition: currentState.analysisState.currentMoveIndex,
-        tags: const [],
+        tags: savedAnalysisData?.tags ?? const [],
         isFavorite: false,
         createdAt: DateTime.now(),
         updatedAt: DateTime.now(),
@@ -3747,6 +3749,7 @@ class ChessBoardScreenNotifierNew
       lastViewedPosition: lastViewedPosition,
       title: title ?? current.title,
       folderId: folderId ?? current.folderId,
+      tags: current.tags,
     );
   }
 
@@ -7387,6 +7390,11 @@ class SavedAnalysisData {
   /// Folder ID the analysis belongs to (for auto-save updates)
   final String? folderId;
 
+  /// Official tags attached to this analysis. Held in memory so background
+  /// auto-save / manual-update never overwrite the row's `tags` with an empty
+  /// list (which would silently wipe tags the user set in the save sheet).
+  final List<String> tags;
+
   const SavedAnalysisData({
     this.analysisId,
     this.sourceGameId,
@@ -7398,6 +7406,7 @@ class SavedAnalysisData {
     required this.lastViewedPosition,
     this.title,
     this.folderId,
+    this.tags = const <String>[],
   });
 }
 

--- a/lib/screens/chessboard/widgets/like_flight.dart
+++ b/lib/screens/chessboard/widgets/like_flight.dart
@@ -19,22 +19,37 @@ enum LikeFlightPhase { idle, bursting, flying, landed }
 /// widget attaches [saveButtonKey] to its icon container so the flight
 /// animation can compute the on-screen target rect.
 class LikeFlightAnchor {
-  LikeFlightAnchor();
+  LikeFlightAnchor({String? debugLabel}) {
+    _debugLabel = debugLabel;
+  }
+
+  late final String? _debugLabel;
 
   /// Attached to the save button's icon container. The flight overlay reads
   /// `renderBox.localToGlobal(Offset.zero)` off this to find its target.
-  final GlobalKey saveButtonKey = GlobalKey();
+  late final GlobalKey saveButtonKey = GlobalKey(
+    debugLabel:
+        _debugLabel == null
+            ? 'likeFlight.saveButton'
+            : 'likeFlight.saveButton.$_debugLabel',
+  );
 
   /// Attached to the small heart badge glyph on the save button. The flight
   /// overlay docks the big flying heart onto THIS rect (center + size) so the
   /// arriving heart lands exactly where — and at the same size as — the badge
   /// it turns into. The badge keeps its layout size even while scaled to 0
   /// (AnimatedScale is a transform), so this rect is measurable mid-flight.
-  final GlobalKey heartBadgeKey = GlobalKey();
+  late final GlobalKey heartBadgeKey = GlobalKey(
+    debugLabel:
+        _debugLabel == null
+            ? 'likeFlight.heartBadge'
+            : 'likeFlight.heartBadge.$_debugLabel',
+  );
 
   /// Drives the save button's own state machine — see [LikeFlightPhase].
-  final ValueNotifier<LikeFlightPhase> phase =
-      ValueNotifier<LikeFlightPhase>(LikeFlightPhase.idle);
+  final ValueNotifier<LikeFlightPhase> phase = ValueNotifier<LikeFlightPhase>(
+    LikeFlightPhase.idle,
+  );
 
   Rect? saveButtonGlobalRect() {
     final ctx = saveButtonKey.currentContext;
@@ -83,12 +98,14 @@ class LikeFlightAnchor {
   void dispose() => phase.dispose();
 }
 
-/// Shared anchor instance. Not autoDispose: the save button and the board's
-/// double-tap handler both `ref.read` it and they MUST resolve to the same
-/// instance, otherwise the GlobalKey on the save button doesn't match the
-/// rect lookup at flight time and the flight is silently skipped.
-final likeFlightAnchorProvider = Provider<LikeFlightAnchor>((ref) {
-  final anchor = LikeFlightAnchor();
+/// Page-scoped anchor. Not autoDispose: a board page and its app-bar save
+/// button must resolve to the same instance, but adjacent PageView pages must
+/// not share GlobalKeys while the swipe tutorial programmatically drags pages.
+final likeFlightAnchorProvider = Provider.family<LikeFlightAnchor, String>((
+  ref,
+  anchorId,
+) {
+  final anchor = LikeFlightAnchor(debugLabel: anchorId);
   ref.onDispose(anchor.dispose);
   return anchor;
 });

--- a/lib/screens/chessboard/widgets/save_analysis_sheet.dart
+++ b/lib/screens/chessboard/widgets/save_analysis_sheet.dart
@@ -676,12 +676,15 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
 
                 SizedBox(height: 24.h),
 
-                // Tags are a My-Likes-only concept: only liked games can be
-                // tagged, and the picker is the same roulette shown right after
-                // a like.
+                // Tags are a My-Likes-only concept: liked games can be tagged
+                // via the same roulette shown right after a like. Also show the
+                // section whenever the game already carries tags, so an existing
+                // tag set stays visible/editable (never silently stuck) even if
+                // the game was unliked.
                 if (ref.watch(
-                  isGameLikedProvider(widget.config.state.game.likeId),
-                )) ...[
+                      isGameLikedProvider(widget.config.state.game.likeId),
+                    ) ||
+                    _selectedTags.isNotEmpty) ...[
                   _buildTagsSection()
                       .animate()
                       .fadeIn(duration: 300.ms, delay: 125.ms)

--- a/lib/screens/chessboard/widgets/save_analysis_sheet.dart
+++ b/lib/screens/chessboard/widgets/save_analysis_sheet.dart
@@ -1,3 +1,4 @@
+import 'package:chessever2/constants/game_tags.dart';
 import 'package:chessever2/repository/liked_games/liked_games_provider.dart';
 import 'package:chessever2/repository/library/library_repository.dart';
 import 'package:chessever2/repository/library/models/library_folder.dart';
@@ -146,6 +147,13 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
   String? _errorMessage;
   bool _isCreatingNewFolder = false;
   bool _showGameDetails = false;
+
+  // Official tags attached to this game. Seeded from the existing saved/liked
+  // row so re-saving never silently wipes them; `_userTouchedTags` guards the
+  // async repo preload from clobbering a choice the user already made.
+  Set<String> _selectedTags = <String>{};
+  bool _userTouchedTags = false;
+
   String _selectedResult = '*';
   Color _selectedFolderColor = _folderColorPresets.first;
 
@@ -196,10 +204,30 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           _isEditMode = true;
           _existingAnalysisId = liked.id;
           _initialFolderId = liked.folderId;
+          // Seed synchronously for instant chip state; repo preload below
+          // confirms against the authoritative row.
+          _selectedTags = liked.tags.toSet();
         }
       }
     }
     _initializeControllers();
+    // Best-effort: pull the authoritative tag set for the row we're editing so
+    // an update never overwrites tags that aren't yet in memory.
+    _preloadTagsFromRepo();
+  }
+
+  Future<void> _preloadTagsFromRepo() async {
+    final id = _existingAnalysisId;
+    if (id == null) return;
+    try {
+      final repository = ref.read(libraryRepositoryProvider);
+      final existing = await repository.getSavedAnalysis(id);
+      if (existing != null && mounted && !_userTouchedTags) {
+        setState(() => _selectedTags = existing.tags.toSet());
+      }
+    } catch (_) {
+      // Preload is non-critical; the synchronous seed (if any) stands.
+    }
   }
 
   void _initializeControllers() {
@@ -440,7 +468,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           variationComments: state.variationComments,
           moveNags: state.moveNags,
           lastViewedPosition: state.analysisState.currentMoveIndex,
-          tags: const [],
+          tags: _selectedTags.toList(),
           notes: null,
           isFavorite: false,
           createdAt: DateTime.now(),
@@ -460,7 +488,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           analysisState: analysisStateJson,
           variationComments: state.variationComments,
           lastViewedPosition: state.analysisState.currentMoveIndex,
-          tags: const [],
+          tags: _selectedTags.toList(),
           notes: null,
           isFavorite: false,
           createdAt: DateTime.now(),
@@ -483,6 +511,7 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
             analysisId: resolvedAnalysisId,
             title: title,
             folderId: targetFolderId,
+            tags: _selectedTags.toList(),
           );
 
       if (mounted && context.mounted) {
@@ -637,6 +666,20 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
                 _buildGameDetailsSection()
                     .animate()
                     .fadeIn(duration: 300.ms, delay: 100.ms)
+                    .slideY(
+                      begin: 0.1,
+                      end: 0,
+                      duration: 350.ms,
+                      curve: Curves.easeOutCubic,
+                    ),
+
+                SizedBox(height: 24.h),
+
+                // Tags (official, personal-library) — always visible so the
+                // user can set/change them right in the save/edit flow.
+                _buildTagsSection()
+                    .animate()
+                    .fadeIn(duration: 300.ms, delay: 125.ms)
                     .slideY(
                       begin: 0.1,
                       end: 0,
@@ -1210,6 +1253,112 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
           ],
         ),
       ],
+    );
+  }
+
+  Widget _buildTagsSection() {
+    final count = _selectedTags.length;
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24.w),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.sell_rounded,
+                size: 16.sp,
+                color: context.colors.textPrimary.withValues(alpha: 0.6),
+              ),
+              SizedBox(width: 8.w),
+              Text(
+                'Tags',
+                style: AppTypography.textSmMedium.copyWith(
+                  color: context.colors.textPrimary.withValues(alpha: 0.8),
+                  letterSpacing: 0.3,
+                ),
+              ),
+              const Spacer(),
+              if (count > 0)
+                Text(
+                  '$count selected',
+                  style: AppTypography.textXsMedium.copyWith(
+                    color: kPrimaryColor,
+                  ),
+                ),
+            ],
+          ),
+          SizedBox(height: 12.h),
+          Wrap(
+            spacing: 8.w,
+            runSpacing: 8.h,
+            children: [
+              for (final tag in kOfficialGameTags)
+                _tagChip(tag, _selectedTags.contains(tag.label)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _tagChip(GameTag tag, bool selected) {
+    return GestureDetector(
+      onTap:
+          _isSaving
+              ? null
+              : () {
+                setState(() {
+                  _userTouchedTags = true;
+                  if (selected) {
+                    _selectedTags.remove(tag.label);
+                  } else {
+                    _selectedTags.add(tag.label);
+                  }
+                });
+                HapticFeedback.selectionClick();
+              },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+        decoration: BoxDecoration(
+          color:
+              selected
+                  ? kPrimaryColor.withValues(alpha: 0.15)
+                  : context.colors.textPrimary.withValues(alpha: 0.04),
+          borderRadius: BorderRadius.circular(20.br),
+          border: Border.all(
+            color:
+                selected
+                    ? kPrimaryColor.withValues(alpha: 0.45)
+                    : context.colors.textPrimary.withValues(alpha: 0.1),
+            width: 1,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              selected ? Icons.check_rounded : tag.icon,
+              size: 14.sp,
+              color:
+                  selected
+                      ? kPrimaryColor
+                      : context.colors.textPrimary.withValues(alpha: 0.55),
+            ),
+            SizedBox(width: 6.w),
+            Text(
+              tag.label,
+              style: AppTypography.textXsMedium.copyWith(
+                color:
+                    selected
+                        ? kPrimaryColor
+                        : context.colors.textPrimary.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/screens/chessboard/widgets/save_analysis_sheet.dart
+++ b/lib/screens/chessboard/widgets/save_analysis_sheet.dart
@@ -7,6 +7,7 @@ import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provid
 import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
 import 'package:chessever2/screens/chessboard/widgets/smooth_sheet_config.dart';
 import 'package:chessever2/screens/library/providers/library_folders_provider.dart';
+import 'package:chessever2/screens/my_likes/widgets/roulette_tag_picker.dart';
 import 'package:chessever2/utils/number_format_utils.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -675,19 +676,23 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
 
                 SizedBox(height: 24.h),
 
-                // Tags (official, personal-library) — always visible so the
-                // user can set/change them right in the save/edit flow.
-                _buildTagsSection()
-                    .animate()
-                    .fadeIn(duration: 300.ms, delay: 125.ms)
-                    .slideY(
-                      begin: 0.1,
-                      end: 0,
-                      duration: 350.ms,
-                      curve: Curves.easeOutCubic,
-                    ),
-
-                SizedBox(height: 24.h),
+                // Tags are a My-Likes-only concept: only liked games can be
+                // tagged, and the picker is the same roulette shown right after
+                // a like.
+                if (ref.watch(
+                  isGameLikedProvider(widget.config.state.game.likeId),
+                )) ...[
+                  _buildTagsSection()
+                      .animate()
+                      .fadeIn(duration: 300.ms, delay: 125.ms)
+                      .slideY(
+                        begin: 0.1,
+                        end: 0,
+                        duration: 350.ms,
+                        curve: Curves.easeOutCubic,
+                      ),
+                  SizedBox(height: 24.h),
+                ],
 
                 // Folder section
                 _buildFolderSection(foldersAsync)
@@ -1256,8 +1261,23 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
     );
   }
 
+  Future<void> _openRouletteForTag() async {
+    if (_isSaving) return;
+    HapticFeedback.selectionClick();
+    final initial = _selectedTags.isNotEmpty ? _selectedTags.first : null;
+    final tag = await showRouletteTagPicker(context, initialTag: initial);
+    // Skip / dismiss (null) cancels in the edit context — keep the current tag.
+    // Use the explicit "Remove tag" control to clear.
+    if (!mounted || tag == null) return;
+    setState(() {
+      _userTouchedTags = true;
+      _selectedTags = <String>{tag};
+    });
+  }
+
   Widget _buildTagsSection() {
-    final count = _selectedTags.length;
+    final hasTag = _selectedTags.isNotEmpty;
+    final label = hasTag ? _selectedTags.first : null;
     return Padding(
       padding: EdgeInsets.symmetric(horizontal: 24.w),
       child: Column(
@@ -1272,92 +1292,97 @@ class _SaveAnalysisPageState extends ConsumerState<_SaveAnalysisPage>
               ),
               SizedBox(width: 8.w),
               Text(
-                'Tags',
+                'Tag',
                 style: AppTypography.textSmMedium.copyWith(
                   color: context.colors.textPrimary.withValues(alpha: 0.8),
                   letterSpacing: 0.3,
                 ),
               ),
               const Spacer(),
-              if (count > 0)
-                Text(
-                  '$count selected',
-                  style: AppTypography.textXsMedium.copyWith(
-                    color: kPrimaryColor,
+              if (hasTag)
+                GestureDetector(
+                  onTap:
+                      _isSaving
+                          ? null
+                          : () {
+                            HapticFeedback.lightImpact();
+                            setState(() {
+                              _userTouchedTags = true;
+                              _selectedTags = <String>{};
+                            });
+                          },
+                  child: Text(
+                    'Remove',
+                    style: AppTypography.textXsMedium.copyWith(
+                      color: kRedColor.withValues(alpha: 0.9),
+                    ),
                   ),
                 ),
             ],
           ),
           SizedBox(height: 12.h),
-          Wrap(
-            spacing: 8.w,
-            runSpacing: 8.h,
-            children: [
-              for (final tag in kOfficialGameTags)
-                _tagChip(tag, _selectedTags.contains(tag.label)),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _tagChip(GameTag tag, bool selected) {
-    return GestureDetector(
-      onTap:
-          _isSaving
-              ? null
-              : () {
-                setState(() {
-                  _userTouchedTags = true;
-                  if (selected) {
-                    _selectedTags.remove(tag.label);
-                  } else {
-                    _selectedTags.add(tag.label);
-                  }
-                });
-                HapticFeedback.selectionClick();
-              },
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 180),
-        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
-        decoration: BoxDecoration(
-          color:
-              selected
-                  ? kPrimaryColor.withValues(alpha: 0.15)
-                  : context.colors.textPrimary.withValues(alpha: 0.04),
-          borderRadius: BorderRadius.circular(20.br),
-          border: Border.all(
-            color:
-                selected
-                    ? kPrimaryColor.withValues(alpha: 0.45)
-                    : context.colors.textPrimary.withValues(alpha: 0.1),
-            width: 1,
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              selected ? Icons.check_rounded : tag.icon,
-              size: 14.sp,
-              color:
-                  selected
-                      ? kPrimaryColor
-                      : context.colors.textPrimary.withValues(alpha: 0.55),
-            ),
-            SizedBox(width: 6.w),
-            Text(
-              tag.label,
-              style: AppTypography.textXsMedium.copyWith(
+          GestureDetector(
+            onTap: _isSaving ? null : _openRouletteForTag,
+            child: Container(
+              padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 12.h),
+              decoration: BoxDecoration(
                 color:
-                    selected
-                        ? kPrimaryColor
-                        : context.colors.textPrimary.withValues(alpha: 0.7),
+                    hasTag
+                        ? kPrimaryColor.withValues(alpha: 0.12)
+                        : context.colors.textPrimary.withValues(alpha: 0.04),
+                borderRadius: BorderRadius.circular(14.br),
+                border: Border.all(
+                  color:
+                      hasTag
+                          ? kPrimaryColor.withValues(alpha: 0.4)
+                          : context.colors.textPrimary.withValues(alpha: 0.1),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    padding: EdgeInsets.all(7.sp),
+                    decoration: BoxDecoration(
+                      color: kPrimaryColor.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(9.br),
+                    ),
+                    child: Icon(
+                      hasTag ? iconForGameTag(label!) : Icons.casino_rounded,
+                      size: 16.sp,
+                      color: kPrimaryColor,
+                    ),
+                  ),
+                  SizedBox(width: 12.w),
+                  Expanded(
+                    child: Text(
+                      hasTag ? label! : 'Spin to tag this game',
+                      style: AppTypography.textSmMedium.copyWith(
+                        color:
+                            hasTag
+                                ? context.colors.textPrimary
+                                : context.colors.textPrimary.withValues(
+                                  alpha: 0.6,
+                                ),
+                      ),
+                    ),
+                  ),
+                  Text(
+                    hasTag ? 'Change' : 'Spin',
+                    style: AppTypography.textXsMedium.copyWith(
+                      color: kPrimaryColor,
+                    ),
+                  ),
+                  SizedBox(width: 4.w),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    size: 18.sp,
+                    color: kPrimaryColor,
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/group_event/group_event_screen.dart
+++ b/lib/screens/group_event/group_event_screen.dart
@@ -517,6 +517,9 @@ class GroupEventScreen extends HookConsumerWidget {
                                         ),
                                 isLoadingMore: isLoadingMore,
                                 scrollController: scrollController,
+                                showSmartLevelEvent:
+                                    currentCategory ==
+                                    GroupEventCategory.current,
                               ),
                             );
                           },

--- a/lib/screens/group_event/group_event_screen.dart
+++ b/lib/screens/group_event/group_event_screen.dart
@@ -4,6 +4,7 @@ import 'package:chessever2/e2e/e2e_ids.dart';
 import 'package:chessever2/providers/event_favorite_players_provider.dart';
 import 'package:chessever2/providers/favorite_events_provider.dart';
 import 'package:chessever2/screens/group_event/widget/search_results_widget.dart';
+import 'package:chessever2/screens/group_event/smart_opening_event.dart';
 import 'package:chessever2/screens/group_event/widget/all_events_tab_widget.dart';
 import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_provider.dart';
 import 'package:chessever2/screens/group_event/widget/for_you_games_widget.dart';
@@ -150,6 +151,18 @@ class GroupEventScreen extends HookConsumerWidget {
       });
     });
 
+    void openOpeningSmartEvent(String value) {
+      final openingQuery = SmartOpeningQuery.parse(value);
+      if (openingQuery == null) return;
+      FocusScope.of(context).unfocus();
+      HapticFeedbackService.buttonPress();
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => SmartOpeningEventScreen(query: openingQuery),
+        ),
+      );
+    }
+
     void scrollActiveEventsTabToTop() {
       final ScrollController target;
       if (selectedTourEvent == GroupEventCategory.forYou) {
@@ -271,6 +284,7 @@ class GroupEventScreen extends HookConsumerWidget {
                           ref.refresh(groupEventScreenProvider);
                         }
                       },
+                      onSubmitted: openOpeningSmartEvent,
                       onTournamentSelected:
                           (t) => ref
                               .read(groupEventScreenProvider.notifier)

--- a/lib/screens/group_event/smart_level_event.dart
+++ b/lib/screens/group_event/smart_level_event.dart
@@ -1,0 +1,572 @@
+import 'dart:async';
+
+import 'package:chessever2/providers/auth_state_provider.dart';
+import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
+import 'package:chessever2/providers/country_dropdown_provider.dart';
+import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
+import 'package:chessever2/repository/sqlite/app_database.dart';
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/repository/supabase/group_broadcast/group_tour_repository.dart';
+import 'package:chessever2/repository/supabase/tour/tour_repository.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
+import 'package:chessever2/screens/group_event/providers/live_group_broadcast_id_provider.dart';
+import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_state.dart';
+import 'package:chessever2/screens/standings/player_standing_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_list_view_mode_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_auto_pin_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart';
+import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/game_filter/rating_tier_filter.dart';
+import 'package:chessever2/widgets/generic_error_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class SmartLevelTier {
+  const SmartLevelTier({required this.label, required this.minRating});
+
+  final String label;
+  final int minRating;
+
+  String get title => '$label Level';
+  String get subtitle => 'Games $minRating+';
+
+  static SmartLevelTier? fromFilter(FilterPopupState filter) {
+    return fromMinRating(filter.minElo);
+  }
+
+  static SmartLevelTier? fromMinRating(int? minRating) {
+    final normalized = RatingTierFilter.normalizeMinRating(minRating);
+    if (normalized == null) return null;
+
+    for (final tier in RatingTierFilter.tiers) {
+      if (tier.minRating == normalized) {
+        return SmartLevelTier(label: tier.label, minRating: tier.minRating);
+      }
+    }
+    return null;
+  }
+}
+
+class SmartLevelEventCard extends ConsumerWidget {
+  const SmartLevelEventCard({super.key, required this.tier, this.margin});
+
+  final SmartLevelTier tier;
+  final EdgeInsetsGeometry? margin;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: margin ?? EdgeInsets.only(bottom: 12.sp),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14.br),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => SmartLevelEventScreen(initialTier: tier),
+            ),
+          );
+        },
+        child: Container(
+          padding: EdgeInsets.all(14.sp),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                kPrimaryColor.withValues(alpha: 0.22),
+                context.colors.surface,
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(14.br),
+            border: Border.all(color: kPrimaryColor.withValues(alpha: 0.35)),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 42.sp,
+                height: 42.sp,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: kPrimaryColor,
+                  borderRadius: BorderRadius.circular(11.br),
+                ),
+                child: Text(
+                  tier.label,
+                  style: TextStyle(
+                    color: kBlackColor,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 15.sp,
+                  ),
+                ),
+              ),
+              SizedBox(width: 12.sp),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      tier.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.colors.textPrimary,
+                        fontSize: 16.sp,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    SizedBox(height: 3.sp),
+                    Text(
+                      'Top games from all current events',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.colors.textSecondary,
+                        fontSize: 12.sp,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: context.colors.textSecondary,
+                size: 22.sp,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SmartLevelEventArgs {
+  const SmartLevelEventArgs({required this.tier, this.query = ''});
+
+  final SmartLevelTier tier;
+  final String query;
+
+  @override
+  bool operator ==(Object other) {
+    return other is SmartLevelEventArgs &&
+        other.tier.minRating == tier.minRating &&
+        other.query == query;
+  }
+
+  @override
+  int get hashCode => Object.hash(tier.minRating, query);
+}
+
+class SmartLevelEventState {
+  const SmartLevelEventState({required this.games});
+
+  final List<GamesTourModel> games;
+
+  Map<DateTime, List<GamesTourModel>> get gamesByDay {
+    final grouped = <DateTime, List<GamesTourModel>>{};
+    for (final game in games) {
+      final rawDate = game.bucketDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final day = DateTime(rawDate.year, rawDate.month, rawDate.day);
+      grouped.putIfAbsent(day, () => <GamesTourModel>[]).add(game);
+    }
+    return grouped;
+  }
+}
+
+final smartLevelEventProvider = FutureProvider.autoDispose
+    .family<SmartLevelEventState, SmartLevelEventArgs>((ref, args) async {
+      final broadcasts = await ref
+          .read(groupBroadcastRepositoryProvider)
+          .getCurrentGroupBroadcasts(minElo: args.tier.minRating, limit: 40);
+      if (broadcasts.isEmpty) {
+        return const SmartLevelEventState(games: []);
+      }
+
+      final liveIds = ref.read(liveGroupBroadcastIdsProvider).valueOrNull ?? [];
+      final visibleBroadcasts = broadcasts
+          .where((broadcast) {
+            final category = GroupEventCardModel.getCategory(
+              groupId: broadcast.id,
+              groupName: broadcast.name,
+              startDate: broadcast.dateStart,
+              endDate: broadcast.dateEnd,
+              liveGroupIds: liveIds,
+            );
+            return category == TourEventCategory.live ||
+                category == TourEventCategory.ongoing ||
+                category == TourEventCategory.upcoming;
+          })
+          .toList(growable: false);
+
+      final toursByEvent = await ref
+          .read(tourRepositoryProvider)
+          .getToursByGroupBroadcastIds(
+            visibleBroadcasts.map((broadcast) => broadcast.id).toList(),
+          );
+      final tourIds = toursByEvent.values
+          .expand((tours) => tours)
+          .map((tour) => tour.id)
+          .toSet()
+          .toList(growable: false);
+      if (tourIds.isEmpty) {
+        return const SmartLevelEventState(games: []);
+      }
+
+      final rawGames = await ref
+          .read(gameRepositoryProvider)
+          .getGamesFromTourIds(tourIds: tourIds, limit: 500, offset: 0);
+      final query = args.query.trim().toLowerCase();
+      final models = <GamesTourModel>[];
+      for (final game in rawGames) {
+        if (!_gameMatchesAverageRating(game, args.tier.minRating)) continue;
+        if (query.isNotEmpty && !_gameMatchesQuery(game, query)) continue;
+        try {
+          models.add(GamesTourModel.fromGame(game));
+        } catch (_) {
+          // Keep the smart event resilient to malformed rows.
+        }
+      }
+
+      final pinnedIds = await _loadSmartLevelAutoPins(ref, models);
+      models.sort((a, b) {
+        final aPinned = pinnedIds.contains(a.gameId);
+        final bPinned = pinnedIds.contains(b.gameId);
+        if (aPinned && !bPinned) return -1;
+        if (!aPinned && bPinned) return 1;
+
+        final dateCompare = _gameDate(b).compareTo(_gameDate(a));
+        if (dateCompare != 0) return dateCompare;
+        return _averageRating(b).compareTo(_averageRating(a));
+      });
+
+      return SmartLevelEventState(games: models);
+    });
+
+bool _gameMatchesAverageRating(Games game, int minRating) {
+  final players = game.players;
+  if (players == null || players.length < 2) return false;
+  final ratings = players
+      .take(2)
+      .map((player) => player.rating)
+      .where((r) => r > 0);
+  if (ratings.length < 2) return false;
+  return ratings.reduce((a, b) => a + b) / 2 >= minRating;
+}
+
+bool _gameMatchesQuery(Games game, String query) {
+  if ((game.name ?? '').toLowerCase().contains(query)) return true;
+  if ((game.openingName ?? '').toLowerCase().contains(query)) return true;
+  if ((game.eco ?? '').toLowerCase().contains(query)) return true;
+  final players = game.players ?? const <Player>[];
+  return players.any(
+    (player) =>
+        player.name.toLowerCase().contains(query) ||
+        player.title.toLowerCase().contains(query) ||
+        player.fed.toLowerCase().contains(query),
+  );
+}
+
+DateTime _gameDate(GamesTourModel game) {
+  return game.bucketDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+}
+
+int _averageRating(GamesTourModel game) {
+  final white = game.whitePlayer.rating;
+  final black = game.blackPlayer.rating;
+  if (white > 0 && black > 0) return ((white + black) / 2).round();
+  return white > black ? white : black;
+}
+
+Future<Set<String>> _loadSmartLevelAutoPins(
+  Ref ref,
+  List<GamesTourModel> games,
+) async {
+  final prefs = await ref.read(autoPinPreferencesProvider.future);
+  if (!prefs.favoritePlayersAutoPinEnabled && !prefs.countrymenAutoPinEnabled) {
+    return const <String>{};
+  }
+
+  final pinnedIds = <String>{};
+  final favoritePlayers =
+      prefs.favoritePlayersAutoPinEnabled
+          ? await ref.read(tournamentFavoritePlayersProvider.future)
+          : const <PlayerStandingModel>[];
+  final countryCode =
+      prefs.countrymenAutoPinEnabled
+          ? await _resolveSmartLevelCountryCode(ref)
+          : null;
+
+  for (final game in games) {
+    if (prefs.favoritePlayersAutoPinEnabled &&
+        _matchesFavoritePlayer(game, favoritePlayers)) {
+      pinnedIds.add(game.gameId);
+      continue;
+    }
+    if (countryCode != null && countryCode.isNotEmpty) {
+      if (CountryCodeMatcher.matches(
+            game.whitePlayer.countryCode,
+            countryCode,
+          ) ||
+          CountryCodeMatcher.matches(
+            game.blackPlayer.countryCode,
+            countryCode,
+          )) {
+        pinnedIds.add(game.gameId);
+      }
+    }
+  }
+  return pinnedIds;
+}
+
+bool _matchesFavoritePlayer(
+  GamesTourModel game,
+  List<PlayerStandingModel> favoritePlayers,
+) {
+  return favoritePlayers.any(
+        (player) =>
+            player.name == game.whitePlayer.name &&
+            (player.countryCode.isEmpty ||
+                CountryCodeMatcher.matches(
+                  game.whitePlayer.countryCode,
+                  player.countryCode,
+                )),
+      ) ||
+      favoritePlayers.any(
+        (player) =>
+            player.name == game.blackPlayer.name &&
+            (player.countryCode.isEmpty ||
+                CountryCodeMatcher.matches(
+                  game.blackPlayer.countryCode,
+                  player.countryCode,
+                )),
+      );
+}
+
+Future<String?> _resolveSmartLevelCountryCode(Ref ref) async {
+  final userId = ref.read(currentUserProvider)?.id;
+  // Keep the repository touched so app-level auto-pin storage is initialized in
+  // the same code path as event games. The selected country remains global.
+  unawaited(
+    AutoPinPreferencesRepository(
+      AppDatabase.instance,
+    ).getTournamentAutoPinDisabled('smart-level', userId),
+  );
+  final cachedCountryCode = await AppDatabase.instance.getString(
+    'selected_country_code',
+  );
+  if (cachedCountryCode != null && cachedCountryCode.isNotEmpty) {
+    return cachedCountryCode;
+  }
+  return ref.read(countryDropdownProvider).valueOrNull?.countryCode;
+}
+
+class SmartLevelEventScreen extends ConsumerStatefulWidget {
+  const SmartLevelEventScreen({super.key, required this.initialTier});
+
+  final SmartLevelTier initialTier;
+
+  @override
+  ConsumerState<SmartLevelEventScreen> createState() =>
+      _SmartLevelEventScreenState();
+}
+
+class _SmartLevelEventScreenState extends ConsumerState<SmartLevelEventScreen> {
+  late SmartLevelTier _tier;
+  String _query = '';
+  final _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _tier = widget.initialTier;
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(
+      smartLevelEventProvider(SmartLevelEventArgs(tier: _tier, query: _query)),
+    );
+    final viewMode = ref.watch(gamesListViewModeProvider);
+
+    return Scaffold(
+      backgroundColor: context.colors.background,
+      appBar: AppBar(
+        backgroundColor: context.colors.background,
+        foregroundColor: context.colors.textPrimary,
+        elevation: 0,
+        title: Text(_tier.title),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(16.sp, 8.sp, 16.sp, 10.sp),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextField(
+                    controller: _searchController,
+                    onChanged: (value) => setState(() => _query = value),
+                    style: TextStyle(color: context.colors.textPrimary),
+                    decoration: InputDecoration(
+                      hintText: 'Search this level',
+                      hintStyle: TextStyle(color: context.colors.textSecondary),
+                      prefixIcon: Icon(
+                        Icons.search_rounded,
+                        color: context.colors.textSecondary,
+                      ),
+                      filled: true,
+                      fillColor: context.colors.surface,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12.br),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: 10.sp),
+                  RatingTierFilter(
+                    selectedMinRating: _tier.minRating,
+                    onChanged: (minRating) {
+                      final tier = SmartLevelTier.fromMinRating(minRating);
+                      if (tier != null) setState(() => _tier = tier);
+                    },
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: state.when(
+                data:
+                    (data) => _SmartLevelGamesList(
+                      tier: _tier,
+                      data: data,
+                      viewMode: viewMode,
+                    ),
+                loading: () => const Center(child: CircularProgressIndicator()),
+                error:
+                    (error, stack) => GenericErrorWidget(
+                      message: error.toString(),
+                      onRetry: () => ref.invalidate(smartLevelEventProvider),
+                    ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SmartLevelGamesList extends ConsumerWidget {
+  const _SmartLevelGamesList({
+    required this.tier,
+    required this.data,
+    required this.viewMode,
+  });
+
+  final SmartLevelTier tier;
+  final SmartLevelEventState data;
+  final GamesListViewMode viewMode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (data.games.isEmpty) {
+      return Center(
+        child: Text(
+          'No ${tier.title} games found',
+          style: TextStyle(color: context.colors.textSecondary),
+        ),
+      );
+    }
+
+    final entries =
+        data.gamesByDay.entries.toList()
+          ..sort((a, b) => b.key.compareTo(a.key));
+    return ListView.builder(
+      padding: EdgeInsets.fromLTRB(16.sp, 0, 16.sp, 24.sp),
+      itemCount: entries.length,
+      itemBuilder: (context, sectionIndex) {
+        final entry = entries[sectionIndex];
+        final games = entry.value;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: EdgeInsets.only(
+                top: sectionIndex == 0 ? 4.sp : 18.sp,
+                bottom: 8.sp,
+              ),
+              child: Text(
+                _formatSmartLevelDay(entry.key),
+                style: TextStyle(
+                  color: context.colors.textPrimary,
+                  fontSize: 15.sp,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+            ...List.generate(games.length, (index) {
+              final game = games[index];
+              final globalIndex = data.games.indexWhere(
+                (item) => item.gameId == game.gameId,
+              );
+              final gamesData = GamesScreenModel(
+                gamesTourModels: data.games,
+                pinnedGamedIs: const [],
+              );
+              return Padding(
+                padding: EdgeInsets.only(bottom: 10.sp),
+                child: GameCardWrapperWidget(
+                  game: game,
+                  gamesData: gamesData,
+                  gameIndex: globalIndex < 0 ? index : globalIndex,
+                  isChessBoardVisible:
+                      viewMode == GamesListViewMode.chessBoardGrid,
+                  viewSource: ChessboardView.forYou,
+                  onReturnFromChessboard: (_) {},
+                  onPinToggle: (_) async {},
+                ),
+              );
+            }),
+          ],
+        );
+      },
+    );
+  }
+}
+
+String _formatSmartLevelDay(DateTime day) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+  if (day == today) return 'Today';
+  if (day == yesterday) return 'Yesterday';
+  const months = <String>[
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[day.month - 1]} ${day.day}';
+}

--- a/lib/screens/group_event/smart_opening_event.dart
+++ b/lib/screens/group_event/smart_opening_event.dart
@@ -1,0 +1,532 @@
+import 'package:chessever2/repository/supabase/game/game_repository.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/repository/supabase/group_broadcast/group_tour_repository.dart';
+import 'package:chessever2/repository/supabase/tour/tour_repository.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
+import 'package:chessever2/screens/group_event/providers/live_group_broadcast_id_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_list_view_mode_provider.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/generic_error_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class SmartOpeningQuery {
+  const SmartOpeningQuery._({
+    required this.rawQuery,
+    this.ecoStart,
+    this.ecoEnd,
+    this.openingTerms = const <String>[],
+  });
+
+  final String rawQuery;
+  final String? ecoStart;
+  final String? ecoEnd;
+  final List<String> openingTerms;
+
+  bool get isEco => ecoStart != null;
+  bool get isOpeningText => openingTerms.isNotEmpty;
+
+  String get title {
+    if (isEco) {
+      if (ecoEnd == null || ecoEnd == ecoStart) return 'ECO: $ecoStart';
+      return 'ECO: $ecoStart–$ecoEnd';
+    }
+    return 'Opening: ${_titleCase(rawQuery)}';
+  }
+
+  String get subtitle {
+    if (isEco) return 'Games from matching ECO codes';
+    return 'Games from matching opening names';
+  }
+
+  String get badge {
+    if (isEco) return ecoEnd == null || ecoEnd == ecoStart ? ecoStart! : 'ECO';
+    final term = openingTerms.first;
+    return term.length <= 4 ? term.toUpperCase() : term[0].toUpperCase();
+  }
+
+  static SmartOpeningQuery? parse(String input) {
+    final query = input.trim();
+    if (query.isEmpty) return null;
+
+    final compact = query.toUpperCase().replaceAll(RegExp(r'\s+'), '');
+    final exactEco = RegExp(r'^[A-E][0-9]{2}$').firstMatch(compact);
+    if (exactEco != null) {
+      return SmartOpeningQuery._(rawQuery: query, ecoStart: compact);
+    }
+
+    final range = RegExp(
+      r'^([A-E])([0-9]{2})[-–—]?(?:([A-E])?([0-9]{2}))$',
+    ).firstMatch(compact);
+    if (range != null && compact.contains(RegExp(r'[-–—]'))) {
+      final family = range.group(1)!;
+      final start = int.parse(range.group(2)!);
+      final endFamily = range.group(3) ?? family;
+      final end = int.parse(range.group(4)!);
+      if (family == endFamily && start <= end) {
+        return SmartOpeningQuery._(
+          rawQuery: query,
+          ecoStart: '$family${start.toString().padLeft(2, '0')}',
+          ecoEnd: '$family${end.toString().padLeft(2, '0')}',
+        );
+      }
+    }
+
+    final normalized = _normalizeOpeningText(query);
+    final terms = normalized
+        .split(' ')
+        .where(
+          (term) => term.length >= 3 && !_ignoredOpeningWords.contains(term),
+        )
+        .toList(growable: false);
+    if (terms.isEmpty) return null;
+
+    final hasOpeningSignal = terms.any(_knownOpeningSignals.contains);
+    if (!hasOpeningSignal) return null;
+
+    return SmartOpeningQuery._(rawQuery: query, openingTerms: terms);
+  }
+
+  bool matchesGame(Games game) {
+    if (isEco) return _matchesEco(game.eco);
+    final haystack = _normalizeOpeningText(
+      '${game.openingName ?? ''} ${game.eco ?? ''} ${game.name ?? ''}',
+    );
+    return openingTerms.every(haystack.contains);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SmartOpeningQuery &&
+        other.rawQuery == rawQuery &&
+        other.ecoStart == ecoStart &&
+        other.ecoEnd == ecoEnd &&
+        _listEquals(other.openingTerms, openingTerms);
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(rawQuery, ecoStart, ecoEnd, Object.hashAll(openingTerms));
+
+  bool _matchesEco(String? value) {
+    final eco = value?.trim().toUpperCase();
+    if (eco == null || !RegExp(r'^[A-E][0-9]{2}$').hasMatch(eco)) {
+      return false;
+    }
+    final start = ecoStart!;
+    final end = ecoEnd ?? start;
+    if (eco[0] != start[0] || eco[0] != end[0]) return false;
+    final code = int.parse(eco.substring(1));
+    return code >= int.parse(start.substring(1)) &&
+        code <= int.parse(end.substring(1));
+  }
+}
+
+bool _listEquals(List<String> a, List<String> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+const _ignoredOpeningWords = <String>{
+  'opening',
+  'defense',
+  'defence',
+  'variation',
+  'system',
+  'attack',
+  'game',
+};
+
+const _knownOpeningSignals = <String>{
+  'sicilian',
+  'najdorf',
+  'dragon',
+  'sveshnikov',
+  'kan',
+  'taimanov',
+  'scheveningen',
+  'alapin',
+  'caro',
+  'kann',
+  'french',
+  'ruy',
+  'lopez',
+  'spanish',
+  'berlin',
+  'italian',
+  'giuoco',
+  'piano',
+  'scotch',
+  'petroff',
+  'philidor',
+  'pirc',
+  'modern',
+  'alekhine',
+  'queen',
+  'gambit',
+  'catalan',
+  'nimzo',
+  'indian',
+  'grunfeld',
+  'gruenfeld',
+  'benoni',
+  'benko',
+  'dutch',
+  'london',
+  'colle',
+  'reti',
+  'english',
+  'bird',
+  'vienna',
+  'kings',
+  'king',
+  'slav',
+  'semi',
+  'tarrasch',
+  'veresov',
+  'trompowsky',
+};
+
+String _normalizeOpeningText(String value) {
+  return value
+      .toLowerCase()
+      .replaceAll('&', ' and ')
+      .replaceAll(RegExp(r'[^a-z0-9]+'), ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+}
+
+String _titleCase(String value) {
+  return value
+      .trim()
+      .split(RegExp(r'\s+'))
+      .where((part) => part.isNotEmpty)
+      .map((part) => part[0].toUpperCase() + part.substring(1).toLowerCase())
+      .join(' ');
+}
+
+class SmartOpeningEventCard extends StatelessWidget {
+  const SmartOpeningEventCard({super.key, required this.query, this.margin});
+
+  final SmartOpeningQuery query;
+  final EdgeInsetsGeometry? margin;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: margin ?? EdgeInsets.only(bottom: 12.sp),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14.br),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => SmartOpeningEventScreen(query: query),
+            ),
+          );
+        },
+        child: Container(
+          padding: EdgeInsets.all(14.sp),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                kPrimaryColor.withValues(alpha: 0.18),
+                context.colors.surface,
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(14.br),
+            border: Border.all(color: kPrimaryColor.withValues(alpha: 0.32)),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 42.sp,
+                height: 42.sp,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: kPrimaryColor,
+                  borderRadius: BorderRadius.circular(11.br),
+                ),
+                child: Text(
+                  query.badge,
+                  style: TextStyle(
+                    color: kBlackColor,
+                    fontWeight: FontWeight.w800,
+                    fontSize: query.badge.length > 3 ? 12.sp : 15.sp,
+                  ),
+                ),
+              ),
+              SizedBox(width: 12.sp),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      query.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.colors.textPrimary,
+                        fontSize: 16.sp,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    SizedBox(height: 3.sp),
+                    Text(
+                      'Smart database from current games',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: context.colors.textSecondary,
+                        fontSize: 12.sp,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: context.colors.textSecondary,
+                size: 22.sp,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SmartOpeningEventState {
+  const SmartOpeningEventState({required this.games});
+
+  final List<GamesTourModel> games;
+
+  Map<DateTime, List<GamesTourModel>> get gamesByDay {
+    final grouped = <DateTime, List<GamesTourModel>>{};
+    for (final game in games) {
+      final rawDate = game.bucketDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final day = DateTime(rawDate.year, rawDate.month, rawDate.day);
+      grouped.putIfAbsent(day, () => <GamesTourModel>[]).add(game);
+    }
+    return grouped;
+  }
+}
+
+final smartOpeningEventProvider = FutureProvider.autoDispose
+    .family<SmartOpeningEventState, SmartOpeningQuery>((ref, query) async {
+      final broadcasts = await ref
+          .read(groupBroadcastRepositoryProvider)
+          .getCurrentGroupBroadcasts(limit: 80);
+      if (broadcasts.isEmpty) return const SmartOpeningEventState(games: []);
+
+      final liveIds = ref.read(liveGroupBroadcastIdsProvider).valueOrNull ?? [];
+      final visibleBroadcasts = broadcasts
+          .where((broadcast) {
+            final category = GroupEventCardModel.getCategory(
+              groupId: broadcast.id,
+              groupName: broadcast.name,
+              startDate: broadcast.dateStart,
+              endDate: broadcast.dateEnd,
+              liveGroupIds: liveIds,
+            );
+            return category == TourEventCategory.live ||
+                category == TourEventCategory.ongoing ||
+                category == TourEventCategory.upcoming;
+          })
+          .toList(growable: false);
+
+      final toursByEvent = await ref
+          .read(tourRepositoryProvider)
+          .getToursByGroupBroadcastIds(
+            visibleBroadcasts.map((broadcast) => broadcast.id).toList(),
+          );
+      final tourIds = toursByEvent.values
+          .expand((tours) => tours)
+          .map((tour) => tour.id)
+          .toSet()
+          .toList(growable: false);
+      if (tourIds.isEmpty) return const SmartOpeningEventState(games: []);
+
+      final rawGames = await ref
+          .read(gameRepositoryProvider)
+          .getGamesFromTourIds(tourIds: tourIds, limit: 1000, offset: 0);
+      final models = <GamesTourModel>[];
+      for (final game in rawGames) {
+        if (!query.matchesGame(game)) continue;
+        try {
+          models.add(GamesTourModel.fromGame(game));
+        } catch (_) {
+          // Keep the smart event resilient to malformed rows.
+        }
+      }
+
+      models.sort((a, b) {
+        final dateCompare = _gameDate(b).compareTo(_gameDate(a));
+        if (dateCompare != 0) return dateCompare;
+        return _averageRating(b).compareTo(_averageRating(a));
+      });
+
+      return SmartOpeningEventState(games: models);
+    });
+
+DateTime _gameDate(GamesTourModel game) {
+  return game.bucketDate ?? DateTime.fromMillisecondsSinceEpoch(0);
+}
+
+int _averageRating(GamesTourModel game) {
+  final white = game.whitePlayer.rating;
+  final black = game.blackPlayer.rating;
+  if (white > 0 && black > 0) return ((white + black) / 2).round();
+  return white > black ? white : black;
+}
+
+class SmartOpeningEventScreen extends ConsumerWidget {
+  const SmartOpeningEventScreen({super.key, required this.query});
+
+  final SmartOpeningQuery query;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(smartOpeningEventProvider(query));
+    final viewMode = ref.watch(gamesListViewModeProvider);
+
+    return Scaffold(
+      backgroundColor: context.colors.background,
+      appBar: AppBar(
+        backgroundColor: context.colors.background,
+        foregroundColor: context.colors.textPrimary,
+        elevation: 0,
+        title: Text(query.title),
+      ),
+      body: SafeArea(
+        child: state.when(
+          data:
+              (data) => _SmartOpeningGamesList(
+                query: query,
+                data: data,
+                viewMode: viewMode,
+              ),
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error:
+              (error, stack) => GenericErrorWidget(
+                message: error.toString(),
+                onRetry: () => ref.invalidate(smartOpeningEventProvider),
+              ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SmartOpeningGamesList extends StatelessWidget {
+  const _SmartOpeningGamesList({
+    required this.query,
+    required this.data,
+    required this.viewMode,
+  });
+
+  final SmartOpeningQuery query;
+  final SmartOpeningEventState data;
+  final GamesListViewMode viewMode;
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.games.isEmpty) {
+      return Center(
+        child: Text(
+          'No ${query.title} games found',
+          style: TextStyle(color: context.colors.textSecondary),
+        ),
+      );
+    }
+
+    final entries =
+        data.gamesByDay.entries.toList()
+          ..sort((a, b) => b.key.compareTo(a.key));
+    return ListView.builder(
+      padding: EdgeInsets.fromLTRB(16.sp, 12.sp, 16.sp, 24.sp),
+      itemCount: entries.length,
+      itemBuilder: (context, sectionIndex) {
+        final entry = entries[sectionIndex];
+        final games = entry.value;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: EdgeInsets.only(
+                top: sectionIndex == 0 ? 0 : 18.sp,
+                bottom: 8.sp,
+              ),
+              child: Text(
+                _formatSmartOpeningDay(entry.key),
+                style: TextStyle(
+                  color: context.colors.textPrimary,
+                  fontSize: 15.sp,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+            ...List.generate(games.length, (index) {
+              final game = games[index];
+              final globalIndex = data.games.indexWhere(
+                (item) => item.gameId == game.gameId,
+              );
+              final gamesData = GamesScreenModel(
+                gamesTourModels: data.games,
+                pinnedGamedIs: const [],
+              );
+              return Padding(
+                padding: EdgeInsets.only(bottom: 10.sp),
+                child: GameCardWrapperWidget(
+                  game: game,
+                  gamesData: gamesData,
+                  gameIndex: globalIndex < 0 ? index : globalIndex,
+                  isChessBoardVisible:
+                      viewMode == GamesListViewMode.chessBoardGrid,
+                  viewSource: ChessboardView.forYou,
+                  onReturnFromChessboard: (_) {},
+                  onPinToggle: (_) async {},
+                ),
+              );
+            }),
+          ],
+        );
+      },
+    );
+  }
+}
+
+String _formatSmartOpeningDay(DateTime day) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+  if (day == today) return 'Today';
+  if (day == yesterday) return 'Yesterday';
+  const months = <String>[
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[day.month - 1]} ${day.day}';
+}

--- a/lib/screens/group_event/widget/all_events_tab_widget.dart
+++ b/lib/screens/group_event/widget/all_events_tab_widget.dart
@@ -1,4 +1,6 @@
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
+import 'package:chessever2/screens/group_event/smart_level_event.dart';
+import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_provider.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -13,11 +15,13 @@ class AllEventsTabWidget extends ConsumerStatefulWidget {
     super.key,
     this.isLoadingMore = false,
     this.scrollController,
+    this.showSmartLevelEvent = false,
   });
   final List<GroupEventCardModel> filteredEvents;
   final ValueChanged<GroupEventCardModel> onSelect;
   final bool isLoadingMore;
   final ScrollController? scrollController;
+  final bool showSmartLevelEvent;
 
   @override
   ConsumerState<AllEventsTabWidget> createState() => _AllEventsTabWidgetState();
@@ -97,7 +101,14 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
 
   @override
   Widget build(BuildContext context) {
-    if (widget.filteredEvents.isEmpty) {
+    final levelTier =
+        widget.showSmartLevelEvent
+            ? SmartLevelTier.fromFilter(
+              ref.watch(currentPastAppliedFilterProvider),
+            )
+            : null;
+
+    if (widget.filteredEvents.isEmpty && levelTier == null) {
       return Center(
         child: Text(
           'No tournaments found',
@@ -114,13 +125,17 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
 
     // Use grid layout for tablets, list layout for phones
     if (isTablet && crossAxisCount > 1) {
-      return _buildTabletGridLayout(bottomPadding, crossAxisCount);
+      return _buildTabletGridLayout(bottomPadding, crossAxisCount, levelTier);
     }
 
-    return _buildPhoneListLayout(bottomPadding);
+    return _buildPhoneListLayout(bottomPadding, levelTier);
   }
 
-  Widget _buildTabletGridLayout(double bottomPadding, int crossAxisCount) {
+  Widget _buildTabletGridLayout(
+    double bottomPadding,
+    int crossAxisCount,
+    SmartLevelTier? levelTier,
+  ) {
     final horizontalPadding = ResponsiveHelper.adaptive(
       phone: 20.sp,
       tablet: 24.sp,
@@ -129,6 +144,17 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
     return CustomScrollView(
       controller: widget.scrollController,
       slivers: [
+        if (levelTier != null)
+          SliverPadding(
+            padding: EdgeInsets.only(
+              left: horizontalPadding,
+              right: horizontalPadding,
+              bottom: 12.sp,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: SmartLevelEventCard(tier: levelTier),
+            ),
+          ),
         SliverPadding(
           padding: EdgeInsets.only(
             left: horizontalPadding,
@@ -155,7 +181,8 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
               padding: EdgeInsets.only(bottom: bottomPadding + 20),
               child: Center(
                 child: CircularProgressIndicator(
-                  color: context.isLightTheme ? kPrimaryColor : kBoardLightDefault,
+                  color:
+                      context.isLightTheme ? kPrimaryColor : kBoardLightDefault,
                 ),
               ),
             ),
@@ -164,7 +191,11 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
     );
   }
 
-  Widget _buildPhoneListLayout(double bottomPadding) {
+  Widget _buildPhoneListLayout(
+    double bottomPadding,
+    SmartLevelTier? levelTier,
+  ) {
+    final smartCardCount = levelTier != null ? 1 : 0;
     return ListView.builder(
       controller: widget.scrollController,
       padding: EdgeInsets.only(
@@ -172,9 +203,17 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
         right: 20.sp,
         bottom: bottomPadding + 12.sp,
       ),
-      itemCount: widget.filteredEvents.length + (widget.isLoadingMore ? 1 : 0),
+      itemCount:
+          widget.filteredEvents.length +
+          smartCardCount +
+          (widget.isLoadingMore ? 1 : 0),
       itemBuilder: (context, index) {
-        if (index == widget.filteredEvents.length) {
+        if (levelTier != null && index == 0) {
+          return SmartLevelEventCard(tier: levelTier);
+        }
+
+        final eventIndex = index - smartCardCount;
+        if (eventIndex == widget.filteredEvents.length) {
           return Padding(
             padding: EdgeInsets.only(bottom: bottomPadding + 20),
             child: const Center(
@@ -182,10 +221,10 @@ class _AllEventsTabWidgetState extends ConsumerState<AllEventsTabWidget>
             ),
           );
         }
-        final tourEventCardModel = widget.filteredEvents[index];
+        final tourEventCardModel = widget.filteredEvents[eventIndex];
         return Padding(
           padding: EdgeInsets.only(bottom: 12.sp),
-          child: _buildEventCard(tourEventCardModel, index),
+          child: _buildEventCard(tourEventCardModel, eventIndex),
         );
       },
     );

--- a/lib/screens/group_event/widget/for_you_games_widget.dart
+++ b/lib/screens/group_event/widget/for_you_games_widget.dart
@@ -6,6 +6,8 @@ import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provid
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/group_event/group_event_screen.dart';
 import 'package:chessever2/screens/group_event/providers/group_event_screen_provider.dart';
+import 'package:chessever2/screens/group_event/smart_level_event.dart';
+import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_provider.dart';
 import 'package:chessever2/screens/group_event/widget/premium_collection_cards.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_list_view_mode_provider.dart';
@@ -159,6 +161,9 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
 
     final state = ref.watch(forYouEventsProvider);
     final viewMode = ref.watch(gamesListViewModeProvider);
+    final levelTier = SmartLevelTier.fromFilter(
+      ref.watch(forYouAppliedFilterProvider),
+    );
     final events = state.events;
 
     if (state.isLoading && events.isEmpty) {
@@ -189,6 +194,7 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
         viewMode: viewMode,
         isScrolling: _isScrolling,
         showLoadingMore: state.hasMore && !state.isLoading,
+        levelTier: levelTier,
       ),
     );
   }
@@ -258,6 +264,7 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
     required GamesListViewMode viewMode,
     required bool isScrolling,
     bool showLoadingMore = false,
+    SmartLevelTier? levelTier,
   }) {
     // On tablet, use a beautiful grid layout
     if (ResponsiveHelper.isTablet) {
@@ -266,14 +273,18 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
         viewMode: viewMode,
         isScrolling: isScrolling,
         showLoadingMore: showLoadingMore,
+        levelTier: levelTier,
       );
     }
 
     // Phone: vertical list layout
     final horizontalPadding = 16.sp;
 
-    // +1 for premium cards, +1 for loading indicator if showing
-    final itemCount = events.length + 1 + (showLoadingMore ? 1 : 0);
+    // +1 for premium cards, +1 for smart level card if selected,
+    // +1 for loading indicator if showing
+    final smartCardCount = levelTier != null ? 1 : 0;
+    final itemCount =
+        events.length + 1 + smartCardCount + (showLoadingMore ? 1 : 0);
 
     return ListView.builder(
       key: const PageStorageKey<String>('for_you_events_list'),
@@ -295,16 +306,22 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
           return const PremiumCollectionCards();
         }
 
+        // Smart level event goes above the current event list when a level is selected.
+        if (levelTier != null && index == 1) {
+          return SmartLevelEventCard(tier: levelTier);
+        }
+
         // Loading indicator at bottom
         if (showLoadingMore && index == itemCount - 1) {
           return _buildLoadingMoreIndicator();
         }
 
-        final event = events[index - 1];
+        final eventIndex = index - 1 - smartCardCount;
+        final event = events[eventIndex];
         return _ForYouEventSection(
           key: ValueKey('event_${event.id}'),
           event: event,
-          isFirst: index == 1,
+          isFirst: eventIndex == 0,
           animatedEventIds: _animatedEventIds,
           animatedGameIds: _animatedGameIds,
           isScrolling: isScrolling,
@@ -337,14 +354,17 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
     required GamesListViewMode viewMode,
     required bool isScrolling,
     bool showLoadingMore = false,
+    SmartLevelTier? levelTier,
   }) {
     final horizontalPadding = ResponsiveHelper.isLandscape ? 32.sp : 24.sp;
     final columnSpacing = 16.sp;
 
     // Number of event-pair rows (ceil division)
     final rowCount = (events.length + 1) ~/ 2;
-    // +1 for premium cards at top, +1 for loading indicator if showing
-    final itemCount = rowCount + 1 + (showLoadingMore ? 1 : 0);
+    final smartCardCount = levelTier != null ? 1 : 0;
+    // +1 for premium cards at top, +1 for smart level card if selected,
+    // +1 for loading indicator if showing
+    final itemCount = rowCount + 1 + smartCardCount + (showLoadingMore ? 1 : 0);
 
     return ListView.builder(
       key: const PageStorageKey<String>('for_you_events_tablet_grid'),
@@ -366,12 +386,20 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
           return const PremiumCollectionCards();
         }
 
+        // Smart level event card spans the full tablet width above real events.
+        if (levelTier != null && index == 1) {
+          return SmartLevelEventCard(
+            tier: levelTier,
+            margin: EdgeInsets.only(bottom: 20.sp),
+          );
+        }
+
         // Loading indicator at bottom
         if (showLoadingMore && index == itemCount - 1) {
           return _buildLoadingMoreIndicator();
         }
 
-        final rowIndex = index - 1;
+        final rowIndex = index - 1 - smartCardCount;
         final i = rowIndex * 2;
         final event1 = events[i];
         final event2 = i + 1 < events.length ? events[i + 1] : null;

--- a/lib/screens/group_event/widget/search_results_widget.dart
+++ b/lib/screens/group_event/widget/search_results_widget.dart
@@ -1,6 +1,7 @@
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/group_event/providers/group_event_screen_provider.dart';
 import 'package:chessever2/screens/group_event/providers/supabase_combined_search_provider.dart';
+import 'package:chessever2/screens/group_event/smart_opening_event.dart';
 import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_provider.dart';
 import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_state.dart';
 import 'package:chessever2/screens/group_event/widget/player_search_cards.dart';
@@ -67,7 +68,10 @@ class SearchResultsWidget extends HookConsumerWidget {
           tournaments = _applySearchFilter(tournaments, searchFilter);
         }
 
-        if (tournaments.isEmpty && results.playerResults.isEmpty) {
+        final openingQuery = SmartOpeningQuery.parse(searchQuery);
+        if (tournaments.isEmpty &&
+            results.playerResults.isEmpty &&
+            openingQuery == null) {
           return _buildEmptyState(context, searchQuery);
         }
 
@@ -75,6 +79,7 @@ class SearchResultsWidget extends HookConsumerWidget {
           scrollController: scrollController,
           tournaments: tournaments,
           searchQuery: searchQuery,
+          openingQuery: openingQuery,
         );
       },
       loading: () => _buildLoadingState(),
@@ -111,9 +116,9 @@ class SearchResultsWidget extends HookConsumerWidget {
                   'No events match "$query"',
                   textAlign: TextAlign.center,
                   style: TextStyle(
-                fontSize: 14.sp,
-                color: context.colors.textSecondary,
-              ),
+                    fontSize: 14.sp,
+                    color: context.colors.textSecondary,
+                  ),
                 ),
               ],
             ),
@@ -213,11 +218,13 @@ class _SearchResultsListView extends ConsumerWidget {
     required this.scrollController,
     required this.tournaments,
     required this.searchQuery,
+    this.openingQuery,
   });
 
   final ScrollController scrollController;
   final List<GroupEventCardModel> tournaments;
   final String searchQuery;
+  final SmartOpeningQuery? openingQuery;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -274,10 +281,22 @@ class _SearchResultsListView extends ConsumerWidget {
               child: PlayerSearchCards(searchQuery: searchQuery),
             ),
           ),
+        if (openingQuery != null)
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                horizontalPadding,
+                hasPlayerCards ? 0 : 16.sp,
+                horizontalPadding,
+                0,
+              ),
+              child: SmartOpeningEventCard(query: openingQuery!),
+            ),
+          ),
         SliverPadding(
           padding: EdgeInsets.symmetric(
             horizontal: horizontalPadding,
-            vertical: hasPlayerCards ? 0 : 16.sp,
+            vertical: hasPlayerCards || openingQuery != null ? 0 : 16.sp,
           ),
           sliver: SliverGrid(
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
@@ -309,8 +328,11 @@ class _SearchResultsListView extends ConsumerWidget {
         horizontal: horizontalPadding,
         vertical: 16.sp,
       ),
-      // Add 1 to item count if we have player cards to show
-      itemCount: tournaments.length + (hasPlayerCards ? 1 : 0),
+      // Add rows for player cards and the opening smart database card.
+      itemCount:
+          tournaments.length +
+          (hasPlayerCards ? 1 : 0) +
+          (openingQuery != null ? 1 : 0),
       addAutomaticKeepAlives: true,
       addRepaintBoundaries: true,
       cacheExtent: 2000,
@@ -323,8 +345,14 @@ class _SearchResultsListView extends ConsumerWidget {
           return PlayerSearchCards(searchQuery: searchQuery);
         }
 
-        // Adjust index if player cards are present
-        final adjustedIndex = hasPlayerCards ? index - 1 : index;
+        final openingIndex = hasPlayerCards ? 1 : 0;
+        if (openingQuery != null && index == openingIndex) {
+          return SmartOpeningEventCard(query: openingQuery!);
+        }
+
+        // Adjust index if player/opening cards are present
+        final adjustedIndex =
+            index - (hasPlayerCards ? 1 : 0) - (openingQuery != null ? 1 : 0);
         if (adjustedIndex < 0 || adjustedIndex >= tournaments.length) {
           return const SizedBox.shrink();
         }

--- a/lib/screens/library/discovery/discovery_filter_widgets.dart
+++ b/lib/screens/library/discovery/discovery_filter_widgets.dart
@@ -1,0 +1,342 @@
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// A selectable pill used across the Discovery filter sheets.
+class FilterPill extends StatelessWidget {
+  const FilterPill({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.icon,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        onTap();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 160),
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+        decoration: BoxDecoration(
+          color:
+              selected
+                  ? kPrimaryColor.withValues(alpha: 0.15)
+                  : context.colors.textPrimary.withValues(alpha: 0.04),
+          borderRadius: BorderRadius.circular(20.br),
+          border: Border.all(
+            color:
+                selected
+                    ? kPrimaryColor.withValues(alpha: 0.45)
+                    : context.colors.textPrimary.withValues(alpha: 0.1),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(
+                icon,
+                size: 13.sp,
+                color:
+                    selected
+                        ? kPrimaryColor
+                        : context.colors.textPrimary.withValues(alpha: 0.55),
+              ),
+              SizedBox(width: 5.w),
+            ],
+            Text(
+              label,
+              style: AppTypography.textXsMedium.copyWith(
+                color:
+                    selected
+                        ? kPrimaryColor
+                        : context.colors.textPrimary.withValues(alpha: 0.75),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Any / Yes / No tri-state selector for nullable-bool filters.
+class TriToggle extends StatelessWidget {
+  const TriToggle({
+    super.key,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String label;
+  final bool? value;
+  final ValueChanged<bool?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.85),
+            ),
+          ),
+        ),
+        _seg('Any', value == null, () => onChanged(null)),
+        SizedBox(width: 6.w),
+        _seg('Yes', value == true, () => onChanged(true)),
+        SizedBox(width: 6.w),
+        _seg('No', value == false, () => onChanged(false)),
+      ],
+    );
+  }
+
+  Widget _seg(String text, bool selected, VoidCallback onTap) {
+    return Builder(
+      builder: (context) => GestureDetector(
+        onTap: () {
+          HapticFeedback.selectionClick();
+          onTap();
+        },
+        child: Container(
+          padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 6.h),
+          decoration: BoxDecoration(
+            color:
+                selected
+                    ? kPrimaryColor.withValues(alpha: 0.15)
+                    : context.colors.textPrimary.withValues(alpha: 0.04),
+            borderRadius: BorderRadius.circular(8.br),
+            border: Border.all(
+              color:
+                  selected
+                      ? kPrimaryColor.withValues(alpha: 0.45)
+                      : context.colors.textPrimary.withValues(alpha: 0.1),
+            ),
+          ),
+          child: Text(
+            text,
+            style: AppTypography.textXsMedium.copyWith(
+              color:
+                  selected
+                      ? kPrimaryColor
+                      : context.colors.textPrimary.withValues(alpha: 0.7),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Labeled section wrapper for a group of filter pills.
+class FilterSection extends StatelessWidget {
+  const FilterSection({super.key, required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: AppTypography.textXsMedium.copyWith(
+            color: context.colors.textPrimary.withValues(alpha: 0.5),
+            letterSpacing: 0.4,
+          ),
+        ),
+        SizedBox(height: 10.h),
+        child,
+      ],
+    );
+  }
+}
+
+/// Shared bottom-sheet shell: drag handle, title, scrollable body, and a
+/// Clear / Apply footer.
+class FilterSheetScaffold extends StatelessWidget {
+  const FilterSheetScaffold({
+    super.key,
+    required this.title,
+    required this.onClear,
+    required this.onApply,
+    required this.children,
+  });
+
+  final String title;
+  final VoidCallback onClear;
+  final VoidCallback onApply;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Container(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.8,
+        ),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24.br)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: EdgeInsets.symmetric(vertical: 12.h),
+              width: 40.w,
+              height: 4.h,
+              decoration: BoxDecoration(
+                color: context.colors.textPrimary.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2.br),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(20.w, 0, 20.w, 8.h),
+              child: Row(
+                children: [
+                  Text(
+                    title,
+                    style: AppTypography.textMdBold.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                  const Spacer(),
+                  GestureDetector(
+                    onTap: () {
+                      HapticFeedback.lightImpact();
+                      onClear();
+                    },
+                    child: Text(
+                      'Clear',
+                      style: AppTypography.textSmMedium.copyWith(
+                        color: kRedColor.withValues(alpha: 0.9),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.fromLTRB(20.w, 8.h, 20.w, 8.h),
+                physics: const BouncingScrollPhysics(),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: children,
+                ),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(20.w, 8.h, 20.w, 16.h),
+              child: GestureDetector(
+                onTap: () {
+                  HapticFeedback.mediumImpact();
+                  onApply();
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding: EdgeInsets.symmetric(vertical: 14.h),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        kPrimaryColor,
+                        kPrimaryColor.withValues(alpha: 0.8),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                    borderRadius: BorderRadius.circular(14.br),
+                  ),
+                  child: Center(
+                    child: Text(
+                      'Apply',
+                      style: AppTypography.textSmBold.copyWith(
+                        color: context.colors.textPrimary,
+                        letterSpacing: 0.3,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Small filter button with an active-count badge, used in the tab headers.
+class FilterButton extends StatelessWidget {
+  const FilterButton({super.key, required this.count, required this.onTap});
+
+  final int count;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final active = count > 0;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
+        decoration: BoxDecoration(
+          color:
+              active
+                  ? kPrimaryColor.withValues(alpha: 0.14)
+                  : context.colors.surface,
+          borderRadius: BorderRadius.circular(20.br),
+          border: Border.all(
+            color:
+                active
+                    ? kPrimaryColor.withValues(alpha: 0.4)
+                    : context.colors.textPrimary.withValues(alpha: 0.1),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.tune_rounded,
+              size: 15.sp,
+              color:
+                  active
+                      ? kPrimaryColor
+                      : context.colors.textPrimary.withValues(alpha: 0.7),
+            ),
+            SizedBox(width: 6.w),
+            Text(
+              active ? 'Filters · $count' : 'Filters',
+              style: AppTypography.textXsMedium.copyWith(
+                color:
+                    active
+                        ? kPrimaryColor
+                        : context.colors.textPrimary.withValues(alpha: 0.85),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/library/discovery/miniatures_tab.dart
+++ b/lib/screens/library/discovery/miniatures_tab.dart
@@ -1,0 +1,494 @@
+import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
+import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
+import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/haptic_feedback_service.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/segmented_switcher.dart';
+import 'package:chessever2/widgets/skeleton_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Discovery → Miniatures: community feed of short decisive games.
+class MiniaturesTab extends ConsumerWidget {
+  const MiniaturesTab({super.key});
+
+  Future<void> _pickSort(BuildContext context, WidgetRef ref) async {
+    HapticFeedback.selectionClick();
+    final current = ref.read(miniaturesQueryProvider).sort;
+    final picked = await showModalBottomSheet<MiniatureSort>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _MiniatureSortSheet(current: current),
+    );
+    if (picked != null) {
+      ref.read(miniaturesQueryProvider.notifier).setSort(picked);
+    }
+  }
+
+  void _openMiniature(
+    BuildContext context,
+    WidgetRef ref,
+    List<Miniature> all,
+    int index,
+  ) {
+    HapticFeedbackService.cardTap();
+    final models = all.map((m) => m.toGamesTourModel()).toList();
+    ref.read(chessboardViewFromProviderNew.notifier).state =
+        ChessboardView.tour;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ChessBoardScreenNew(
+          currentIndex: index,
+          games: models,
+          showGamebaseButton: true,
+          disableGamebaseOverlayByDefault: true,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final query = ref.watch(miniaturesQueryProvider);
+    final listAsync = ref.watch(miniaturesListProvider);
+
+    return Column(
+      children: [
+        // Window sub-tabs (Today / Week / All time).
+        Padding(
+          padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 8.h),
+          child: SegmentedSwitcher(
+            options: const ['Today', 'Week', 'All time'],
+            currentSelection: query.window.index,
+            backgroundColor: context.colors.surface,
+            selectedBackgroundColor: context.colors.surfaceRecessed,
+            onSelectionChanged: (i) {
+              HapticFeedback.selectionClick();
+              ref
+                  .read(miniaturesQueryProvider.notifier)
+                  .setWindow(MiniatureWindow.values[i]);
+            },
+          ),
+        ),
+        _SortRow(label: query.sort.label, onTap: () => _pickSort(context, ref)),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: () async {
+              HapticFeedbackService.medium();
+              ref.invalidate(miniaturesListProvider);
+              await ref.read(miniaturesListProvider.future);
+            },
+            color: context.colors.textPrimary,
+            backgroundColor: context.colors.surface,
+            child: listAsync.when(
+              data: (page) {
+                if (page.items.isEmpty) {
+                  return const _EmptyMiniatures();
+                }
+                return ListView.separated(
+                  primary: false,
+                  physics: const AlwaysScrollableScrollPhysics(
+                    parent: BouncingScrollPhysics(),
+                  ),
+                  padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 24.h),
+                  itemCount: page.items.length,
+                  separatorBuilder: (_, __) => SizedBox(height: 8.h),
+                  itemBuilder: (context, i) => _MiniatureCard(
+                    miniature: page.items[i],
+                    onTap: () =>
+                        _openMiniature(context, ref, page.items, i),
+                  ),
+                );
+              },
+              loading: () => _MiniaturesLoading(),
+              error: (e, _) => _MiniaturesError(
+                onRetry: () => ref.invalidate(miniaturesListProvider),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SortRow extends StatelessWidget {
+  const _SortRow({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 8.h),
+      child: Row(
+        children: [
+          const Spacer(),
+          GestureDetector(
+            onTap: onTap,
+            child: Container(
+              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
+              decoration: BoxDecoration(
+                color: context.colors.surface,
+                borderRadius: BorderRadius.circular(20.br),
+                border: Border.all(
+                  color: context.colors.textPrimary.withValues(alpha: 0.1),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.swap_vert_rounded, size: 15.sp, color: kPrimaryColor),
+                  SizedBox(width: 6.w),
+                  Text(
+                    label,
+                    style: AppTypography.textXsMedium.copyWith(
+                      color: context.colors.textPrimary.withValues(alpha: 0.85),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniatureCard extends StatelessWidget {
+  const _MiniatureCard({required this.miniature, required this.onTap});
+
+  final Miniature miniature;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final white = (miniature.whiteName ?? 'White').trim();
+    final black = (miniature.blackName ?? 'Black').trim();
+    final whiteWins = miniature.result == 'W';
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 12.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(12.br),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: _PlayerLine(
+                    name: white,
+                    elo: miniature.whiteElo,
+                    isWinner: whiteWins,
+                    alignEnd: false,
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 8.w),
+                  child: Container(
+                    padding:
+                        EdgeInsets.symmetric(horizontal: 8.w, vertical: 3.h),
+                    decoration: BoxDecoration(
+                      color: context.colors.surfaceRecessed,
+                      borderRadius: BorderRadius.circular(6.br),
+                    ),
+                    child: Text(
+                      whiteWins ? '1-0' : '0-1',
+                      style: AppTypography.textXsBold.copyWith(
+                        color: context.colors.textPrimary,
+                      ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: _PlayerLine(
+                    name: black,
+                    elo: miniature.blackElo,
+                    isWinner: !whiteWins,
+                    alignEnd: true,
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 10.h),
+            Row(
+              children: [
+                _Chip(
+                  icon: Icons.bolt_rounded,
+                  label: 'M${miniature.finalMoveNumber}',
+                ),
+                SizedBox(width: 6.w),
+                if (miniature.eco != null && miniature.eco!.isNotEmpty)
+                  _Chip(icon: Icons.account_tree_rounded, label: miniature.eco!),
+                const Spacer(),
+                if (miniature.avgRating != null)
+                  _Chip(
+                    icon: Icons.military_tech_rounded,
+                    label: '${miniature.avgRating}',
+                    accent: true,
+                  ),
+              ],
+            ),
+            if ((miniature.event ?? '').trim().isNotEmpty) ...[
+              SizedBox(height: 8.h),
+              Row(
+                children: [
+                  Icon(
+                    Icons.emoji_events_outlined,
+                    size: 13.sp,
+                    color: context.colors.textPrimary.withValues(alpha: 0.4),
+                  ),
+                  SizedBox(width: 5.w),
+                  Expanded(
+                    child: Text(
+                      miniature.event!.trim(),
+                      style: AppTypography.textXsRegular.copyWith(
+                        color: context.colors.textPrimary.withValues(alpha: 0.5),
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlayerLine extends StatelessWidget {
+  const _PlayerLine({
+    required this.name,
+    required this.elo,
+    required this.isWinner,
+    required this.alignEnd,
+  });
+
+  final String name;
+  final int? elo;
+  final bool isWinner;
+  final bool alignEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment:
+          alignEnd ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+      children: [
+        Text(
+          name.isEmpty ? '—' : name,
+          style: AppTypography.textSmMedium.copyWith(
+            color: context.colors.textPrimary,
+            fontWeight: isWinner ? FontWeight.w700 : FontWeight.w500,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        if (elo != null && elo! > 0) ...[
+          SizedBox(height: 2.h),
+          Text(
+            '$elo',
+            style: AppTypography.textXsRegular.copyWith(
+              color: context.colors.textSecondary,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.icon, required this.label, this.accent = false});
+
+  final IconData icon;
+  final String label;
+  final bool accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final color =
+        accent ? kPrimaryColor : context.colors.textPrimary.withValues(alpha: 0.6);
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 4.h),
+      decoration: BoxDecoration(
+        color: accent
+            ? kPrimaryColor.withValues(alpha: 0.12)
+            : context.colors.textPrimary.withValues(alpha: 0.05),
+        borderRadius: BorderRadius.circular(8.br),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 12.sp, color: color),
+          SizedBox(width: 4.w),
+          Text(
+            label,
+            style: AppTypography.textXxsMedium.copyWith(color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniatureSortSheet extends StatelessWidget {
+  const _MiniatureSortSheet({required this.current});
+
+  final MiniatureSort current;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24.br)),
+        ),
+        padding: EdgeInsets.only(bottom: 8.h),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: EdgeInsets.symmetric(vertical: 12.h),
+              width: 40.w,
+              height: 4.h,
+              decoration: BoxDecoration(
+                color: context.colors.textPrimary.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2.br),
+              ),
+            ),
+            for (final option in MiniatureSort.values)
+              ListTile(
+                onTap: () => Navigator.of(context).pop(option),
+                title: Text(
+                  option.label,
+                  style: AppTypography.textSmMedium.copyWith(
+                    color: context.colors.textPrimary,
+                  ),
+                ),
+                trailing: option == current
+                    ? Icon(Icons.check_rounded, color: kPrimaryColor, size: 20.sp)
+                    : null,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniaturesLoading extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 24.h),
+      child: SkeletonWidget(
+        child: Column(
+          children: [
+            for (var i = 0; i < 6; i++) ...[
+              Container(
+                height: 92.h,
+                decoration: BoxDecoration(
+                  color: context.colors.surface,
+                  borderRadius: BorderRadius.circular(12.br),
+                ),
+              ),
+              SizedBox(height: 8.h),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyMiniatures extends StatelessWidget {
+  const _EmptyMiniatures();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(height: 120.h),
+        Icon(
+          Icons.bolt_outlined,
+          size: 56.sp,
+          color: context.colors.textPrimary.withValues(alpha: 0.4),
+        ),
+        SizedBox(height: 12.h),
+        Center(
+          child: Text(
+            'No miniatures in this window',
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.8),
+            ),
+          ),
+        ),
+        SizedBox(height: 6.h),
+        Center(
+          child: Text(
+            'Try a wider time window',
+            style: AppTypography.textSmRegular.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.5),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MiniaturesError extends StatelessWidget {
+  const _MiniaturesError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(height: 120.h),
+        Icon(Icons.cloud_off_rounded, size: 48.sp, color: kRedColor.withValues(alpha: 0.7)),
+        SizedBox(height: 12.h),
+        Center(
+          child: Text(
+            'Could not load miniatures',
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
+          ),
+        ),
+        SizedBox(height: 12.h),
+        Center(
+          child: TextButton(
+            onPressed: onRetry,
+            child: Text(
+              'Retry',
+              style: AppTypography.textSmMedium.copyWith(color: kPrimaryColor),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/library/discovery/miniatures_tab.dart
+++ b/lib/screens/library/discovery/miniatures_tab.dart
@@ -1,5 +1,6 @@
 import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
 import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
+import 'package:chessever2/screens/library/discovery/discovery_filter_widgets.dart';
 import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/theme/app_colors.dart';
@@ -28,6 +29,16 @@ class MiniaturesTab extends ConsumerWidget {
     if (picked != null) {
       ref.read(miniaturesQueryProvider.notifier).setSort(picked);
     }
+  }
+
+  Future<void> _pickFilters(BuildContext context, WidgetRef ref) async {
+    HapticFeedback.selectionClick();
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => const _MiniaturesFilterSheet(),
+    );
   }
 
   void _openMiniature(
@@ -75,7 +86,22 @@ class MiniaturesTab extends ConsumerWidget {
             },
           ),
         ),
-        _SortRow(label: query.sort.label, onTap: () => _pickSort(context, ref)),
+        Padding(
+          padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 8.h),
+          child: Row(
+            children: [
+              FilterButton(
+                count: query.activeFilterCount,
+                onTap: () => _pickFilters(context, ref),
+              ),
+              const Spacer(),
+              _SortChip(
+                label: query.sort.label,
+                onTap: () => _pickSort(context, ref),
+              ),
+            ],
+          ),
+        ),
         Expanded(
           child: RefreshIndicator(
             onRefresh: () async {
@@ -117,47 +143,147 @@ class MiniaturesTab extends ConsumerWidget {
   }
 }
 
-class _SortRow extends StatelessWidget {
-  const _SortRow({required this.label, required this.onTap});
+class _SortChip extends StatelessWidget {
+  const _SortChip({required this.label, required this.onTap});
 
   final String label;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 8.h),
-      child: Row(
-        children: [
-          const Spacer(),
-          GestureDetector(
-            onTap: onTap,
-            child: Container(
-              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
-              decoration: BoxDecoration(
-                color: context.colors.surface,
-                borderRadius: BorderRadius.circular(20.br),
-                border: Border.all(
-                  color: context.colors.textPrimary.withValues(alpha: 0.1),
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.swap_vert_rounded, size: 15.sp, color: kPrimaryColor),
-                  SizedBox(width: 6.w),
-                  Text(
-                    label,
-                    style: AppTypography.textXsMedium.copyWith(
-                      color: context.colors.textPrimary.withValues(alpha: 0.85),
-                    ),
-                  ),
-                ],
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(20.br),
+          border: Border.all(
+            color: context.colors.textPrimary.withValues(alpha: 0.1),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.swap_vert_rounded, size: 15.sp, color: kPrimaryColor),
+            SizedBox(width: 6.w),
+            Text(
+              label,
+              style: AppTypography.textXsMedium.copyWith(
+                color: context.colors.textPrimary.withValues(alpha: 0.85),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
+    );
+  }
+}
+
+const List<String> _miniatureEcoCategories = ['A', 'B', 'C', 'D', 'E'];
+
+class _MiniaturesFilterSheet extends ConsumerStatefulWidget {
+  const _MiniaturesFilterSheet();
+
+  @override
+  ConsumerState<_MiniaturesFilterSheet> createState() =>
+      _MiniaturesFilterSheetState();
+}
+
+class _MiniaturesFilterSheetState
+    extends ConsumerState<_MiniaturesFilterSheet> {
+  late Set<String> _results;
+  late Set<String> _timeControls;
+  late Set<String> _eco;
+
+  @override
+  void initState() {
+    super.initState();
+    final q = ref.read(miniaturesQueryProvider);
+    _results = {...q.results};
+    _timeControls = {...q.timeControls};
+    _eco = {...q.ecoCategories};
+  }
+
+  void _toggle(Set<String> set, String value) {
+    setState(() {
+      if (!set.remove(value)) set.add(value);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterSheetScaffold(
+      title: 'Filter miniatures',
+      onClear: () {
+        setState(() {
+          _results = {};
+          _timeControls = {};
+          _eco = {};
+        });
+      },
+      onApply: () {
+        ref.read(miniaturesQueryProvider.notifier).applyFilters(
+              results: _results,
+              timeControls: _timeControls,
+              ecoCategories: _eco,
+            );
+        Navigator.of(context).pop();
+      },
+      children: [
+        FilterSection(
+          title: 'RESULT',
+          child: Wrap(
+            spacing: 8.w,
+            runSpacing: 8.h,
+            children: [
+              FilterPill(
+                label: 'White wins',
+                selected: _results.contains('W'),
+                onTap: () => _toggle(_results, 'W'),
+              ),
+              FilterPill(
+                label: 'Black wins',
+                selected: _results.contains('B'),
+                onTap: () => _toggle(_results, 'B'),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(height: 20.h),
+        FilterSection(
+          title: 'TIME CONTROL',
+          child: Wrap(
+            spacing: 8.w,
+            runSpacing: 8.h,
+            children: [
+              for (final tc in const ['CLASSICAL', 'RAPID', 'BLITZ'])
+                FilterPill(
+                  label: tc[0] + tc.substring(1).toLowerCase(),
+                  selected: _timeControls.contains(tc),
+                  onTap: () => _toggle(_timeControls, tc),
+                ),
+            ],
+          ),
+        ),
+        SizedBox(height: 20.h),
+        FilterSection(
+          title: 'ECO CATEGORY',
+          child: Wrap(
+            spacing: 8.w,
+            runSpacing: 8.h,
+            children: [
+              for (final c in _miniatureEcoCategories)
+                FilterPill(
+                  label: c,
+                  selected: _eco.contains(c),
+                  onTap: () => _toggle(_eco, c),
+                ),
+            ],
+          ),
+        ),
+        SizedBox(height: 8.h),
+      ],
     );
   }
 }

--- a/lib/screens/library/discovery/miniatures_tab.dart
+++ b/lib/screens/library/discovery/miniatures_tab.dart
@@ -595,17 +595,23 @@ class _MiniatureSortSheet extends StatelessWidget {
               ),
             ),
             for (final option in MiniatureSort.values)
-              ListTile(
-                onTap: () => Navigator.of(context).pop(option),
-                title: Text(
-                  option.label,
-                  style: AppTypography.textSmMedium.copyWith(
-                    color: context.colors.textPrimary,
+              // Transparent Material gives the ListTile a Material ancestor for
+              // ink; the colored sheet Container would otherwise hide it.
+              Material(
+                type: MaterialType.transparency,
+                child: ListTile(
+                  onTap: () => Navigator.of(context).pop(option),
+                  title: Text(
+                    option.label,
+                    style: AppTypography.textSmMedium.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
                   ),
+                  trailing: option == current
+                      ? Icon(Icons.check_rounded,
+                          color: kPrimaryColor, size: 20.sp)
+                      : null,
                 ),
-                trailing: option == current
-                    ? Icon(Icons.check_rounded, color: kPrimaryColor, size: 20.sp)
-                    : null,
               ),
           ],
         ),

--- a/lib/screens/library/discovery/miniatures_tab.dart
+++ b/lib/screens/library/discovery/miniatures_tab.dart
@@ -1,5 +1,6 @@
 import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
 import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/library/discovery/discovery_filter_widgets.dart';
 import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
@@ -8,10 +9,13 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/app_button.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:chessever2/widgets/segmented_switcher.dart';
 import 'package:chessever2/widgets/skeleton_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Discovery → Miniatures: community feed of short decisive games.
@@ -116,19 +120,42 @@ class MiniaturesTab extends ConsumerWidget {
                 if (page.items.isEmpty) {
                   return const _EmptyMiniatures();
                 }
+                // Free users browse the top of the list; a paywall card caps
+                // the free range (v1 gating is client-side — backend isn't
+                // enforcing yet).
+                final isPremium = ref.watch(
+                  subscriptionProvider.select((s) => s.isSubscribed),
+                );
+                const freeCap = 12;
+                final items = page.items;
+                final capped = !isPremium && items.length > freeCap;
+                final visible = capped ? freeCap : items.length;
+                final itemCount = visible + (capped ? 1 : 0);
                 return ListView.separated(
                   primary: false,
                   physics: const AlwaysScrollableScrollPhysics(
                     parent: BouncingScrollPhysics(),
                   ),
                   padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 24.h),
-                  itemCount: page.items.length,
+                  itemCount: itemCount,
                   separatorBuilder: (_, __) => SizedBox(height: 8.h),
-                  itemBuilder: (context, i) => _MiniatureCard(
-                    miniature: page.items[i],
-                    onTap: () =>
-                        _openMiniature(context, ref, page.items, i),
-                  ),
+                  itemBuilder: (context, i) {
+                    if (capped && i == visible) {
+                      return _MiniaturePaywallCard(
+                        onTap: () async {
+                          HapticFeedbackService.buttonPress();
+                          await requirePremiumGuard(context, ref);
+                        },
+                      );
+                    }
+                    return _MiniatureCard(
+                      miniature: items[i],
+                      onTap: () => _openMiniature(context, ref, items, i),
+                    ).animate().fadeIn(
+                          duration: 220.ms,
+                          delay: Duration(milliseconds: (i % 12) * 28),
+                        );
+                  },
                 );
               },
               loading: () => _MiniaturesLoading(),
@@ -300,7 +327,7 @@ class _MiniatureCard extends StatelessWidget {
     final black = (miniature.blackName ?? 'Black').trim();
     final whiteWins = miniature.result == 'W';
 
-    return GestureDetector(
+    return TappableScale(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 12.h),
@@ -468,6 +495,73 @@ class _Chip extends StatelessWidget {
             style: AppTypography.textXxsMedium.copyWith(color: color),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Client-side paywall card shown at the edge of the free range.
+class _MiniaturePaywallCard extends StatelessWidget {
+  const _MiniaturePaywallCard({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return TappableScale(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 18.h),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              kPrimaryColor.withValues(alpha: 0.16),
+              kPrimaryColor.withValues(alpha: 0.06),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(14.br),
+          border: Border.all(color: kPrimaryColor.withValues(alpha: 0.35)),
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: EdgeInsets.all(10.sp),
+              decoration: BoxDecoration(
+                color: kPrimaryColor.withValues(alpha: 0.18),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(Icons.workspace_premium_rounded,
+                  size: 20.sp, color: kPrimaryColor),
+            ),
+            SizedBox(width: 14.w),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'See every miniature',
+                    style: AppTypography.textSmBold.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                  SizedBox(height: 3.h),
+                  Text(
+                    'Upgrade to browse the full archive, filter and sort freely.',
+                    style: AppTypography.textXsRegular.copyWith(
+                      color: context.colors.textPrimary.withValues(alpha: 0.6),
+                      height: 1.4,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: 8.w),
+            Icon(Icons.chevron_right_rounded, size: 20.sp, color: kPrimaryColor),
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/library/discovery/studies_tab.dart
+++ b/lib/screens/library/discovery/studies_tab.dart
@@ -8,9 +8,11 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/app_button.dart';
 import 'package:chessever2/widgets/skeleton_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 
@@ -92,9 +94,18 @@ class StudiesTab extends ConsumerWidget {
           listAsync.when(
             data: (page) {
               if (page.items.isEmpty) {
-                return const SliverFillRemaining(
+                return SliverFillRemaining(
                   hasScrollBody: false,
-                  child: _EmptyStudies(),
+                  child:
+                      filterCount > 0
+                          ? _EmptyFilteredStudies(
+                            onClear:
+                                () =>
+                                    ref
+                                        .read(studiesQueryProvider.notifier)
+                                        .clearFilters(),
+                          )
+                          : const _EmptyStudies(),
                 );
               }
               return SliverPadding(
@@ -103,7 +114,10 @@ class StudiesTab extends ConsumerWidget {
                   delegate: SliverChildBuilderDelegate(
                     (context, i) => Padding(
                       padding: EdgeInsets.only(bottom: 8.h),
-                      child: _StudyCard(study: page.items[i]),
+                      child: _StudyCard(study: page.items[i]).animate().fadeIn(
+                            duration: 220.ms,
+                            delay: Duration(milliseconds: (i % 12) * 28),
+                          ),
                     ),
                     childCount: page.items.length,
                   ),
@@ -299,7 +313,7 @@ class _StudyCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return TappableScale(
       onTap: () {
         HapticFeedbackService.cardTap();
         Navigator.of(context).push(
@@ -548,6 +562,43 @@ class _EmptyStudies extends StatelessWidget {
             'Pull to refresh',
             style: AppTypography.textSmRegular.copyWith(
               color: context.colors.textPrimary.withValues(alpha: 0.5),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyFilteredStudies extends StatelessWidget {
+  const _EmptyFilteredStudies({required this.onClear});
+
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.filter_alt_off_outlined,
+            size: 56.sp,
+            color: context.colors.textPrimary.withValues(alpha: 0.4),
+          ),
+          SizedBox(height: 12.h),
+          Text(
+            'No studies match your filters',
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.85),
+            ),
+          ),
+          SizedBox(height: 12.h),
+          TextButton(
+            onPressed: onClear,
+            child: Text(
+              'Clear filters',
+              style: AppTypography.textSmMedium.copyWith(color: kPrimaryColor),
             ),
           ),
         ],

--- a/lib/screens/library/discovery/studies_tab.dart
+++ b/lib/screens/library/discovery/studies_tab.dart
@@ -487,18 +487,25 @@ class _SortSheet<T> extends StatelessWidget {
               ),
             ),
             for (final option in options)
-              ListTile(
-                onTap: () => Navigator.of(context).pop(option),
-                title: Text(
-                  labelOf(option),
-                  style: AppTypography.textSmMedium.copyWith(
-                    color: context.colors.textPrimary,
+              // Wrap in a transparent Material so the ListTile ink/highlight
+              // has a Material ancestor; the colored sheet Container would
+              // otherwise intercept it and trip a framework assertion.
+              Material(
+                type: MaterialType.transparency,
+                child: ListTile(
+                  onTap: () => Navigator.of(context).pop(option),
+                  title: Text(
+                    labelOf(option),
+                    style: AppTypography.textSmMedium.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
                   ),
+                  trailing:
+                      option == current
+                          ? Icon(Icons.check_rounded,
+                              color: kPrimaryColor, size: 20.sp)
+                          : null,
                 ),
-                trailing:
-                    option == current
-                        ? Icon(Icons.check_rounded, color: kPrimaryColor, size: 20.sp)
-                        : null,
               ),
           ],
         ),

--- a/lib/screens/library/discovery/studies_tab.dart
+++ b/lib/screens/library/discovery/studies_tab.dart
@@ -1,6 +1,7 @@
 import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
 import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
 import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
+import 'package:chessever2/screens/library/discovery/discovery_filter_widgets.dart';
 import 'package:chessever2/screens/library/discovery/study_chapters_screen.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
@@ -42,10 +43,23 @@ class StudiesTab extends ConsumerWidget {
     if (picked != null) ref.read(studiesQueryProvider.notifier).setSort(picked);
   }
 
+  Future<void> _pickFilters(BuildContext context, WidgetRef ref) async {
+    HapticFeedback.selectionClick();
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => const _StudiesFilterSheet(),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final listAsync = ref.watch(studiesListProvider);
     final sort = ref.watch(studiesQueryProvider.select((q) => q.sort));
+    final filterCount = ref.watch(
+      studiesQueryProvider.select((q) => q.activeFilterCount),
+    );
 
     return RefreshIndicator(
       onRefresh: () => _refresh(ref),
@@ -58,9 +72,21 @@ class StudiesTab extends ConsumerWidget {
         ),
         slivers: [
           SliverToBoxAdapter(
-            child: _SortBar(
-              label: sort.label,
-              onTap: () => _pickSort(context, ref),
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 8.h),
+              child: Row(
+                children: [
+                  FilterButton(
+                    count: filterCount,
+                    onTap: () => _pickFilters(context, ref),
+                  ),
+                  const Spacer(),
+                  _SortChip(
+                    label: sort.label,
+                    onTap: () => _pickSort(context, ref),
+                  ),
+                ],
+              ),
             ),
           ),
           listAsync.when(
@@ -99,47 +125,169 @@ class StudiesTab extends ConsumerWidget {
   }
 }
 
-class _SortBar extends StatelessWidget {
-  const _SortBar({required this.label, required this.onTap});
+class _SortChip extends StatelessWidget {
+  const _SortChip({required this.label, required this.onTap});
 
   final String label;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 8.h),
-      child: Row(
-        children: [
-          const Spacer(),
-          GestureDetector(
-            onTap: onTap,
-            child: Container(
-              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
-              decoration: BoxDecoration(
-                color: context.colors.surface,
-                borderRadius: BorderRadius.circular(20.br),
-                border: Border.all(
-                  color: context.colors.textPrimary.withValues(alpha: 0.1),
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(20.br),
+          border: Border.all(
+            color: context.colors.textPrimary.withValues(alpha: 0.1),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.swap_vert_rounded, size: 15.sp, color: kPrimaryColor),
+            SizedBox(width: 6.w),
+            Text(
+              label,
+              style: AppTypography.textXsMedium.copyWith(
+                color: context.colors.textPrimary.withValues(alpha: 0.85),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// ECO categories are a fixed A–E set (not facet-dependent).
+const List<String> _ecoCategories = ['A', 'B', 'C', 'D', 'E'];
+
+class _StudiesFilterSheet extends ConsumerStatefulWidget {
+  const _StudiesFilterSheet();
+
+  @override
+  ConsumerState<_StudiesFilterSheet> createState() =>
+      _StudiesFilterSheetState();
+}
+
+class _StudiesFilterSheetState extends ConsumerState<_StudiesFilterSheet> {
+  late Set<String> _eco;
+  late Set<String> _variants;
+  late Set<String> _chapterModes;
+  bool? _gamebook;
+  bool? _hasAnnotations;
+
+  @override
+  void initState() {
+    super.initState();
+    final q = ref.read(studiesQueryProvider);
+    _eco = {...q.ecoCategories};
+    _variants = {...q.variants};
+    _chapterModes = {...q.chapterModes};
+    _gamebook = q.gamebook;
+    _hasAnnotations = q.hasAnnotations;
+  }
+
+  void _toggle(Set<String> set, String value) {
+    setState(() {
+      if (!set.remove(value)) set.add(value);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final facets = ref.watch(studyFacetsProvider).valueOrNull ?? StudyFacets.empty;
+
+    return FilterSheetScaffold(
+      title: 'Filter studies',
+      onClear: () {
+        setState(() {
+          _eco = {};
+          _variants = {};
+          _chapterModes = {};
+          _gamebook = null;
+          _hasAnnotations = null;
+        });
+      },
+      onApply: () {
+        ref.read(studiesQueryProvider.notifier).applyFilters(
+              ecoCategories: _eco,
+              variants: _variants,
+              chapterModes: _chapterModes,
+              gamebook: _gamebook,
+              hasAnnotations: _hasAnnotations,
+            );
+        Navigator.of(context).pop();
+      },
+      children: [
+        FilterSection(
+          title: 'ECO CATEGORY',
+          child: Wrap(
+            spacing: 8.w,
+            runSpacing: 8.h,
+            children: [
+              for (final c in _ecoCategories)
+                FilterPill(
+                  label: c,
+                  selected: _eco.contains(c),
+                  onTap: () => _toggle(_eco, c),
                 ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.swap_vert_rounded, size: 15.sp, color: kPrimaryColor),
-                  SizedBox(width: 6.w),
-                  Text(
-                    label,
-                    style: AppTypography.textXsMedium.copyWith(
-                      color: context.colors.textPrimary.withValues(alpha: 0.85),
-                    ),
+            ],
+          ),
+        ),
+        if (facets.variants.isNotEmpty) ...[
+          SizedBox(height: 20.h),
+          FilterSection(
+            title: 'VARIANT',
+            child: Wrap(
+              spacing: 8.w,
+              runSpacing: 8.h,
+              children: [
+                for (final v in facets.variants)
+                  FilterPill(
+                    label: v,
+                    selected: _variants.contains(v),
+                    onTap: () => _toggle(_variants, v),
                   ),
-                ],
-              ),
+              ],
             ),
           ),
         ],
-      ),
+        if (facets.chapterModes.isNotEmpty) ...[
+          SizedBox(height: 20.h),
+          FilterSection(
+            title: 'CHAPTER TYPE',
+            child: Wrap(
+              spacing: 8.w,
+              runSpacing: 8.h,
+              children: [
+                for (final m in facets.chapterModes)
+                  FilterPill(
+                    label: m,
+                    selected: _chapterModes.contains(m),
+                    onTap: () => _toggle(_chapterModes, m),
+                  ),
+              ],
+            ),
+          ),
+        ],
+        SizedBox(height: 20.h),
+        TriToggle(
+          label: 'Interactive (gamebook)',
+          value: _gamebook,
+          onChanged: (v) => setState(() => _gamebook = v),
+        ),
+        SizedBox(height: 14.h),
+        TriToggle(
+          label: 'Has annotations',
+          value: _hasAnnotations,
+          onChanged: (v) => setState(() => _hasAnnotations = v),
+        ),
+        SizedBox(height: 8.h),
+      ],
     );
   }
 }

--- a/lib/screens/library/discovery/studies_tab.dart
+++ b/lib/screens/library/discovery/studies_tab.dart
@@ -1,0 +1,443 @@
+import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
+import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
+import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
+import 'package:chessever2/screens/library/discovery/study_chapters_screen.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/haptic_feedback_service.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/skeleton_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+
+/// The Studies tab in the Library: curated Lichess studies, quality-ranked.
+class StudiesTab extends ConsumerWidget {
+  const StudiesTab({super.key});
+
+  Future<void> _refresh(WidgetRef ref) async {
+    HapticFeedbackService.medium();
+    // Kick a backend re-sync, then reload the (possibly updated) list.
+    await ref.read(gamebaseRepositoryProvider).refreshStudies();
+    ref.invalidate(studiesListProvider);
+    await ref.read(studiesListProvider.future);
+  }
+
+  Future<void> _pickSort(BuildContext context, WidgetRef ref) async {
+    HapticFeedback.selectionClick();
+    final current = ref.read(studiesQueryProvider).sort;
+    final picked = await showModalBottomSheet<StudiesSort>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder:
+          (_) => _SortSheet<StudiesSort>(
+            title: 'Sort studies',
+            current: current,
+            options: StudiesSort.values,
+            labelOf: (s) => s.label,
+          ),
+    );
+    if (picked != null) ref.read(studiesQueryProvider.notifier).setSort(picked);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final listAsync = ref.watch(studiesListProvider);
+    final sort = ref.watch(studiesQueryProvider.select((q) => q.sort));
+
+    return RefreshIndicator(
+      onRefresh: () => _refresh(ref),
+      color: context.colors.textPrimary,
+      backgroundColor: context.colors.surface,
+      child: CustomScrollView(
+        primary: false,
+        physics: const AlwaysScrollableScrollPhysics(
+          parent: BouncingScrollPhysics(),
+        ),
+        slivers: [
+          SliverToBoxAdapter(
+            child: _SortBar(
+              label: sort.label,
+              onTap: () => _pickSort(context, ref),
+            ),
+          ),
+          listAsync.when(
+            data: (page) {
+              if (page.items.isEmpty) {
+                return const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: _EmptyStudies(),
+                );
+              }
+              return SliverPadding(
+                padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 24.h),
+                sliver: SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, i) => Padding(
+                      padding: EdgeInsets.only(bottom: 8.h),
+                      child: _StudyCard(study: page.items[i]),
+                    ),
+                    childCount: page.items.length,
+                  ),
+                ),
+              );
+            },
+            loading: () => const _StudiesLoadingSliver(),
+            error: (e, _) => SliverFillRemaining(
+              hasScrollBody: false,
+              child: _DiscoveryError(
+                message: 'Could not load studies',
+                onRetry: () => ref.invalidate(studiesListProvider),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SortBar extends StatelessWidget {
+  const _SortBar({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 8.h),
+      child: Row(
+        children: [
+          const Spacer(),
+          GestureDetector(
+            onTap: onTap,
+            child: Container(
+              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 7.h),
+              decoration: BoxDecoration(
+                color: context.colors.surface,
+                borderRadius: BorderRadius.circular(20.br),
+                border: Border.all(
+                  color: context.colors.textPrimary.withValues(alpha: 0.1),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.swap_vert_rounded, size: 15.sp, color: kPrimaryColor),
+                  SizedBox(width: 6.w),
+                  Text(
+                    label,
+                    style: AppTypography.textXsMedium.copyWith(
+                      color: context.colors.textPrimary.withValues(alpha: 0.85),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StudyCard extends StatelessWidget {
+  const _StudyCard({required this.study});
+
+  final LichessStudy study;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedbackService.cardTap();
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => StudyChaptersScreen(study: study),
+          ),
+        );
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 14.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(12.br),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 44.h,
+              height: 44.h,
+              decoration: BoxDecoration(
+                color: kPrimaryColor.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(12.br),
+              ),
+              child: Icon(
+                Icons.menu_book_rounded,
+                color: kPrimaryColor,
+                size: 22.sp,
+              ),
+            ),
+            SizedBox(width: 12.w),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    study.name,
+                    style: AppTypography.textSmMedium.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  SizedBox(height: 4.h),
+                  Text(
+                    _subtitle(),
+                    style: AppTypography.textXsRegular.copyWith(
+                      color: const Color(0xFFA1A1A1),
+                      height: 16 / 12,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: 8.w),
+            _QualityBadge(score: study.credibilityScore),
+            SizedBox(width: 4.w),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 20.sp,
+              color: context.colors.textPrimary.withValues(alpha: 0.5),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _subtitle() {
+    final parts = <String>[
+      study.chapterCount == 1 ? '1 chapter' : '${study.chapterCount} chapters',
+    ];
+    final updated = _timeAgo(study.lichessUpdatedAt);
+    if (updated != null) parts.add('updated $updated');
+    if (study.authorUsername != null && study.authorUsername!.isNotEmpty) {
+      parts.add('by ${study.authorUsername}');
+    }
+    return parts.join('  ·  ');
+  }
+}
+
+class _QualityBadge extends StatelessWidget {
+  const _QualityBadge({required this.score});
+
+  final double score;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = score.clamp(0, 100).round();
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 4.h),
+      decoration: BoxDecoration(
+        color: kPrimaryColor.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8.br),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.star_rounded, size: 12.sp, color: kPrimaryColor),
+          SizedBox(width: 3.w),
+          Text(
+            '$value',
+            style: AppTypography.textXxsBold.copyWith(color: kPrimaryColor),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String? _timeAgo(DateTime? date) {
+  if (date == null) return null;
+  final now = DateTime.now();
+  final diff = now.difference(date.toLocal());
+  if (diff.inDays == 0) return 'today';
+  if (diff.inDays == 1) return 'yesterday';
+  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  if (diff.inDays < 30) return '${(diff.inDays / 7).floor()}w ago';
+  return DateFormat('MMM yyyy').format(date.toLocal());
+}
+
+/// Reusable single-select sort sheet.
+class _SortSheet<T> extends StatelessWidget {
+  const _SortSheet({
+    required this.title,
+    required this.current,
+    required this.options,
+    required this.labelOf,
+  });
+
+  final String title;
+  final T current;
+  final List<T> options;
+  final String Function(T) labelOf;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24.br)),
+        ),
+        padding: EdgeInsets.only(bottom: 8.h),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: EdgeInsets.symmetric(vertical: 12.h),
+              width: 40.w,
+              height: 4.h,
+              decoration: BoxDecoration(
+                color: context.colors.textPrimary.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2.br),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 4.h),
+              child: Row(
+                children: [
+                  Text(
+                    title,
+                    style: AppTypography.textMdBold.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            for (final option in options)
+              ListTile(
+                onTap: () => Navigator.of(context).pop(option),
+                title: Text(
+                  labelOf(option),
+                  style: AppTypography.textSmMedium.copyWith(
+                    color: context.colors.textPrimary,
+                  ),
+                ),
+                trailing:
+                    option == current
+                        ? Icon(Icons.check_rounded, color: kPrimaryColor, size: 20.sp)
+                        : null,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StudiesLoadingSliver extends StatelessWidget {
+  const _StudiesLoadingSliver();
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPadding(
+      padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 24.h),
+      sliver: SliverToBoxAdapter(
+        child: SkeletonWidget(
+          child: Column(
+            children: [
+              for (var i = 0; i < 6; i++) ...[
+                Container(
+                  height: 72.h,
+                  decoration: BoxDecoration(
+                    color: context.colors.surface,
+                    borderRadius: BorderRadius.circular(12.br),
+                  ),
+                ),
+                SizedBox(height: 8.h),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyStudies extends StatelessWidget {
+  const _EmptyStudies();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.menu_book_outlined,
+            size: 56.sp,
+            color: context.colors.textPrimary.withValues(alpha: 0.4),
+          ),
+          SizedBox(height: 12.h),
+          Text(
+            'No studies yet',
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.8),
+            ),
+          ),
+          SizedBox(height: 6.h),
+          Text(
+            'Pull to refresh',
+            style: AppTypography.textSmRegular.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.5),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiscoveryError extends StatelessWidget {
+  const _DiscoveryError({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.cloud_off_rounded, size: 48.sp, color: kRedColor.withValues(alpha: 0.7)),
+          SizedBox(height: 12.h),
+          Text(
+            message,
+            style: AppTypography.textMdMedium.copyWith(
+              color: context.colors.textPrimary,
+            ),
+          ),
+          SizedBox(height: 12.h),
+          TextButton(
+            onPressed: onRetry,
+            child: Text(
+              'Retry',
+              style: AppTypography.textSmMedium.copyWith(color: kPrimaryColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/library/discovery/study_chapters_screen.dart
+++ b/lib/screens/library/discovery/study_chapters_screen.dart
@@ -1,0 +1,244 @@
+import 'package:chessever2/repository/gamebase/discovery/discovery_models.dart';
+import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
+import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
+import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
+import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
+import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
+import 'package:chessever2/services/pgn_file_intake_service.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/haptic_feedback_service.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Chapter list for a single Lichess study. Tapping a chapter pulls its cached
+/// PGN and opens it on the board, the same as any other game in the app.
+class StudyChaptersScreen extends ConsumerStatefulWidget {
+  const StudyChaptersScreen({super.key, required this.study});
+
+  final LichessStudy study;
+
+  @override
+  ConsumerState<StudyChaptersScreen> createState() =>
+      _StudyChaptersScreenState();
+}
+
+class _StudyChaptersScreenState extends ConsumerState<StudyChaptersScreen> {
+  String? _loadingChapterId;
+
+  Future<void> _openChapter(LichessStudyChapter chapter) async {
+    if (_loadingChapterId != null) return;
+    HapticFeedbackService.cardTap();
+    setState(() => _loadingChapterId = chapter.chapterId);
+    try {
+      final pgn = await ref
+          .read(gamebaseRepositoryProvider)
+          .getStudyChapterPgn(widget.study.id, chapter.chapterId);
+      if (!mounted) return;
+      if (pgn == null || pgn.trim().isEmpty) {
+        _toast("Couldn't load this chapter");
+        return;
+      }
+      final chessGame = ChessGame.fromPgn('study_${chapter.chapterId}', pgn);
+      final model = chessGameToImportedGamesTourModel(chessGame);
+      ref.read(chessboardViewFromProviderNew.notifier).state =
+          ChessboardView.tour;
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => ChessBoardScreenNew(
+            currentIndex: 0,
+            games: [model],
+            showGamebaseButton: false,
+            disableGamebaseOverlayByDefault: true,
+          ),
+        ),
+      );
+    } catch (_) {
+      if (mounted) _toast("Couldn't open this chapter");
+    } finally {
+      if (mounted) setState(() => _loadingChapterId = null);
+    }
+  }
+
+  void _toast(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: AppTypography.textSmMedium.copyWith(
+            color: context.colors.textPrimary,
+          ),
+        ),
+        backgroundColor: context.colors.surface.withValues(alpha: 0.95),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final detailAsync = ref.watch(studyDetailProvider(widget.study.id));
+
+    return Scaffold(
+      backgroundColor: context.colors.background,
+      appBar: AppBar(
+        backgroundColor: context.colors.background,
+        elevation: 0,
+        leading: IconButton(
+          onPressed: () => Navigator.of(context).maybePop(),
+          icon: Icon(
+            Icons.arrow_back_ios_new_rounded,
+            color: context.colors.textPrimary,
+            size: 20.sp,
+          ),
+        ),
+        title: Text(
+          widget.study.name,
+          style: AppTypography.textMdBold.copyWith(
+            color: context.colors.textPrimary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      body: SafeArea(
+        top: false,
+        child: detailAsync.when(
+          data: (detail) {
+            final chapters = detail?.chapters ?? const <LichessStudyChapter>[];
+            if (chapters.isEmpty) {
+              return Center(
+                child: Text(
+                  'This study has no chapters',
+                  style: AppTypography.textSmRegular.copyWith(
+                    color: context.colors.textPrimary.withValues(alpha: 0.6),
+                  ),
+                ),
+              );
+            }
+            return ListView.separated(
+              padding: EdgeInsets.fromLTRB(16.w, 8.h, 16.w, 24.h),
+              itemCount: chapters.length,
+              separatorBuilder: (_, __) => SizedBox(height: 8.h),
+              itemBuilder: (context, i) {
+                final chapter = chapters[i];
+                final loading = _loadingChapterId == chapter.chapterId;
+                return _ChapterCard(
+                  index: i + 1,
+                  chapter: chapter,
+                  loading: loading,
+                  onTap: () => _openChapter(chapter),
+                );
+              },
+            );
+          },
+          loading: () => Center(
+            child: CircularProgressIndicator(
+              color: context.colors.textPrimary,
+              strokeWidth: 2.5,
+            ),
+          ),
+          error: (e, _) => Center(
+            child: Text(
+              'Could not load chapters',
+              style: AppTypography.textSmRegular.copyWith(
+                color: context.colors.textPrimary.withValues(alpha: 0.6),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChapterCard extends StatelessWidget {
+  const _ChapterCard({
+    required this.index,
+    required this.chapter,
+    required this.loading,
+    required this.onTap,
+  });
+
+  final int index;
+  final LichessStudyChapter chapter;
+  final bool loading;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final moves = (chapter.plyCount / 2).ceil();
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 14.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(12.br),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 32.h,
+              height: 32.h,
+              decoration: BoxDecoration(
+                color: kPrimaryColor.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(8.br),
+              ),
+              child: Center(
+                child: Text(
+                  '$index',
+                  style: AppTypography.textSmBold.copyWith(color: kPrimaryColor),
+                ),
+              ),
+            ),
+            SizedBox(width: 12.w),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    chapter.name?.trim().isNotEmpty == true
+                        ? chapter.name!
+                        : 'Chapter $index',
+                    style: AppTypography.textSmMedium.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  SizedBox(height: 2.h),
+                  Text(
+                    moves <= 0 ? 'Position' : (moves == 1 ? '1 move' : '$moves moves'),
+                    style: AppTypography.textXsRegular.copyWith(
+                      color: const Color(0xFFA1A1A1),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: 8.w),
+            if (loading)
+              SizedBox(
+                width: 18.w,
+                height: 18.h,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(kPrimaryColor),
+                ),
+              )
+            else
+              Icon(
+                Icons.play_arrow_rounded,
+                size: 22.sp,
+                color: kPrimaryColor,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/library/discovery/study_chapters_screen.dart
+++ b/lib/screens/library/discovery/study_chapters_screen.dart
@@ -212,11 +212,27 @@ class _ChapterCard extends StatelessWidget {
                   ),
                   SizedBox(height: 2.h),
                   Text(
-                    moves <= 0 ? 'Position' : (moves == 1 ? '1 move' : '$moves moves'),
+                    [
+                      moves <= 0
+                          ? 'Position'
+                          : (moves == 1 ? '1 move' : '$moves moves'),
+                      if ((chapter.eco ?? '').trim().isNotEmpty) chapter.eco!.trim(),
+                    ].join('  ·  '),
                     style: AppTypography.textXsRegular.copyWith(
                       color: const Color(0xFFA1A1A1),
                     ),
                   ),
+                  if (chapter.gameSubtitle != null) ...[
+                    SizedBox(height: 2.h),
+                    Text(
+                      chapter.gameSubtitle!,
+                      style: AppTypography.textXsRegular.copyWith(
+                        color: context.colors.textPrimary.withValues(alpha: 0.45),
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/lib/screens/library/discovery/study_chapters_screen.dart
+++ b/lib/screens/library/discovery/study_chapters_screen.dart
@@ -10,6 +10,7 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/app_button.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -170,7 +171,7 @@ class _ChapterCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final moves = (chapter.plyCount / 2).ceil();
-    return GestureDetector(
+    return TappableScale(
       onTap: onTap,
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 14.h),

--- a/lib/screens/library/library_screen.dart
+++ b/lib/screens/library/library_screen.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:chessever2/e2e/e2e_ids.dart';
+import 'package:chessever2/repository/gamebase/discovery/discovery_providers.dart';
 import 'package:chessever2/repository/library/library_repository.dart';
 import 'package:chessever2/repository/library/models/library_folder.dart';
 import 'package:chessever2/screens/home/widget/bottom_nav_bar.dart';
@@ -11,6 +14,8 @@ import 'package:chessever2/screens/board_editor/board_editor_screen.dart';
 import 'package:chessever2/screens/library/twic_contents_screen.dart';
 import 'package:chessever2/screens/library/widgets/add_to_library_sheet.dart';
 import 'package:chessever2/screens/library/widgets/create_folder_dialog.dart';
+import 'package:chessever2/screens/library/discovery/miniatures_tab.dart';
+import 'package:chessever2/screens/library/discovery/studies_tab.dart';
 import 'package:chessever2/screens/library/widgets/folder_card.dart';
 import 'package:chessever2/screens/library/widgets/library_search_bar.dart';
 import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
@@ -57,6 +62,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   // live in an IndexedStack (all kept alive).
   _LibraryTab _activeTab = _LibraryTab.myDatabase;
   final Map<_LibraryTab, String> _tabQueries = {};
+  Timer? _studiesSearchDebounce;
 
   @override
   void initState() {
@@ -77,6 +83,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
 
   @override
   void dispose() {
+    _studiesSearchDebounce?.cancel();
     _searchFocusNode.removeListener(_onSearchFocusChange);
     _searchFocusNode.dispose();
     _searchController.dispose();
@@ -423,6 +430,15 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       hintText: 'Search',
       onChanged: (query) {
         setState(() => _searchQuery = query.trim().toLowerCase());
+        // Studies search hits the backend `q` param (debounced); My Database
+        // filters folders locally via _searchQuery; Discovery has no search.
+        if (_activeTab == _LibraryTab.studies) {
+          _studiesSearchDebounce?.cancel();
+          _studiesSearchDebounce = Timer(
+            const Duration(milliseconds: 350),
+            () => ref.read(studiesQueryProvider.notifier).setSearch(query.trim()),
+          );
+        }
       },
     );
   }
@@ -456,6 +472,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       );
       _searchQuery = restored.trim().toLowerCase();
     });
+    // Keep the Studies backend query in sync with its restored search text.
+    if (next == _LibraryTab.studies) {
+      _studiesSearchDebounce?.cancel();
+      ref.read(studiesQueryProvider.notifier).setSearch(restored.trim());
+    }
   }
 
   Widget _buildTabBody() {
@@ -472,55 +493,25 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   }
 
   Widget _buildStudiesTab() {
-    return const Center(
-      child: _ComingSoonPanel(
-        icon: Icons.menu_book_rounded,
-        title: 'Studies',
-        message:
-            'Curated Lichess studies, filtered for quality and ranked so the '
-            'strongest surface first. Landing here soon.',
-      ),
-    );
+    return const StudiesTab();
   }
 
   Widget _buildDiscoveryTab() {
-    return CustomScrollView(
-      // Explicit non-primary: keeps this view from contending for the
-      // PrimaryScrollController with the My Database tab that lives alongside
-      // it in the IndexedStack.
-      primary: false,
-      physics: const AlwaysScrollableScrollPhysics(
-        parent: BouncingScrollPhysics(),
-      ),
-      slivers: [
-        SliverToBoxAdapter(child: SizedBox(height: 4.h)),
-        SliverPadding(
-          padding: EdgeInsets.symmetric(horizontal: 16.w),
-          sliver: SliverToBoxAdapter(
-            child: FolderCard(
-              folder: kTwicFolder,
-              isExpanded: true,
-              isFeatured: true,
-              titleOverride: 'ChessEver Master Database',
-              onTap: () => _navigateToFolder(kTwicFolder),
-            ),
+    // The ChessEver master database is pinned at the top of Discovery (it's
+    // community content, not the user's own); Miniatures fill the rest.
+    return Column(
+      children: [
+        Padding(
+          padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 8.h),
+          child: FolderCard(
+            folder: kTwicFolder,
+            isExpanded: true,
+            isFeatured: true,
+            titleOverride: 'ChessEver Master Database',
+            onTap: () => _navigateToFolder(kTwicFolder),
           ),
         ),
-        SliverToBoxAdapter(child: SizedBox(height: 24.h)),
-        SliverToBoxAdapter(
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24.w),
-            child: _ComingSoonPanel(
-              icon: Icons.bolt_rounded,
-              title: 'Miniatures',
-              message:
-                  'A community feed of short, decisive games — strongest games '
-                  'first, then most-liked as likes roll in. Arriving soon.',
-              compact: true,
-            ),
-          ),
-        ),
-        SliverToBoxAdapter(child: SizedBox(height: 24.h)),
+        const Expanded(child: MiniaturesTab()),
       ],
     );
   }
@@ -805,95 +796,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-/// Placeholder surface for tabs whose backend isn't wired yet (Studies,
-/// Miniatures). Kept deliberately honest — no fake data, just a clear note
-/// that the section is on the way.
-class _ComingSoonPanel extends StatelessWidget {
-  const _ComingSoonPanel({
-    required this.icon,
-    required this.title,
-    required this.message,
-    this.compact = false,
-  });
-
-  final IconData icon;
-  final String title;
-  final String message;
-  final bool compact;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: EdgeInsets.symmetric(
-        horizontal: 24.w,
-        vertical: compact ? 28.h : 36.h,
-      ),
-      decoration: BoxDecoration(
-        color: context.colors.surface.withValues(alpha: compact ? 0.6 : 0.0),
-        borderRadius: BorderRadius.circular(20.br),
-        border:
-            compact
-                ? Border.all(
-                  color: context.colors.textPrimary.withValues(alpha: 0.06),
-                )
-                : null,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            padding: EdgeInsets.all(16.sp),
-            decoration: BoxDecoration(
-              color: kPrimaryColor.withValues(alpha: 0.12),
-              shape: BoxShape.circle,
-            ),
-            child: Icon(icon, size: 30.sp, color: kPrimaryColor),
-          ),
-          SizedBox(height: 16.h),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                title,
-                style: AppTypography.textLgBold.copyWith(
-                  color: context.colors.textPrimary,
-                ),
-              ),
-              SizedBox(width: 8.w),
-              Container(
-                padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 3.h),
-                decoration: BoxDecoration(
-                  color: kPrimaryColor.withValues(alpha: 0.15),
-                  borderRadius: BorderRadius.circular(8.br),
-                ),
-                child: Text(
-                  'Soon',
-                  style: AppTypography.textXsMedium.copyWith(
-                    color: kPrimaryColor,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          SizedBox(height: 8.h),
-          Padding(
-            padding: EdgeInsets.symmetric(horizontal: 12.w),
-            child: Text(
-              message,
-              textAlign: TextAlign.center,
-              style: AppTypography.textSmRegular.copyWith(
-                color: context.colors.textPrimary.withValues(alpha: 0.6),
-                height: 1.5,
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/screens/library/library_screen.dart
+++ b/lib/screens/library/library_screen.dart
@@ -27,11 +27,16 @@ import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
 import 'package:chessever2/widgets/skeleton_widget.dart';
 import 'package:chessever2/widgets/screen_wrapper.dart';
+import 'package:chessever2/widgets/segmented_switcher.dart';
 import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:motor/motor.dart';
+
+/// The three top-level Library surfaces. Order matches the segmented control
+/// and is used directly as the IndexedStack index, so don't reorder casually.
+enum _LibraryTab { studies, myDatabase, discovery }
 
 class LibraryScreen extends ConsumerStatefulWidget {
   const LibraryScreen({super.key});
@@ -46,6 +51,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   final ScrollController _scrollController = ScrollController();
   String _searchQuery = '';
   bool _isSearchFocused = false;
+
+  // Lands on My Database by default. Per-tab search text is preserved in
+  // `_tabQueries`; scroll position survives switches because the tab bodies
+  // live in an IndexedStack (all kept alive).
+  _LibraryTab _activeTab = _LibraryTab.myDatabase;
+  final Map<_LibraryTab, String> _tabQueries = {};
 
   @override
   void initState() {
@@ -321,7 +332,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
               maxWidth: ResponsiveHelper.contentMaxWidth,
             ),
             child: Column(
-              children: [_buildTopBar(), Expanded(child: _buildContent())],
+              children: [
+                _buildTopBar(),
+                _buildTabSelector(),
+                Expanded(child: _buildTabBody()),
+              ],
             ),
           ),
         ),
@@ -409,6 +424,104 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
       onChanged: (query) {
         setState(() => _searchQuery = query.trim().toLowerCase());
       },
+    );
+  }
+
+  Widget _buildTabSelector() {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 8.h),
+      child: SegmentedSwitcher(
+        options: const ['Studies', 'My Database', 'Discovery'],
+        initialSelection: _LibraryTab.myDatabase.index,
+        currentSelection: _activeTab.index,
+        backgroundColor: context.colors.surface,
+        selectedBackgroundColor: context.colors.surfaceRecessed,
+        onSelectionChanged: _onTabChanged,
+      ),
+    );
+  }
+
+  void _onTabChanged(int index) {
+    final next = _LibraryTab.values[index];
+    if (next == _activeTab) return;
+    HapticFeedbackService.light();
+    // Stash the outgoing tab's search text, restore the incoming tab's.
+    _tabQueries[_activeTab] = _searchController.text;
+    final restored = _tabQueries[next] ?? '';
+    setState(() {
+      _activeTab = next;
+      _searchController.text = restored;
+      _searchController.selection = TextSelection.collapsed(
+        offset: restored.length,
+      );
+      _searchQuery = restored.trim().toLowerCase();
+    });
+  }
+
+  Widget _buildTabBody() {
+    // IndexedStack keeps every tab mounted, so My Database's scroll position
+    // (and provider subscriptions) survive switching away and back.
+    return IndexedStack(
+      index: _activeTab.index,
+      children: [
+        _buildStudiesTab(),
+        _buildContent(),
+        _buildDiscoveryTab(),
+      ],
+    );
+  }
+
+  Widget _buildStudiesTab() {
+    return const Center(
+      child: _ComingSoonPanel(
+        icon: Icons.menu_book_rounded,
+        title: 'Studies',
+        message:
+            'Curated Lichess studies, filtered for quality and ranked so the '
+            'strongest surface first. Landing here soon.',
+      ),
+    );
+  }
+
+  Widget _buildDiscoveryTab() {
+    return CustomScrollView(
+      // Explicit non-primary: keeps this view from contending for the
+      // PrimaryScrollController with the My Database tab that lives alongside
+      // it in the IndexedStack.
+      primary: false,
+      physics: const AlwaysScrollableScrollPhysics(
+        parent: BouncingScrollPhysics(),
+      ),
+      slivers: [
+        SliverToBoxAdapter(child: SizedBox(height: 4.h)),
+        SliverPadding(
+          padding: EdgeInsets.symmetric(horizontal: 16.w),
+          sliver: SliverToBoxAdapter(
+            child: FolderCard(
+              folder: kTwicFolder,
+              isExpanded: true,
+              isFeatured: true,
+              titleOverride: 'ChessEver Master Database',
+              onTap: () => _navigateToFolder(kTwicFolder),
+            ),
+          ),
+        ),
+        SliverToBoxAdapter(child: SizedBox(height: 24.h)),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24.w),
+            child: _ComingSoonPanel(
+              icon: Icons.bolt_rounded,
+              title: 'Miniatures',
+              message:
+                  'A community feed of short, decisive games — strongest games '
+                  'first, then most-liked as likes roll in. Arriving soon.',
+              compact: true,
+            ),
+          ),
+        ),
+        SliverToBoxAdapter(child: SizedBox(height: 24.h)),
+      ],
     );
   }
 
@@ -513,9 +626,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   }
 
   Widget _buildFoldersSliver(List<LibraryFolder> folders) {
-    // Pin the permanent collections at the top: real per-user Liked Games
-    // folder first (auto-created via ensureDefaultFolders), then TWIC, then
-    // the rest in normal order.
+    // Pin the My Likes collection at the top (auto-created via
+    // ensureDefaultFolders), then the rest in normal order. The ChessEver
+    // master database (TWIC) now lives in the Discovery tab, not here.
     final likedIdx = folders.indexWhere((f) => f.isLikedGames);
     final rest =
         likedIdx == -1
@@ -523,7 +636,6 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
             : (List<LibraryFolder>.from(folders)..removeAt(likedIdx));
     final allFolders = <LibraryFolder>[
       if (likedIdx != -1) folders[likedIdx],
-      kTwicFolder,
       ...rest,
     ];
     final filteredFolders = _filterFolders(allFolders);
@@ -693,6 +805,95 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Placeholder surface for tabs whose backend isn't wired yet (Studies,
+/// Miniatures). Kept deliberately honest — no fake data, just a clear note
+/// that the section is on the way.
+class _ComingSoonPanel extends StatelessWidget {
+  const _ComingSoonPanel({
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.compact = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(
+        horizontal: 24.w,
+        vertical: compact ? 28.h : 36.h,
+      ),
+      decoration: BoxDecoration(
+        color: context.colors.surface.withValues(alpha: compact ? 0.6 : 0.0),
+        borderRadius: BorderRadius.circular(20.br),
+        border:
+            compact
+                ? Border.all(
+                  color: context.colors.textPrimary.withValues(alpha: 0.06),
+                )
+                : null,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            padding: EdgeInsets.all(16.sp),
+            decoration: BoxDecoration(
+              color: kPrimaryColor.withValues(alpha: 0.12),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(icon, size: 30.sp, color: kPrimaryColor),
+          ),
+          SizedBox(height: 16.h),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                style: AppTypography.textLgBold.copyWith(
+                  color: context.colors.textPrimary,
+                ),
+              ),
+              SizedBox(width: 8.w),
+              Container(
+                padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 3.h),
+                decoration: BoxDecoration(
+                  color: kPrimaryColor.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(8.br),
+                ),
+                child: Text(
+                  'Soon',
+                  style: AppTypography.textXsMedium.copyWith(
+                    color: kPrimaryColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 8.h),
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12.w),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: AppTypography.textSmRegular.copyWith(
+                color: context.colors.textPrimary.withValues(alpha: 0.6),
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/library/utils/load_saved_analysis.dart
+++ b/lib/screens/library/utils/load_saved_analysis.dart
@@ -141,6 +141,7 @@ SavedAnalysisData createSavedAnalysisData(SavedAnalysis analysis) {
     lastViewedPosition: analysis.lastViewedPosition,
     title: analysis.title,
     folderId: analysis.folderId,
+    tags: analysis.tags,
   );
 }
 
@@ -156,6 +157,7 @@ SavedAnalysisData createReadOnlySavedAnalysisData(SavedAnalysis analysis) {
     movePointer: null,
     isBoardFlipped: false,
     lastViewedPosition: analysis.lastViewedPosition,
+    tags: analysis.tags,
   );
 }
 

--- a/lib/screens/library/widgets/folder_card.dart
+++ b/lib/screens/library/widgets/folder_card.dart
@@ -37,12 +37,18 @@ class FolderCard extends ConsumerWidget {
   final bool isFeatured;
   final VoidCallback? onTap;
 
+  /// Overrides the displayed title without touching the underlying folder
+  /// identity (used e.g. to surface TWIC as "ChessEver Master Database" in
+  /// the Discovery tab while keeping its internal id/logic unchanged).
+  final String? titleOverride;
+
   const FolderCard({
     super.key,
     required this.folder,
     this.isExpanded = false,
     this.isFeatured = false,
     this.onTap,
+    this.titleOverride,
   });
 
   void _navigateToFolder(BuildContext context) {
@@ -107,7 +113,7 @@ class FolderCard extends ConsumerWidget {
                 ),
               ),
               Text(
-                folder.displayName,
+                titleOverride ?? folder.displayName,
                 style: AppTypography.textSmMedium.copyWith(
                   color: context.colors.textPrimary,
                 ),
@@ -276,7 +282,7 @@ class FolderCard extends ConsumerWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    folder.displayName,
+                    titleOverride ?? folder.displayName,
                     style: AppTypography.textSmMedium.copyWith(
                       color: context.colors.textPrimary,
                     ),

--- a/lib/screens/my_likes/my_likes_screen.dart
+++ b/lib/screens/my_likes/my_likes_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:chessever2/constants/game_tags.dart';
 import 'package:chessever2/repository/liked_games/liked_games_provider.dart';
 import 'package:chessever2/repository/library/models/saved_analysis.dart';
 import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
@@ -418,6 +419,7 @@ class _MyLikesScreenState extends ConsumerState<MyLikesScreen>
             child: _buildSearchBar(),
           ),
         ),
+        SliverToBoxAdapter(child: _buildTagChipsRow()),
         if (data.hasNoMatches)
           SliverFillRemaining(
             hasScrollBody: false,
@@ -449,6 +451,82 @@ class _MyLikesScreenState extends ConsumerState<MyLikesScreen>
       onChanged: _onSearchChanged,
       onClear: _clearSearch,
       onFilterTap: _showFilterDialog,
+    );
+  }
+
+  /// Tag chips: tapping one to *filter* is premium. Attaching tags stays free
+  /// and happens in the board save/edit sheet, not here.
+  Future<void> _onTagChipTap(String tag) async {
+    HapticFeedbackService.buttonPress();
+    final isPremium = ref.read(subscriptionProvider).isSubscribed;
+    if (!isPremium) {
+      final unlocked = await requirePremiumGuard(context, ref);
+      if (!unlocked || !mounted) return;
+    }
+    ref.read(myLikesFilterProvider.notifier).toggleTag(tag);
+  }
+
+  Widget _buildTagChipsRow() {
+    final selected = ref.watch(
+      myLikesFilterProvider.select((s) => s.selectedTags),
+    );
+    return SizedBox(
+      height: 34.h,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 4.h),
+        itemCount: kOfficialGameTags.length,
+        separatorBuilder: (_, __) => SizedBox(width: 8.w),
+        itemBuilder: (context, index) {
+          final tag = kOfficialGameTags[index];
+          final isOn = selected.contains(tag.label);
+          return GestureDetector(
+            onTap: () => _onTagChipTap(tag.label),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 180),
+              padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 6.h),
+              decoration: BoxDecoration(
+                color:
+                    isOn
+                        ? context.colors.danger.withValues(alpha: 0.15)
+                        : context.colors.textPrimary.withValues(alpha: 0.04),
+                borderRadius: BorderRadius.circular(20.br),
+                border: Border.all(
+                  color:
+                      isOn
+                          ? context.colors.danger.withValues(alpha: 0.5)
+                          : context.colors.textPrimary.withValues(alpha: 0.1),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    isOn ? Icons.check_rounded : tag.icon,
+                    size: 13.sp,
+                    color:
+                        isOn
+                            ? context.colors.danger
+                            : context.colors.textPrimary.withValues(alpha: 0.55),
+                  ),
+                  SizedBox(width: 5.w),
+                  Text(
+                    tag.label,
+                    style: AppTypography.textXsMedium.copyWith(
+                      color:
+                          isOn
+                              ? context.colors.danger
+                              : context.colors.textPrimary.withValues(
+                                alpha: 0.7,
+                              ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/screens/my_likes/my_likes_screen.dart
+++ b/lib/screens/my_likes/my_likes_screen.dart
@@ -17,6 +17,7 @@ import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/game_filter/game_filter.dart';
 import 'package:chessever2/widgets/game_filter/game_search_filter_bar.dart';
 import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
+import 'package:chessever2/widgets/segmented_switcher.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -181,6 +182,7 @@ class _MyLikesScreenState extends ConsumerState<MyLikesScreen>
         child: Column(
           children: [
             _buildHeader(),
+            _buildWindowTabs(),
             Expanded(
               child: viewAsync.when(
                 data: _buildBody,
@@ -219,14 +221,43 @@ class _MyLikesScreenState extends ConsumerState<MyLikesScreen>
           ),
           const Spacer(),
           if (totalLiked > 0)
-            IconButton(
-              onPressed: _handleExportPgn,
-              tooltip: 'Export as PGN',
+            // Export now lives in the 3-dot menu, not as a primary action.
+            PopupMenuButton<String>(
+              tooltip: 'More',
+              color: context.colors.surface,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12.br),
+              ),
               icon: Icon(
-                Icons.ios_share_rounded,
+                Icons.more_vert_rounded,
                 color: context.colors.textPrimary,
                 size: 20.sp,
               ),
+              onSelected: (value) {
+                if (value == 'export') _handleExportPgn();
+              },
+              itemBuilder:
+                  (context) => [
+                    PopupMenuItem<String>(
+                      value: 'export',
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.ios_share_rounded,
+                            size: 18.sp,
+                            color: context.colors.textPrimary,
+                          ),
+                          SizedBox(width: 12.w),
+                          Text(
+                            'Export as PGN',
+                            style: AppTypography.textSmMedium.copyWith(
+                              color: context.colors.textPrimary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
             ),
         ],
       ),
@@ -404,7 +435,61 @@ class _MyLikesScreenState extends ConsumerState<MyLikesScreen>
     }
   }
 
+  Widget _buildWindowTabs() {
+    final window = ref.watch(myLikesFilterProvider.select((s) => s.window));
+    final isPremium = ref.watch(
+      subscriptionProvider.select((s) => s.isSubscribed),
+    );
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16.w, 4.h, 16.w, 4.h),
+      child: SegmentedSwitcher(
+        options: const ['Today', 'This Week', 'All Time'],
+        currentSelection: window.index,
+        backgroundColor: context.colors.surface,
+        selectedBackgroundColor: context.colors.surfaceRecessed,
+        // Show a small lock on All Time for free users.
+        optionLabels: [
+          const Text('Today'),
+          const Text('This Week'),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Flexible(
+                child: Text('All Time', overflow: TextOverflow.ellipsis),
+              ),
+              if (!isPremium) ...[
+                SizedBox(width: 4.w),
+                Icon(
+                  Icons.lock_rounded,
+                  size: 12.sp,
+                  color: const Color(0xFFFFB300),
+                ),
+              ],
+            ],
+          ),
+        ],
+        onSelectionChanged: (i) {
+          HapticFeedbackService.buttonPress();
+          ref
+              .read(myLikesFilterProvider.notifier)
+              .setWindow(MyLikesWindow.values[i]);
+        },
+      ),
+    );
+  }
+
   Widget _buildBody(MyLikesData data) {
+    // All Time archive is Premium for free users — show the gentle lock panel
+    // instead of the list at this exact spot.
+    final window = ref.watch(myLikesFilterProvider.select((s) => s.window));
+    final isPremium = ref.watch(
+      subscriptionProvider.select((s) => s.isSubscribed),
+    );
+    if (window == MyLikesWindow.allTime && !isPremium) {
+      return _buildAllTimeLocked();
+    }
+
     if (data.isEmpty) return _buildEmptyState();
 
     Widget content = CustomScrollView(
@@ -587,6 +672,74 @@ class _MyLikesScreenState extends ConsumerState<MyLikesScreen>
         ),
       ),
     );
+  }
+
+  Widget _buildAllTimeLocked() {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: 32.w),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 80.w,
+              height: 80.h,
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFB300).withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(20.br),
+              ),
+              child: Icon(
+                Icons.lock_rounded,
+                color: const Color(0xFFFFB300),
+                size: 36.ic,
+              ),
+            ),
+            SizedBox(height: 20.h),
+            Text(
+              'Your full library, unlocked',
+              style: AppTypography.textMdMedium.copyWith(
+                color: context.colors.textPrimary,
+              ),
+            ),
+            SizedBox(height: 8.h),
+            Text(
+              'Your older liked games are saved. Upgrade to view your full '
+              'liked-games library.',
+              style: AppTypography.textSmRegular.copyWith(
+                color: context.colors.textSecondary,
+                height: 1.5,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 24.h),
+            GestureDetector(
+              onTap: () async {
+                HapticFeedbackService.buttonPress();
+                await requirePremiumGuard(context, ref);
+              },
+              child: Container(
+                padding: EdgeInsets.symmetric(horizontal: 28.w, vertical: 14.h),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      const Color(0xFFFFB300),
+                      const Color(0xFFFFB300).withValues(alpha: 0.82),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(14.br),
+                ),
+                child: Text(
+                  'Upgrade to Premium',
+                  style: AppTypography.textSmBold.copyWith(color: kBlackColor),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ).animate().fadeIn(duration: 300.ms).slideY(begin: 0.04, end: 0);
   }
 
   Widget _buildEmptyState() {

--- a/lib/screens/my_likes/my_likes_screen.dart
+++ b/lib/screens/my_likes/my_likes_screen.dart
@@ -11,6 +11,7 @@ import 'package:chessever2/screens/my_likes/provider/my_likes_provider.dart';
 import 'package:chessever2/screens/my_likes/widgets/date_section_header.dart';
 import 'package:chessever2/screens/my_likes/widgets/my_likes_game_card.dart';
 import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';

--- a/lib/screens/my_likes/provider/my_likes_provider.dart
+++ b/lib/screens/my_likes/provider/my_likes_provider.dart
@@ -60,15 +60,28 @@ class MyLikesData {
 /// Favorites games tab exposes (apply/clear filter, search/clear) so the same
 /// [GameFilter] dialog drives both.
 class MyLikesFilterState {
-  const MyLikesFilterState({required this.filter, required this.searchQuery});
+  const MyLikesFilterState({
+    required this.filter,
+    required this.searchQuery,
+    this.selectedTags = const <String>{},
+  });
 
   final GameFilter filter;
   final String searchQuery;
 
-  MyLikesFilterState copyWith({GameFilter? filter, String? searchQuery}) {
+  /// Official tags the user is filtering by (premium). Empty = no tag filter.
+  /// A game matches if it carries ANY of the selected tags (union).
+  final Set<String> selectedTags;
+
+  MyLikesFilterState copyWith({
+    GameFilter? filter,
+    String? searchQuery,
+    Set<String>? selectedTags,
+  }) {
     return MyLikesFilterState(
       filter: filter ?? this.filter,
       searchQuery: searchQuery ?? this.searchQuery,
+      selectedTags: selectedTags ?? this.selectedTags,
     );
   }
 }
@@ -85,6 +98,14 @@ class MyLikesFilterNotifier extends StateNotifier<MyLikesFilterState> {
       state = state.copyWith(filter: GameFilter.defaultFilter());
   void searchGames(String query) => state = state.copyWith(searchQuery: query);
   void clearSearch() => state = state.copyWith(searchQuery: '');
+
+  void toggleTag(String tag) {
+    final next = Set<String>.from(state.selectedTags);
+    if (!next.remove(tag)) next.add(tag);
+    state = state.copyWith(selectedTags: next);
+  }
+
+  void clearTags() => state = state.copyWith(selectedTags: const <String>{});
 }
 
 final myLikesFilterProvider =
@@ -220,6 +241,15 @@ final myLikesViewProvider = Provider.autoDispose<AsyncValue<MyLikesData>>((ref) 
             playerNameQuery: query.isNotEmpty ? query : null,
           ).map((g) => g.gameId).toSet();
       entries = entries.where((e) => keptIds.contains(e.game.gameId)).toList();
+    }
+
+    // Tag filter (premium only): keep games carrying ANY selected tag.
+    if (canFilterAndSort && filterState.selectedTags.isNotEmpty) {
+      final wanted = filterState.selectedTags;
+      entries =
+          entries
+              .where((e) => e.analysis.tags.any(wanted.contains))
+              .toList();
     }
 
     // Sort override (premium only). When a multi-key sort is set, flatten the

--- a/lib/screens/my_likes/provider/my_likes_provider.dart
+++ b/lib/screens/my_likes/provider/my_likes_provider.dart
@@ -56,6 +56,21 @@ class MyLikesData {
   bool get hasNoMatches => totalLiked > 0 && visibleCount == 0;
 }
 
+/// The three My Likes time windows. Today + This Week are the free, renewing
+/// window; All Time is the full archive (Premium for free users).
+enum MyLikesWindow { today, thisWeek, allTime }
+
+extension MyLikesWindowX on MyLikesWindow {
+  String get label => switch (this) {
+    MyLikesWindow.today => 'Today',
+    MyLikesWindow.thisWeek => 'This Week',
+    MyLikesWindow.allTime => 'All Time',
+  };
+
+  /// Free users may freely browse Today + This Week; All Time is gated.
+  bool get isFreeWindow => this != MyLikesWindow.allTime;
+}
+
 /// Filter + search state for the My Likes screen. Mirrors the surface the
 /// Favorites games tab exposes (apply/clear filter, search/clear) so the same
 /// [GameFilter] dialog drives both.
@@ -64,6 +79,7 @@ class MyLikesFilterState {
     required this.filter,
     required this.searchQuery,
     this.selectedTags = const <String>{},
+    this.window = MyLikesWindow.thisWeek,
   });
 
   final GameFilter filter;
@@ -73,15 +89,20 @@ class MyLikesFilterState {
   /// A game matches if it carries ANY of the selected tags (union).
   final Set<String> selectedTags;
 
+  /// Active time window tab.
+  final MyLikesWindow window;
+
   MyLikesFilterState copyWith({
     GameFilter? filter,
     String? searchQuery,
     Set<String>? selectedTags,
+    MyLikesWindow? window,
   }) {
     return MyLikesFilterState(
       filter: filter ?? this.filter,
       searchQuery: searchQuery ?? this.searchQuery,
       selectedTags: selectedTags ?? this.selectedTags,
+      window: window ?? this.window,
     );
   }
 }
@@ -98,6 +119,8 @@ class MyLikesFilterNotifier extends StateNotifier<MyLikesFilterState> {
       state = state.copyWith(filter: GameFilter.defaultFilter());
   void searchGames(String query) => state = state.copyWith(searchQuery: query);
   void clearSearch() => state = state.copyWith(searchQuery: '');
+
+  void setWindow(MyLikesWindow window) => state = state.copyWith(window: window);
 
   void toggleTag(String tag) {
     final next = Set<String>.from(state.selectedTags);
@@ -220,6 +243,29 @@ final myLikesViewProvider = Provider.autoDispose<AsyncValue<MyLikesData>>((ref) 
             .toList();
 
     final total = entries.length;
+
+    // Time-window tab filter (Today / This Week / All Time). Today + This Week
+    // are the free renewing window; All Time shows everything (UI gates the
+    // archive behind Premium for free users).
+    final now = DateTime.now();
+    final todayStart = DateTime(now.year, now.month, now.day);
+    bool inWindow(DateTime likedAtLocal) {
+      final likedDay = DateTime(
+        likedAtLocal.year,
+        likedAtLocal.month,
+        likedAtLocal.day,
+      );
+      switch (filterState.window) {
+        case MyLikesWindow.today:
+          return likedDay == todayStart;
+        case MyLikesWindow.thisWeek:
+          return !likedDay.isBefore(todayStart.subtract(const Duration(days: 6)));
+        case MyLikesWindow.allTime:
+          return true;
+      }
+    }
+
+    entries = entries.where((e) => inWindow(e.likedAt)).toList();
 
     final query = filterState.searchQuery.trim().toLowerCase();
     if (query.isNotEmpty) {

--- a/lib/screens/my_likes/widgets/my_likes_game_card.dart
+++ b/lib/screens/my_likes/widgets/my_likes_game_card.dart
@@ -1,3 +1,4 @@
+import 'package:chessever2/constants/game_tags.dart';
 import 'package:chessever2/repository/library/models/saved_analysis.dart';
 import 'package:chessever2/screens/library/widgets/library_game_card.dart';
 import 'package:chessever2/screens/library/widgets/swipe_action_card.dart';
@@ -57,7 +58,16 @@ class MyLikesGameCard extends ConsumerWidget {
       onTap: isLocked ? () => _handleLockedTap(context, ref) : onOpen,
     );
 
-    final content = isLocked ? _lockedOverlay(card) : card;
+    final visual =
+        analysis.tags.isEmpty
+            ? card
+            : Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [card, _buildTagsStrip(context)],
+            );
+
+    final content = isLocked ? _lockedOverlay(visual) : visual;
 
     return SwipeActionCard(
       dismissKey: ValueKey('mylikes_remove_${analysis.id}'),
@@ -83,6 +93,49 @@ class MyLikesGameCard extends ConsumerWidget {
           child: IgnorePointer(child: const _PremiumBadge()),
         ),
       ],
+    );
+  }
+
+  /// Compact, read-only chips showing the tags the user attached to this game
+  /// (set in the board save/edit sheet). Tapping them to filter happens via the
+  /// tag row at the top of the screen, so these are non-interactive.
+  Widget _buildTagsStrip(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(12.w, 6.h, 12.w, 2.h),
+      child: Wrap(
+        spacing: 6.w,
+        runSpacing: 6.h,
+        children: [
+          for (final tag in analysis.tags)
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 4.h),
+              decoration: BoxDecoration(
+                color: context.colors.danger.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8.br),
+                border: Border.all(
+                  color: context.colors.danger.withValues(alpha: 0.25),
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    iconForGameTag(tag),
+                    size: 11.sp,
+                    color: context.colors.danger.withValues(alpha: 0.9),
+                  ),
+                  SizedBox(width: 4.w),
+                  Text(
+                    tag,
+                    style: AppTypography.textXxsMedium.copyWith(
+                      color: context.colors.textPrimary.withValues(alpha: 0.75),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/my_likes/widgets/my_likes_game_card.dart
+++ b/lib/screens/my_likes/widgets/my_likes_game_card.dart
@@ -5,6 +5,7 @@ import 'package:chessever2/screens/library/widgets/swipe_action_card.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:flutter/material.dart';
@@ -44,6 +45,7 @@ class MyLikesGameCard extends ConsumerWidget {
   final Future<void> Function() onRemove;
 
   Future<void> _handleLockedTap(BuildContext context, WidgetRef ref) async {
+    HapticFeedbackService.cardTap();
     final unlocked = await requirePremiumGuard(context, ref);
     if (unlocked) onOpen();
   }

--- a/lib/screens/my_likes/widgets/my_likes_game_card.dart
+++ b/lib/screens/my_likes/widgets/my_likes_game_card.dart
@@ -3,6 +3,7 @@ import 'package:chessever2/repository/library/models/saved_analysis.dart';
 import 'package:chessever2/screens/library/widgets/library_game_card.dart';
 import 'package:chessever2/screens/library/widgets/swipe_action_card.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';

--- a/lib/screens/my_likes/widgets/roulette_tag_picker.dart
+++ b/lib/screens/my_likes/widgets/roulette_tag_picker.dart
@@ -7,6 +7,7 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 /// Presents the roulette tag picker as a modal sheet and resolves to the

--- a/lib/screens/my_likes/widgets/roulette_tag_picker.dart
+++ b/lib/screens/my_likes/widgets/roulette_tag_picker.dart
@@ -1,0 +1,686 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:chessever2/constants/game_tags.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Presents the roulette tag picker as a modal sheet and resolves to the
+/// chosen tag label, or `null` when the user skips / lets the spin run out /
+/// dismisses. Tags are a My-Likes-only concept, so this is the single entry
+/// point used both right after a like and from the liked-game save sheet.
+Future<String?> showRouletteTagPicker(
+  BuildContext context, {
+  String? initialTag,
+}) {
+  return showModalBottomSheet<String?>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: Colors.transparent,
+    barrierColor: Colors.black.withValues(alpha: 0.62),
+    builder: (_) => _RouletteTagPicker(initialTag: initialTag),
+  );
+}
+
+/// Per-slice accent colours — muted enough to sit on the dark surface, distinct
+/// enough to read as a gambling wheel. Index-aligned to [kOfficialGameTags].
+const List<Color> _sliceColors = [
+  Color(0xFFEF5350), // Wild Game
+  Color(0xFFFFCA28), // Beautiful Mate
+  Color(0xFFAB47BC), // Trap
+  Color(0xFF26A69A), // Good Defense
+  Color(0xFF66BB6A), // Comeback
+  Color(0xFF42A5F5), // High Technique
+  Color(0xFF5C6BC0), // Positional Masterpiece
+  Color(0xFFFF7043), // Sacrifice
+  Color(0xFF29B6F6), // Combination
+  Color(0xFFEC407A), // Blunder
+];
+
+class _RouletteTagPicker extends StatefulWidget {
+  const _RouletteTagPicker({this.initialTag});
+
+  final String? initialTag;
+
+  @override
+  State<_RouletteTagPicker> createState() => _RouletteTagPickerState();
+}
+
+class _RouletteTagPickerState extends State<_RouletteTagPicker>
+    with SingleTickerProviderStateMixin {
+  // ── Physics state (radians; canvas angle 0 = +x, clockwise) ──────────────
+  final ValueNotifier<double> _angle = ValueNotifier<double>(0);
+  double _velocity = 0; // rad/s
+  bool _dragging = false;
+  bool _settled = false;
+  bool _resolved = false;
+
+  // ── Countdown (1 → 0) ────────────────────────────────────────────────────
+  static const double _countdownSeconds = 5.0;
+  final ValueNotifier<double> _countdown = ValueNotifier<double>(1);
+  double _remaining = _countdownSeconds;
+
+  late final Ticker _ticker;
+  Duration _lastTick = Duration.zero;
+
+  // Cached icon glyph painters, one per slice.
+  late final List<TextPainter> _iconPainters;
+
+  int get _sliceCount => kOfficialGameTags.length;
+  double get _sliceAngle => (2 * math.pi) / _sliceCount;
+
+  // Pointer sits at the top of the wheel (12 o'clock). In canvas space (y down)
+  // that is -π/2.
+  static const double _pointerAngle = -math.pi / 2;
+
+  @override
+  void initState() {
+    super.initState();
+    _iconPainters = [
+      for (final tag in kOfficialGameTags)
+        TextPainter(
+          textDirection: TextDirection.ltr,
+          text: TextSpan(
+            text: String.fromCharCode(tag.icon.codePoint),
+            style: TextStyle(
+              fontSize: 20,
+              fontFamily: tag.icon.fontFamily,
+              package: tag.icon.fontPackage,
+              color: Colors.white,
+            ),
+          ),
+        )..layout(),
+    ];
+
+    // Pre-position the wheel so the user's existing tag (if any) starts under
+    // the pointer — editing feels continuous rather than random.
+    final startIndex =
+        widget.initialTag == null
+            ? 0
+            : kOfficialGameTagLabels.indexOf(widget.initialTag!);
+    _angle.value = _angleForIndex(startIndex < 0 ? 0 : startIndex);
+
+    _ticker = createTicker(_onTick);
+    if (!_reduceMotion) {
+      _ticker.start();
+      // A gentle inviting kick so the wheel breathes on entry.
+      _velocity = 3.2;
+      _settled = false;
+    }
+  }
+
+  bool get _reduceMotion {
+    final v = WidgetsBinding.instance.platformDispatcher.accessibilityFeatures;
+    return v.disableAnimations;
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    _angle.dispose();
+    _countdown.dispose();
+    for (final p in _iconPainters) {
+      p.dispose();
+    }
+    super.dispose();
+  }
+
+  // The wheel angle that places slice [index]'s centre under the top pointer.
+  double _angleForIndex(int index) {
+    final centerLocal = (index + 0.5) * _sliceAngle;
+    return _normalize(_pointerAngle - centerLocal);
+  }
+
+  double _normalize(double a) {
+    final twoPi = 2 * math.pi;
+    var r = a % twoPi;
+    if (r < 0) r += twoPi;
+    return r;
+  }
+
+  // Shortest signed delta from a → b, in (-π, π].
+  double _shortestDelta(double from, double to) {
+    var d = (to - from) % (2 * math.pi);
+    if (d > math.pi) d -= 2 * math.pi;
+    if (d < -math.pi) d += 2 * math.pi;
+    return d;
+  }
+
+  int get _selectedIndex {
+    final localAtPointer = _normalize(_pointerAngle - _angle.value);
+    return localAtPointer ~/ _sliceAngle % _sliceCount;
+  }
+
+  double _nearestCenterAngle() => _angleForIndex(_selectedIndex);
+
+  void _onTick(Duration elapsed) {
+    final dt = _lastTick == Duration.zero
+        ? 1 / 60
+        : (elapsed - _lastTick).inMicroseconds / 1e6;
+    _lastTick = elapsed;
+    if (dt <= 0) return;
+
+    if (!_dragging) {
+      // Countdown pauses while the user is actively positioning the wheel, so a
+      // careful spin is never cut short; it resumes the moment they let go.
+      _remaining -= dt;
+      _countdown.value = (_remaining / _countdownSeconds).clamp(0.0, 1.0);
+
+      // Detent spring toward the nearest slice centre + exponential friction.
+      // Reuses the heart-burst language: lightly underdamped, settles clean.
+      final target = _nearestCenterAngle();
+      final diff = _shortestDelta(_angle.value, target);
+      const detentStiffness = 42.0; // pull-to-centre
+      const friction = 2.4; // rad/s decay
+      _velocity += diff * detentStiffness * dt;
+      _velocity *= math.exp(-friction * dt);
+      _angle.value = _normalize(_angle.value + _velocity * dt);
+
+      final atRest = _velocity.abs() < 0.05 && diff.abs() < 0.012;
+      if (atRest) {
+        _angle.value = target;
+        _velocity = 0;
+        if (!_settled) {
+          _settled = true;
+          HapticFeedback.selectionClick();
+        }
+      } else {
+        _settled = false;
+      }
+    }
+
+    if (_remaining <= 0 && !_resolved) {
+      // Stop on a slice → that tag. Still spinning → no commitment → null.
+      _resolve(_settled ? kOfficialGameTags[_selectedIndex].label : null);
+    }
+  }
+
+  void _onPanStart(DragStartDetails d) {
+    _dragging = true;
+    _settled = false;
+    _velocity = 0;
+  }
+
+  void _onPanUpdate(DragUpdateDetails d, Offset center) {
+    // Convert the drag into rotation about the wheel centre: the tangential
+    // component of the finger movement spins the wheel.
+    final pos = d.localPosition - center;
+    final r = pos.distance;
+    if (r < 8) return;
+    final tangent = Offset(-pos.dy, pos.dx) / r; // unit tangent (clockwise)
+    final dTheta = (d.delta.dx * tangent.dx + d.delta.dy * tangent.dy) / r;
+    _angle.value = _normalize(_angle.value + dTheta);
+    // Track instantaneous velocity for the fling on release.
+    final dt = 1 / 60;
+    _velocity = dTheta / dt;
+    if (!_ticker.isActive && !_reduceMotion) _ticker.start();
+  }
+
+  void _onPanEnd(DragEndDetails d) {
+    _dragging = false;
+    // Clamp absurd flings so it always settles within the countdown.
+    _velocity = _velocity.clamp(-22.0, 22.0);
+  }
+
+  void _lockNow() {
+    HapticFeedback.mediumImpact();
+    // Force-settle to the slice currently under the pointer and commit it.
+    _angle.value = _nearestCenterAngle();
+    _resolve(kOfficialGameTags[_selectedIndex].label);
+  }
+
+  void _skip() {
+    HapticFeedback.lightImpact();
+    _resolve(null);
+  }
+
+  void _resolve(String? tag) {
+    if (_resolved) return;
+    _resolved = true;
+    if (_ticker.isActive) _ticker.stop();
+    if (tag != null) HapticFeedback.heavyImpact();
+    if (mounted) Navigator.of(context).pop(tag);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_reduceMotion) return _buildReducedMotionFallback();
+
+    final wheelSize = math.min(ResponsiveHelper.screenWidth * 0.84, 360.0.w);
+
+    return _SheetShell(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildHeader(),
+          SizedBox(height: 8.h),
+          // The wheel is anchored low and clipped to its upper portion so it
+          // reads as a rising "half circle" gauge while still rotating as a
+          // full detented wheel underneath.
+          ClipRect(
+            child: Align(
+              alignment: Alignment.topCenter,
+              heightFactor: 0.62,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onPanStart: _onPanStart,
+                onPanUpdate:
+                    (d) => _onPanUpdate(
+                      d,
+                      Offset(wheelSize / 2, wheelSize / 2),
+                    ),
+                onPanEnd: _onPanEnd,
+                onTap: _lockNow,
+                child: SizedBox(
+                  width: wheelSize,
+                  height: wheelSize,
+                  child: RepaintBoundary(
+                    child: CustomPaint(
+                      painter: _WheelPainter(
+                        repaint: Listenable.merge([_angle, _countdown]),
+                        angle: _angle,
+                        countdown: _countdown,
+                        iconPainters: _iconPainters,
+                        sliceColors: _sliceColors,
+                        sliceAngle: _sliceAngle,
+                        pointerAngle: _pointerAngle,
+                        hubColor: context.colors.surface,
+                        ringTrackColor:
+                            context.colors.textPrimary.withValues(alpha: 0.12),
+                        ringColor: kPrimaryColor,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          _buildLiveLabel(),
+          SizedBox(height: 16.h),
+          _buildActions(),
+          SizedBox(height: 8.h),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Column(
+      children: [
+        Text(
+          'Tag this game',
+          style: AppTypography.textLgBold.copyWith(
+            color: context.colors.textPrimary,
+            letterSpacing: -0.3,
+          ),
+        ),
+        SizedBox(height: 4.h),
+        Text(
+          'Spin and let it rest on a slice. Skip to leave it untagged.',
+          textAlign: TextAlign.center,
+          style: AppTypography.textXsRegular.copyWith(
+            color: context.colors.textPrimary.withValues(alpha: 0.55),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLiveLabel() {
+    return AnimatedBuilder(
+      animation: _angle,
+      builder: (context, _) {
+        final tag = kOfficialGameTags[_selectedIndex];
+        final color = _sliceColors[_selectedIndex];
+        return Container(
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.16),
+            borderRadius: BorderRadius.circular(20.br),
+            border: Border.all(color: color.withValues(alpha: 0.5)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(tag.icon, size: 16.sp, color: color),
+              SizedBox(width: 8.w),
+              Text(
+                tag.label,
+                style: AppTypography.textSmBold.copyWith(
+                  color: context.colors.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildActions() {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24.w),
+      child: Row(
+        children: [
+          Expanded(
+            child: GestureDetector(
+              onTap: _skip,
+              child: Container(
+                padding: EdgeInsets.symmetric(vertical: 14.h),
+                decoration: BoxDecoration(
+                  color: context.colors.textPrimary.withValues(alpha: 0.05),
+                  borderRadius: BorderRadius.circular(14.br),
+                  border: Border.all(
+                    color: context.colors.textPrimary.withValues(alpha: 0.1),
+                  ),
+                ),
+                child: Center(
+                  child: Text(
+                    'Skip',
+                    style: AppTypography.textSmMedium.copyWith(
+                      color: context.colors.textPrimary.withValues(alpha: 0.7),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          SizedBox(width: 12.w),
+          Expanded(
+            flex: 2,
+            child: GestureDetector(
+              onTap: _lockNow,
+              child: Container(
+                padding: EdgeInsets.symmetric(vertical: 14.h),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [kPrimaryColor, kPrimaryColor.withValues(alpha: 0.8)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(14.br),
+                  boxShadow: [
+                    BoxShadow(
+                      color: kPrimaryColor.withValues(alpha: 0.3),
+                      blurRadius: 18,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+                ),
+                child: Center(
+                  child: Text(
+                    'Lock it in',
+                    style: AppTypography.textSmBold.copyWith(
+                      color: context.colors.textPrimary,
+                      letterSpacing: 0.3,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // Accessibility / low-power path: a plain single-choice chip grid, no motion.
+  Widget _buildReducedMotionFallback() {
+    return _SheetShell(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildHeader(),
+          SizedBox(height: 16.h),
+          Wrap(
+            spacing: 8.w,
+            runSpacing: 8.h,
+            alignment: WrapAlignment.center,
+            children: [
+              for (var i = 0; i < kOfficialGameTags.length; i++)
+                GestureDetector(
+                  onTap: () => _resolve(kOfficialGameTags[i].label),
+                  child: Container(
+                    padding:
+                        EdgeInsets.symmetric(horizontal: 12.w, vertical: 8.h),
+                    decoration: BoxDecoration(
+                      color: _sliceColors[i].withValues(alpha: 0.14),
+                      borderRadius: BorderRadius.circular(20.br),
+                      border:
+                          Border.all(color: _sliceColors[i].withValues(alpha: 0.5)),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          kOfficialGameTags[i].icon,
+                          size: 14.sp,
+                          color: _sliceColors[i],
+                        ),
+                        SizedBox(width: 6.w),
+                        Text(
+                          kOfficialGameTags[i].label,
+                          style: AppTypography.textXsMedium.copyWith(
+                            color: context.colors.textPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          SizedBox(height: 16.h),
+          _buildActions(),
+          SizedBox(height: 8.h),
+        ],
+      ),
+    );
+  }
+}
+
+/// Shared dark rounded sheet shell with a drag handle.
+class _SheetShell extends StatelessWidget {
+  const _SheetShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: context.colors.surface.withValues(alpha: 0.98),
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28.br)),
+        border: Border.all(
+          color: context.colors.textPrimary.withValues(alpha: 0.06),
+        ),
+      ),
+      padding: EdgeInsets.only(bottom: 16.h),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            margin: EdgeInsets.symmetric(vertical: 12.h),
+            width: 40.w,
+            height: 4.h,
+            decoration: BoxDecoration(
+              color: context.colors.textPrimary.withValues(alpha: 0.2),
+              borderRadius: BorderRadius.circular(2.br),
+            ),
+          ),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _WheelPainter extends CustomPainter {
+  _WheelPainter({
+    required Listenable repaint,
+    required this.angle,
+    required this.countdown,
+    required this.iconPainters,
+    required this.sliceColors,
+    required this.sliceAngle,
+    required this.pointerAngle,
+    required this.hubColor,
+    required this.ringTrackColor,
+    required this.ringColor,
+  }) : super(repaint: repaint);
+
+  final ValueNotifier<double> angle;
+  final ValueNotifier<double> countdown;
+  final List<TextPainter> iconPainters;
+  final List<Color> sliceColors;
+  final double sliceAngle;
+  final double pointerAngle;
+  final Color hubColor;
+  final Color ringTrackColor;
+  final Color ringColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2;
+    final a = angle.value;
+    final n = iconPainters.length;
+
+    final localAtPointer = _norm(pointerAngle - a);
+    final selected = localAtPointer ~/ sliceAngle % n;
+
+    // ── Slices ──────────────────────────────────────────────────────────
+    for (var i = 0; i < n; i++) {
+      final start = i * sliceAngle + a;
+      final isSelected = i == selected;
+      final color = sliceColors[i];
+
+      final paint = Paint()
+        ..style = PaintingStyle.fill
+        ..color = isSelected
+            ? color.withValues(alpha: 0.92)
+            : color.withValues(alpha: 0.42);
+
+      final path = Path()
+        ..moveTo(center.dx, center.dy)
+        ..arcTo(
+          Rect.fromCircle(center: center, radius: radius),
+          start,
+          sliceAngle,
+          false,
+        )
+        ..close();
+      canvas.drawPath(path, paint);
+
+      // Slice divider.
+      final edge = Offset(
+        center.dx + radius * math.cos(start),
+        center.dy + radius * math.sin(start),
+      );
+      canvas.drawLine(
+        center,
+        edge,
+        Paint()
+          ..color = Colors.black.withValues(alpha: 0.25)
+          ..strokeWidth = 1.0,
+      );
+
+      // Icon glyph at mid-radius, kept upright.
+      final mid = start + sliceAngle / 2;
+      final iconR = radius * 0.66;
+      final ip = iconPainters[i];
+      final pos = Offset(
+        center.dx + iconR * math.cos(mid) - ip.width / 2,
+        center.dy + iconR * math.sin(mid) - ip.height / 2,
+      );
+      // Dim unselected icons slightly for focus on the pointer slice.
+      final iconOpacity = isSelected ? 1.0 : 0.85;
+      canvas.saveLayer(
+        Rect.fromCircle(center: pos + Offset(ip.width / 2, ip.height / 2), radius: 18),
+        Paint()..color = Colors.white.withValues(alpha: iconOpacity),
+      );
+      ip.paint(canvas, pos);
+      canvas.restore();
+    }
+
+    // ── Outer rim ───────────────────────────────────────────────────────
+    canvas.drawCircle(
+      center,
+      radius - 1,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..color = Colors.black.withValues(alpha: 0.35),
+    );
+
+    // ── Hub + countdown ring ────────────────────────────────────────────
+    final hubR = radius * 0.26;
+    canvas.drawCircle(
+      center,
+      hubR,
+      Paint()
+        ..style = PaintingStyle.fill
+        ..color = hubColor,
+    );
+    canvas.drawCircle(
+      center,
+      hubR,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1
+        ..color = Colors.white.withValues(alpha: 0.08),
+    );
+
+    final ringR = hubR - 6;
+    canvas.drawCircle(
+      center,
+      ringR,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 4
+        ..color = ringTrackColor,
+    );
+    final sweep = 2 * math.pi * countdown.value;
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: ringR),
+      -math.pi / 2,
+      sweep,
+      false,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 4
+        ..strokeCap = StrokeCap.round
+        ..color = ringColor,
+    );
+
+    // ── Top pointer (fixed) ─────────────────────────────────────────────
+    final tipY = center.dy - radius + 2;
+    final pointer = Path()
+      ..moveTo(center.dx, tipY + 18)
+      ..lineTo(center.dx - 11, tipY - 4)
+      ..lineTo(center.dx + 11, tipY - 4)
+      ..close();
+    canvas.drawShadow(pointer, Colors.black, 3, false);
+    canvas.drawPath(
+      pointer,
+      Paint()
+        ..style = PaintingStyle.fill
+        ..color = Colors.white,
+    );
+  }
+
+  double _norm(double v) {
+    final twoPi = 2 * math.pi;
+    var r = v % twoPi;
+    if (r < 0) r += twoPi;
+    return r;
+  }
+
+  @override
+  bool shouldRepaint(covariant _WheelPainter oldDelegate) => false;
+}

--- a/lib/screens/settings/widgets/board_settings_body.dart
+++ b/lib/screens/settings/widgets/board_settings_body.dart
@@ -2,9 +2,8 @@ import 'package:chessever2/providers/auto_pin_preferences_provider.dart';
 import 'package:chessever2/providers/board_settings_provider_new.dart';
 import 'package:chessever2/providers/pip_mode_provider.dart';
 import 'package:chessever2/repository/local_storage/auto_pin_preferences/auto_pin_preferences_repository.dart';
-import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
-import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:chessever2/screens/settings/widgets/settings_primitives.dart';
+import 'package:chessever2/services/analytics/analytics_service.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
@@ -32,21 +31,23 @@ class BoardSettingsBody extends ConsumerWidget {
 
     return boardSettingsAsync.when(
       data: (boardSettings) => _buildContent(context, ref, boardSettings),
-      loading: () => const Padding(
-        padding: EdgeInsets.symmetric(vertical: 32),
-        child: Center(child: CircularProgressIndicator()),
-      ),
-      error: (error, stack) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 24),
-        child: Center(
-          child: Text(
-            'Error loading board settings',
-            style: AppTypography.textMdRegular.copyWith(
-              color: context.colors.textPrimary,
+      loading:
+          () => const Padding(
+            padding: EdgeInsets.symmetric(vertical: 32),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+      error:
+          (error, stack) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 24),
+            child: Center(
+              child: Text(
+                'Error loading board settings',
+                style: AppTypography.textMdRegular.copyWith(
+                  color: context.colors.textPrimary,
+                ),
+              ),
             ),
           ),
-        ),
-      ),
     );
   }
 
@@ -91,9 +92,7 @@ class BoardSettingsBody extends ConsumerWidget {
               _ViewModeSelector(
                 selectedIndex: boardSettings.gamesListViewModeIndex,
                 onModeSelected: (index) {
-                  trackPersist(
-                    boardNotifier.setGamesListViewModeIndex(index),
-                  );
+                  trackPersist(boardNotifier.setGamesListViewModeIndex(index));
                 },
               ),
             ],
@@ -145,14 +144,16 @@ class BoardSettingsBody extends ConsumerWidget {
               Switch.adaptive(
                 value: boardSettings.soundEnabled,
                 thumbColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor
-                      : context.colors.textSecondary.withValues(alpha: 0.6),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor
+                          : context.colors.textSecondary.withValues(alpha: 0.6),
                 ),
                 trackColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor.withValues(alpha: 0.35)
-                      : context.colors.divider.withValues(alpha: 0.5),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : context.colors.divider.withValues(alpha: 0.5),
                 ),
                 onChanged: (value) {
                   trackPersist(boardNotifier.toggleSound(value));
@@ -176,34 +177,11 @@ class BoardSettingsBody extends ConsumerWidget {
                       fontSize: 13.f,
                     ),
                   ),
-                  if (!ref.watch(subscriptionProvider).isSubscribed) ...[
-                    SizedBox(width: 8.w),
-                    Container(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 8.sp,
-                        vertical: 2.sp,
-                      ),
-                      decoration: BoxDecoration(
-                        color: kPrimaryColor.withValues(alpha: 0.15),
-                        borderRadius: BorderRadius.circular(6.br),
-                        border: Border.all(
-                          color: kPrimaryColor.withValues(alpha: 0.3),
-                        ),
-                      ),
-                      child: Text(
-                        'PRO',
-                        style: AppTypography.textXsMedium.copyWith(
-                          color: kPrimaryColor,
-                          fontSize: 9.f,
-                        ),
-                      ),
-                    ),
-                  ],
                 ],
               ),
               SizedBox(height: 4.h),
               Text(
-                'Pop a mini board out when you leave the app. Choose which games can float.',
+                'Pop a mini board out for live games when you leave the app.',
                 style: AppTypography.textSmRegular.copyWith(
                   color: context.colors.textSecondary,
                   fontSize: 11.f,
@@ -213,15 +191,13 @@ class BoardSettingsBody extends ConsumerWidget {
               _PipModeSelector(
                 selected: boardSettings.pipMode,
                 onSelected: (mode) async {
-                  // Premium-gated: choosing any active mode by a free user opens
-                  // the paywall; "Off" is always allowed.
-                  if (mode != PipMode.off &&
-                      !ref.read(subscriptionProvider).isSubscribed) {
-                    final subscribed = await showPremiumPaywallSheet(
-                      context: context,
-                    );
-                    if (!subscribed) return;
-                  }
+                  AnalyticsService.instance.trackEventDetached(
+                    'PiP Mode Changed',
+                    properties: {
+                      'previous_mode': boardSettings.pipMode.label,
+                      'selected_mode': mode.label,
+                    },
+                  );
                   trackPersist(boardNotifier.setPipMode(mode));
                 },
               ),
@@ -283,14 +259,16 @@ class BoardSettingsBody extends ConsumerWidget {
               Switch.adaptive(
                 value: boardSettings.useFigurine,
                 thumbColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor
-                      : context.colors.textSecondary.withValues(alpha: 0.6),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor
+                          : context.colors.textSecondary.withValues(alpha: 0.6),
                 ),
                 trackColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor.withValues(alpha: 0.35)
-                      : context.colors.divider.withValues(alpha: 0.5),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : context.colors.divider.withValues(alpha: 0.5),
                 ),
                 onChanged: (value) {
                   trackPersist(boardNotifier.toggleFigurine(value));
@@ -329,14 +307,16 @@ class BoardSettingsBody extends ConsumerWidget {
               Switch.adaptive(
                 value: boardSettings.showCoordinates,
                 thumbColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor
-                      : context.colors.textSecondary.withValues(alpha: 0.6),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor
+                          : context.colors.textSecondary.withValues(alpha: 0.6),
                 ),
                 trackColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor.withValues(alpha: 0.35)
-                      : context.colors.divider.withValues(alpha: 0.5),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : context.colors.divider.withValues(alpha: 0.5),
                 ),
                 onChanged: (value) {
                   trackPersist(boardNotifier.toggleShowCoordinates(value));
@@ -375,14 +355,16 @@ class BoardSettingsBody extends ConsumerWidget {
               Switch.adaptive(
                 value: boardSettings.rawPgnMode,
                 thumbColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor
-                      : context.colors.textSecondary.withValues(alpha: 0.6),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor
+                          : context.colors.textSecondary.withValues(alpha: 0.6),
                 ),
                 trackColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor.withValues(alpha: 0.35)
-                      : context.colors.divider.withValues(alpha: 0.5),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : context.colors.divider.withValues(alpha: 0.5),
                 ),
                 onChanged: (value) {
                   trackPersist(boardNotifier.toggleRawPgnMode(value));
@@ -438,9 +420,10 @@ class _AutoPinSection extends ConsumerWidget {
                 value: prefs.favoritePlayersAutoPinEnabled,
                 thumbColor: WidgetStatePropertyAll(kPrimaryColor),
                 trackColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor.withValues(alpha: 0.35)
-                      : context.colors.divider.withValues(alpha: 0.5),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : context.colors.divider.withValues(alpha: 0.5),
                 ),
                 onChanged: (value) {
                   trackPersist(notifier.setFavoritePlayersAutoPin(value));
@@ -479,9 +462,10 @@ class _AutoPinSection extends ConsumerWidget {
                 value: prefs.countrymenAutoPinEnabled,
                 thumbColor: WidgetStatePropertyAll(kPrimaryColor),
                 trackColor: WidgetStateProperty.resolveWith(
-                  (states) => states.contains(WidgetState.selected)
-                      ? kPrimaryColor.withValues(alpha: 0.35)
-                      : context.colors.divider.withValues(alpha: 0.5),
+                  (states) =>
+                      states.contains(WidgetState.selected)
+                          ? kPrimaryColor.withValues(alpha: 0.35)
+                          : context.colors.divider.withValues(alpha: 0.5),
                 ),
                 onChanged: (value) {
                   trackPersist(notifier.setCountrymenAutoPin(value));
@@ -644,13 +628,14 @@ class _BoardThemePickerCard extends StatelessWidget {
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       constraints: ResponsiveHelper.bottomSheetConstraints,
-      builder: (context) => _BoardThemeGallerySheet(
-        currentIndex: currentIndex,
-        onThemeSelected: (index) {
-          onThemeSelected(index);
-          Navigator.pop(context);
-        },
-      ),
+      builder:
+          (context) => _BoardThemeGallerySheet(
+            currentIndex: currentIndex,
+            onThemeSelected: (index) {
+              onThemeSelected(index);
+              Navigator.pop(context);
+            },
+          ),
     );
   }
 }
@@ -804,15 +789,16 @@ class _BoardThemeGridItem extends StatelessWidget {
             color: isSelected ? kPrimaryColor : Colors.transparent,
             width: 2,
           ),
-          boxShadow: isSelected
-              ? [
-                  BoxShadow(
-                    color: kPrimaryColor.withValues(alpha: 0.3),
-                    blurRadius: 12,
-                    spreadRadius: 0,
-                  ),
-                ]
-              : null,
+          boxShadow:
+              isSelected
+                  ? [
+                    BoxShadow(
+                      color: kPrimaryColor.withValues(alpha: 0.3),
+                      blurRadius: 12,
+                      spreadRadius: 0,
+                    ),
+                  ]
+                  : null,
         ),
         child: Column(
           children: [
@@ -1081,13 +1067,14 @@ class _PieceSetPickerCard extends StatelessWidget {
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       constraints: ResponsiveHelper.bottomSheetConstraints,
-      builder: (context) => _PieceSetGallerySheet(
-        currentIndex: currentIndex,
-        onPieceSetSelected: (index) {
-          onPieceSetSelected(index);
-          Navigator.pop(context);
-        },
-      ),
+      builder:
+          (context) => _PieceSetGallerySheet(
+            currentIndex: currentIndex,
+            onPieceSetSelected: (index) {
+              onPieceSetSelected(index);
+              Navigator.pop(context);
+            },
+          ),
     );
   }
 }
@@ -1241,15 +1228,16 @@ class _PieceSetGridItem extends StatelessWidget {
             color: isSelected ? kPrimaryColor : Colors.transparent,
             width: 2,
           ),
-          boxShadow: isSelected
-              ? [
-                  BoxShadow(
-                    color: kPrimaryColor.withValues(alpha: 0.3),
-                    blurRadius: 12,
-                    spreadRadius: 0,
-                  ),
-                ]
-              : null,
+          boxShadow:
+              isSelected
+                  ? [
+                    BoxShadow(
+                      color: kPrimaryColor.withValues(alpha: 0.3),
+                      blurRadius: 12,
+                      spreadRadius: 0,
+                    ),
+                  ]
+                  : null,
         ),
         child: Column(
           children: [
@@ -1293,9 +1281,10 @@ class _PieceSetGridItem extends StatelessWidget {
               width: double.infinity,
               padding: EdgeInsets.symmetric(horizontal: 4.sp, vertical: 6.sp),
               decoration: BoxDecoration(
-                color: isSelected
-                    ? kPrimaryColor.withValues(alpha: 0.1)
-                    : Colors.transparent,
+                color:
+                    isSelected
+                        ? kPrimaryColor.withValues(alpha: 0.1)
+                        : Colors.transparent,
                 borderRadius: BorderRadius.vertical(
                   bottom: Radius.circular(10.br),
                 ),
@@ -1328,6 +1317,8 @@ class _PipModeSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final effectiveSelected = selected == PipMode.all ? PipMode.live : selected;
+
     return Container(
       padding: EdgeInsets.all(4.sp),
       decoration: BoxDecoration(
@@ -1336,14 +1327,18 @@ class _PipModeSelector extends StatelessWidget {
       ),
       child: Row(
         children: [
-          _buildOption(context, mode: PipMode.off, icon: Icons.block_rounded),
-          SizedBox(width: 4.w),
-          _buildOption(context, mode: PipMode.live, icon: Icons.sensors_rounded),
+          _buildOption(
+            context,
+            selected: effectiveSelected,
+            mode: PipMode.off,
+            icon: Icons.block_rounded,
+          ),
           SizedBox(width: 4.w),
           _buildOption(
             context,
-            mode: PipMode.all,
-            icon: Icons.all_inclusive_rounded,
+            selected: effectiveSelected,
+            mode: PipMode.live,
+            icon: Icons.sensors_rounded,
           ),
         ],
       ),
@@ -1352,6 +1347,7 @@ class _PipModeSelector extends StatelessWidget {
 
   Widget _buildOption(
     BuildContext context, {
+    required PipMode selected,
     required PipMode mode,
     required IconData icon,
   }) {
@@ -1363,31 +1359,34 @@ class _PipModeSelector extends StatelessWidget {
           duration: const Duration(milliseconds: 200),
           padding: EdgeInsets.symmetric(vertical: 8.sp),
           decoration: BoxDecoration(
-            color: isSelected
-                ? kPrimaryColor.withValues(alpha: 0.08)
-                : Colors.transparent,
+            color:
+                isSelected
+                    ? kPrimaryColor.withValues(alpha: 0.08)
+                    : Colors.transparent,
             borderRadius: BorderRadius.circular(8.br),
             border: Border.all(
               color: isSelected ? kPrimaryColor : Colors.transparent,
               width: isSelected ? 1.5 : 1.0,
             ),
-            boxShadow: isSelected
-                ? [
-                    BoxShadow(
-                      color: kPrimaryColor.withValues(alpha: 0.18),
-                      blurRadius: 8,
-                      spreadRadius: 0,
-                    ),
-                  ]
-                : null,
+            boxShadow:
+                isSelected
+                    ? [
+                      BoxShadow(
+                        color: kPrimaryColor.withValues(alpha: 0.18),
+                        blurRadius: 8,
+                        spreadRadius: 0,
+                      ),
+                    ]
+                    : null,
           ),
           child: Column(
             children: [
               Icon(
                 icon,
-                color: isSelected
-                    ? context.colors.textPrimary
-                    : context.colors.textTertiary,
+                color:
+                    isSelected
+                        ? context.colors.textPrimary
+                        : context.colors.textTertiary,
                 size: 20.ic,
               ),
               SizedBox(height: 4.h),
@@ -1396,9 +1395,10 @@ class _PipModeSelector extends StatelessWidget {
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: AppTypography.textXsMedium.copyWith(
-                  color: isSelected
-                      ? context.colors.textPrimary
-                      : context.colors.textTertiary,
+                  color:
+                      isSelected
+                          ? context.colors.textPrimary
+                          : context.colors.textTertiary,
                   fontSize: 10.f,
                 ),
               ),
@@ -1468,40 +1468,44 @@ class _ViewModeSelector extends StatelessWidget {
           duration: const Duration(milliseconds: 200),
           padding: EdgeInsets.symmetric(vertical: 8.sp),
           decoration: BoxDecoration(
-            color: isSelected
-                ? kPrimaryColor.withValues(alpha: 0.08)
-                : Colors.transparent,
+            color:
+                isSelected
+                    ? kPrimaryColor.withValues(alpha: 0.08)
+                    : Colors.transparent,
             borderRadius: BorderRadius.circular(8.br),
             border: Border.all(
               color: isSelected ? kPrimaryColor : Colors.transparent,
               width: isSelected ? 1.5 : 1.0,
             ),
-            boxShadow: isSelected
-                ? [
-                    BoxShadow(
-                      color: kPrimaryColor.withValues(alpha: 0.18),
-                      blurRadius: 8,
-                      spreadRadius: 0,
-                    ),
-                  ]
-                : null,
+            boxShadow:
+                isSelected
+                    ? [
+                      BoxShadow(
+                        color: kPrimaryColor.withValues(alpha: 0.18),
+                        blurRadius: 8,
+                        spreadRadius: 0,
+                      ),
+                    ]
+                    : null,
           ),
           child: Column(
             children: [
               Icon(
                 icon,
-                color: isSelected
-                    ? context.colors.textPrimary
-                    : context.colors.textTertiary,
+                color:
+                    isSelected
+                        ? context.colors.textPrimary
+                        : context.colors.textTertiary,
                 size: 20.ic,
               ),
               SizedBox(height: 4.h),
               Text(
                 label,
                 style: AppTypography.textXsMedium.copyWith(
-                  color: isSelected
-                      ? context.colors.textPrimary
-                      : context.colors.textTertiary,
+                  color:
+                      isSelected
+                          ? context.colors.textPrimary
+                          : context.colors.textTertiary,
                   fontSize: 10.f,
                 ),
               ),

--- a/lib/screens/settings/widgets/notification_settings_body.dart
+++ b/lib/screens/settings/widgets/notification_settings_body.dart
@@ -1,5 +1,6 @@
 import 'package:chessever2/providers/notification_preferences_provider.dart';
 import 'package:chessever2/providers/notifications_settings_provider.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/settings/widgets/board_settings_body.dart'
     show TrackPersist;
 import 'package:chessever2/theme/app_colors.dart';
@@ -8,6 +9,8 @@ import 'package:chessever2/widgets/notification_settings/notif_lead_time_control
 import 'package:chessever2/widgets/notification_settings/notif_push_card.dart';
 import 'package:chessever2/widgets/notification_settings/notif_section_header.dart';
 import 'package:chessever2/widgets/notification_settings/notif_toggle_tile.dart';
+import 'package:chessever2/widgets/notification_settings/pro_badge.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -26,6 +29,7 @@ class NotificationSettingsBody extends ConsumerWidget {
     final prefsLoading = prefsAsync.isLoading;
     final pushEnabled = pushSettings.enabled;
     final interactive = pushEnabled && !prefsLoading;
+    final isSubscribed = ref.watch(subscriptionProvider).isSubscribed;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -165,6 +169,34 @@ class NotificationSettingsBody extends ConsumerWidget {
               ),
             ),
           ),
+        ),
+
+        SizedBox(height: 24.h),
+
+        const NotifSectionHeader(title: 'Live'),
+
+        NotifToggleTile(
+          title: 'Live Updates',
+          subtitle:
+              'Move-by-move updates on your lock screen for ongoing games. '
+              'Premium only.',
+          value: prefs.liveGameUpdates && isSubscribed,
+          badge: isSubscribed ? null : const ProBadge(),
+          onChanged: !interactive
+              ? null
+              : (value) async {
+                  if (value && !ref.read(subscriptionProvider).isSubscribed) {
+                    final subscribed = await showPremiumPaywallSheet(
+                      context: context,
+                    );
+                    if (!subscribed) return;
+                  }
+                  trackPersist(
+                    ref
+                        .read(notificationPreferencesProvider.notifier)
+                        .setLiveGameUpdates(value),
+                  );
+                },
         ),
 
         SizedBox(height: 24.h),

--- a/lib/services/live_updates_service.dart
+++ b/lib/services/live_updates_service.dart
@@ -38,7 +38,6 @@ class LiveUpdatesService {
     required Map<String, dynamic> attributes,
     required Map<String, dynamic> content,
   }) async {
-    /*
     await setup();
     if (kIsWeb) return;
 
@@ -88,11 +87,9 @@ class LiveUpdatesService {
     if (started) {
       await _registerSubscription(gameId, enabled: true);
     }
-    */
   }
 
   Future<void> endLiveActivity(String activityId) async {
-    /*
     if (kIsWeb) return;
 
     final gameId = _activeGameId;
@@ -109,7 +106,6 @@ class LiveUpdatesService {
 
     _activeGameId = null;
     await _registerSubscription(gameId, enabled: false);
-    */
   }
 
   /// Convenience method to start live updates for a game when app goes to background.

--- a/lib/widgets/notification_settings/pro_badge.dart
+++ b/lib/widgets/notification_settings/pro_badge.dart
@@ -1,0 +1,32 @@
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+
+/// Small pill badge marking a feature as premium-only ("PRO").
+class ProBadge extends StatelessWidget {
+  const ProBadge({super.key, this.label = 'PRO'});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 6.sp, vertical: 2.sp),
+      decoration: BoxDecoration(
+        color: kPrimaryColor.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4.br),
+        border: Border.all(color: kPrimaryColor.withValues(alpha: 0.3)),
+      ),
+      child: Text(
+        label,
+        style: AppTypography.textSmRegular.copyWith(
+          color: kPrimaryColor,
+          fontSize: 9.f,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.4,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/search/enhanced_rounded_search_bar.dart
+++ b/lib/widgets/search/enhanced_rounded_search_bar.dart
@@ -24,6 +24,7 @@ class EnhancedRoundedSearchBar extends ConsumerStatefulWidget {
   final bool showFilter;
   final FocusNode? focusNode;
   final VoidCallback? onClearSearchField;
+  final ValueChanged<String>? onSubmitted;
   final int filterBadgeCount;
   final Key? textFieldKey;
   final Key? filterButtonKey;
@@ -43,6 +44,7 @@ class EnhancedRoundedSearchBar extends ConsumerStatefulWidget {
     this.showFilter = true,
     this.focusNode,
     this.onClearSearchField,
+    this.onSubmitted,
     this.filterBadgeCount = 0,
     this.textFieldKey,
     this.filterButtonKey,
@@ -214,7 +216,7 @@ class _EnhancedRoundedSearchBarState
                         border: Border.all(
                           color:
                               _effectiveNode.hasFocus
-                                  ? kPrimaryColor.withOpacity(0.5)
+                                  ? kPrimaryColor.withValues(alpha: 0.5)
                                   : Colors.transparent,
                           width: 2.0,
                         ),
@@ -222,7 +224,9 @@ class _EnhancedRoundedSearchBarState
                             _effectiveNode.hasFocus
                                 ? [
                                   BoxShadow(
-                                    color: kPrimaryColor.withOpacity(0.15),
+                                    color: kPrimaryColor.withValues(
+                                      alpha: 0.15,
+                                    ),
                                     blurRadius: 12,
                                     offset: const Offset(0, 4),
                                   ),
@@ -287,6 +291,7 @@ class _EnhancedRoundedSearchBarState
               controller: widget.controller,
               focusNode: _effectiveNode,
               onCloseTap: _clearSearchAndHide,
+              onSubmitted: widget.onSubmitted,
               onOpenFilter: widget.onFilterTap,
               filterBadgeCount: widget.filterBadgeCount,
             ),

--- a/lib/widgets/simple_search_bar.dart
+++ b/lib/widgets/simple_search_bar.dart
@@ -16,6 +16,7 @@ class SimpleSearchBar extends StatefulWidget {
     required this.focusNode,
     required this.onCloseTap,
     required this.onOpenFilter,
+    this.onSubmitted,
     this.hintText = '',
     this.autofocus = false,
     this.onChanged,
@@ -30,6 +31,7 @@ class SimpleSearchBar extends StatefulWidget {
   final FocusNode focusNode;
   final VoidCallback onCloseTap;
   final VoidCallback? onOpenFilter;
+  final ValueChanged<String>? onSubmitted;
   final String hintText;
   final bool autofocus;
   final ValueChanged<String>? onChanged;
@@ -158,19 +160,14 @@ class _SimpleSearchBarState extends State<SimpleSearchBar> {
     if (hints == null || hints.isEmpty) return null;
     // Empty string during fade-out lets SpringHintWord spring the last word
     // away instead of popping it off in a single frame.
-    final word =
-        _cycleFadingOut ? '' : hints[_hintIndex % hints.length];
+    final word = _cycleFadingOut ? '' : hints[_hintIndex % hints.length];
     final prefix = widget.hintText.isEmpty ? '' : '${widget.hintText} ';
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (prefix.isNotEmpty)
-          Text(prefix, style: AppTypography.textMdRegular),
+        if (prefix.isNotEmpty) Text(prefix, style: AppTypography.textMdRegular),
         Flexible(
-          child: SpringHintWord(
-            word: word,
-            style: AppTypography.textMdRegular,
-          ),
+          child: SpringHintWord(word: word, style: AppTypography.textMdRegular),
         ),
       ],
     );
@@ -205,6 +202,7 @@ class _SimpleSearchBarState extends State<SimpleSearchBar> {
               focusNode: widget.focusNode,
               autofocus: widget.autofocus,
               onChanged: widget.onChanged,
+              onSubmitted: widget.onSubmitted,
               style: AppTypography.textMdRegular,
               decoration: InputDecoration(
                 hintText: rotatingHint == null ? widget.hintText : null,
@@ -220,12 +218,10 @@ class _SimpleSearchBarState extends State<SimpleSearchBar> {
           // contains text. Scoped to a ListenableBuilder so toggling it
           // doesn't rebuild the TextField and cause IME / focus churn.
           ListenableBuilder(
-            listenable: Listenable.merge([
-              widget.controller,
-              widget.focusNode,
-            ]),
+            listenable: Listenable.merge([widget.controller, widget.focusNode]),
             builder: (context, _) {
-              final visible = widget.focusNode.hasFocus ||
+              final visible =
+                  widget.focusNode.hasFocus ||
                   widget.controller.text.isNotEmpty;
               if (!visible) return const SizedBox.shrink();
               return GestureDetector(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -961,10 +961,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1686,10 +1686,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   type_plus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 20.0.0+1542
+version: 20.1.0+1543
 
 environment:
   sdk: ^3.7.2
@@ -200,7 +200,7 @@ flutter:
     - assets/sfx/
     - assets/launch.webp
     - assets/app_icon.png
-    # - .env
+    - .env
     - shorebird.yaml
 
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 19.6.0+1542
+version: 19.6.1+1542
 
 environment:
   sdk: ^3.7.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 19.6.0+1541
+version: 19.6.0+1542
 
 environment:
   sdk: ^3.7.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 19.6.1+1542
+version: 20.0.0+1542
 
 environment:
   sdk: ^3.7.2

--- a/test/smart_opening_event_test.dart
+++ b/test/smart_opening_event_test.dart
@@ -1,0 +1,84 @@
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/screens/group_event/smart_opening_event.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Games _game({String? eco, String? openingName, String? name}) {
+  return Games(
+    id: 'game-${eco ?? openingName ?? name}',
+    roundId: 'round-1',
+    roundSlug: 'round-1',
+    tourId: 'tour-1',
+    tourSlug: 'tour-1',
+    name: name,
+    eco: eco,
+    openingName: openingName,
+    players: const <Player>[],
+  );
+}
+
+void main() {
+  group('SmartOpeningQuery', () {
+    test('parses exact ECO codes', () {
+      final query = SmartOpeningQuery.parse('B90');
+
+      expect(query, isNotNull);
+      expect(query!.title, 'ECO: B90');
+      expect(query.matchesGame(_game(eco: 'B90')), isTrue);
+      expect(query.matchesGame(_game(eco: 'B91')), isFalse);
+    });
+
+    test('parses short same-family ECO ranges', () {
+      final query = SmartOpeningQuery.parse('B90-98');
+
+      expect(query, isNotNull);
+      expect(query!.title, 'ECO: B90–B98');
+      expect(query.matchesGame(_game(eco: 'B90')), isTrue);
+      expect(query.matchesGame(_game(eco: 'B95')), isTrue);
+      expect(query.matchesGame(_game(eco: 'B98')), isTrue);
+      expect(query.matchesGame(_game(eco: 'B99')), isFalse);
+      expect(query.matchesGame(_game(eco: 'C95')), isFalse);
+    });
+
+    test('parses explicit ECO ranges', () {
+      final query = SmartOpeningQuery.parse('B90-B98');
+
+      expect(query, isNotNull);
+      expect(query!.matchesGame(_game(eco: 'B93')), isTrue);
+      expect(query.matchesGame(_game(eco: 'B89')), isFalse);
+    });
+
+    test('matches broad opening text by token', () {
+      final query = SmartOpeningQuery.parse('Sicilian');
+
+      expect(query, isNotNull);
+      expect(
+        query!.matchesGame(
+          _game(openingName: 'Sicilian Defense: Najdorf Variation'),
+        ),
+        isTrue,
+      );
+      expect(query.matchesGame(_game(openingName: 'French Defense')), isFalse);
+    });
+
+    test('narrows opening text when variation is supplied', () {
+      final query = SmartOpeningQuery.parse('sicilian najdorf');
+
+      expect(query, isNotNull);
+      expect(
+        query!.matchesGame(
+          _game(openingName: 'Sicilian Defense: Najdorf Variation'),
+        ),
+        isTrue,
+      );
+      expect(
+        query.matchesGame(_game(openingName: 'Sicilian Defense: Dragon')),
+        isFalse,
+      );
+    });
+
+    test('does not hijack unrelated player/event searches', () {
+      expect(SmartOpeningQuery.parse('Magnus Carlsen'), isNull);
+      expect(SmartOpeningQuery.parse('World Championship'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a level smart event for GM/IM/FM/CM filters in the For You feed.
- Shows the selected level card above the Current list on phone when a level filter is active.
- Opens a games-only smart event with search, level switching, date grouping, and favorite/countrymen pin prioritization before strongest average-rating games.

## Validation
- `dart format lib/screens/group_event/smart_level_event.dart lib/screens/group_event/widget/for_you_games_widget.dart lib/screens/group_event/widget/all_events_tab_widget.dart lib/screens/group_event/group_event_screen.dart`
- `flutter analyze --no-fatal-infos lib/screens/group_event/smart_level_event.dart lib/screens/group_event/widget/for_you_games_widget.dart lib/screens/group_event/widget/all_events_tab_widget.dart lib/screens/group_event/group_event_screen.dart`
- `git diff --check`

## Review
- Phone/app frontend review requested.
