### PR TITLE
Polish level games UI

### DIFF
--- a/lib/screens/group_event/smart_event/smart_aggregate_event_provider.dart
+++ b/lib/screens/group_event/smart_event/smart_aggregate_event_provider.dart
@@ -79,7 +79,7 @@ class SmartEventRequest {
 
   String get favoriteEventId => 'smart_event:$scopeId';
 
-  String get displayName => '$tierLabel $titleSuffix';
+  String get displayName => '$tierLabel $titleSuffix'.trim();
 
   Map<String, dynamic> toFavoriteMetadata() {
     return {
@@ -90,6 +90,7 @@ class SmartEventRequest {
       'minElo': minElo,
       'maxElo': maxElo,
       'caption': caption,
+      'notificationsEnabled': false,
       'countSingular': countSingular,
       'countPlural': countPlural,
       'savedAt': (savedAt ?? DateTime.now()).toIso8601String(),
@@ -134,10 +135,13 @@ class SmartEventRequest {
     return SmartEventRequest(
       source: source,
       tierLabel: metadata['tierLabel']?.toString() ?? favorite.eventName,
-      titleSuffix: metadata['titleSuffix']?.toString() ?? 'Games',
+      titleSuffix: _normalizedTitleSuffix(metadata['titleSuffix']),
       minElo: _intFromMetadata(metadata['minElo']) ?? kFilterMinElo.round(),
       maxElo: _intFromMetadata(metadata['maxElo']) ?? kFilterMaxElo.round(),
-      caption: metadata['caption']?.toString() ?? 'Saved smart event',
+      caption: _normalizedCaption(
+        metadata['caption'],
+        _intFromMetadata(metadata['minElo']) ?? kFilterMinElo.round(),
+      ),
       countSingular: metadata['countSingular']?.toString() ?? 'filtered event',
       countPlural: metadata['countPlural']?.toString() ?? 'filtered events',
       events: events,
@@ -204,9 +208,6 @@ class SmartEventCardData {
 
     final minElo = filter.minElo ?? kFilterMinElo.round();
     final maxElo = filter.maxElo ?? kFilterMaxElo.round();
-    final hasOnlyEloFilter =
-        filter.hasEloFilter && filter.formatsAndStates.isEmpty;
-
     final fullLabel =
         filter.hasEloFilter ? RatingTierFilter.labelForMinRating(minElo) : null;
     final tierLabel =
@@ -222,15 +223,15 @@ class SmartEventCardData {
       request: SmartEventRequest(
         source: source,
         tierLabel: tierLabel,
-        titleSuffix: hasOnlyEloFilter ? 'Live Games' : 'Games',
+        titleSuffix: 'Games',
         minElo: minElo,
         maxElo: maxElo,
         caption:
             filter.hasEloFilter
-                ? 'Gathered from your $minElo+ filter'
-                : 'Gathered from your filters',
-        countSingular: hasOnlyEloFilter ? 'live event' : 'filtered event',
-        countPlural: hasOnlyEloFilter ? 'live events' : 'filtered events',
+                ? 'From your $minElo+ filter'
+                : 'From your filters',
+        countSingular: 'event',
+        countPlural: 'events',
         events: events,
       ),
       eventCount: events.length,
@@ -324,9 +325,9 @@ final smartCurrentEventIdsProvider = FutureProvider.autoDispose
       return broadcasts.map((broadcast) => broadcast.id).toSet();
     });
 
-/// The synthetic "smart event": live games gathered from every currently-live
-/// broadcast (optionally narrowed by the applied ELO tier) into one place, plus
-/// the aggregate metadata the event view needs for its About header.
+/// Generated level games gathered from every currently-live broadcast
+/// (optionally narrowed by the applied ELO tier) into one place, plus the
+/// aggregate metadata the event view needs for its About header.
 class SmartAggregateEvent {
   const SmartAggregateEvent({
     required this.games,
@@ -650,6 +651,7 @@ SmartAggregateEvent _buildAggregateEventFromGameRows({
 
   final orderedGames = _sortSmartGames(
     gamesById.values.toList(growable: false),
+    pinnedIds: const <String>[],
   );
   final participatingEvents =
       eventIdsWithGames.isEmpty
@@ -696,6 +698,7 @@ SmartAggregateEvent _buildAggregateEvent(
 
   final orderedGames = _sortSmartGames(
     gamesById.values.toList(growable: false),
+    pinnedIds: pinnedIds,
   );
 
   final participatingEvents =
@@ -807,17 +810,21 @@ int smartGameAverageElo(GamesTourModel game) {
   return (ratings.reduce((a, b) => a + b) / ratings.length).round();
 }
 
-List<GamesTourModel> _sortSmartGames(List<GamesTourModel> games) {
+List<GamesTourModel> _sortSmartGames(
+  List<GamesTourModel> games, {
+  required List<String> pinnedIds,
+}) {
+  final pinned = pinnedIds.toSet();
   final sorted = List<GamesTourModel>.from(games);
   sorted.sort((a, b) {
-    final aLive = a.effectiveGameStatus.isOngoing ? 1 : 0;
-    final bLive = b.effectiveGameStatus.isOngoing ? 1 : 0;
-    if (aLive != bLive) return bLive.compareTo(aLive);
+    final ad = _smartGameDay(a);
+    final bd = _smartGameDay(b);
+    final byDay = bd.compareTo(ad);
+    if (byDay != 0) return byDay;
 
-    final ad = a.lastMoveTime ?? a.bucketDate ?? DateTime(0);
-    final bd = b.lastMoveTime ?? b.bucketDate ?? DateTime(0);
-    final byDate = bd.compareTo(ad);
-    if (byDate != 0) return byDate;
+    final aPinned = pinned.contains(a.gameId) ? 1 : 0;
+    final bPinned = pinned.contains(b.gameId) ? 1 : 0;
+    if (aPinned != bPinned) return bPinned.compareTo(aPinned);
 
     final byAvgElo = smartGameAverageElo(b).compareTo(smartGameAverageElo(a));
     if (byAvgElo != 0) return byAvgElo;
@@ -833,6 +840,30 @@ List<GamesTourModel> _sortSmartGames(List<GamesTourModel> games) {
     return a.gameId.compareTo(b.gameId);
   });
   return sorted;
+}
+
+DateTime _smartGameDay(GamesTourModel game) {
+  final raw = game.lastMoveTime ?? game.bucketDate ?? DateTime(0);
+  final local = raw.toLocal();
+  return DateTime(local.year, local.month, local.day);
+}
+
+String _normalizedTitleSuffix(Object? value) {
+  final text = value?.toString().trim();
+  if (text == null || text.isEmpty || text == 'Live Games') return 'Games';
+  return text;
+}
+
+String _normalizedCaption(Object? value, int minElo) {
+  final text = value?.toString().trim();
+  if (text == null ||
+      text.isEmpty ||
+      text == 'Saved smart event' ||
+      text.startsWith('Gathered from your')) {
+    if (minElo > kFilterMinElo) return 'From your $minElo+ filter';
+    return 'From your filters';
+  }
+  return text;
 }
 
 GroupEventCardModel? _eventFromMetadata(Map<String, dynamic> json) {

--- a/lib/screens/group_event/smart_event/smart_event_screen.dart
+++ b/lib/screens/group_event/smart_event/smart_event_screen.dart
@@ -1,9 +1,11 @@
 import 'package:chessever2/providers/favorite_events_provider.dart';
 import 'package:chessever2/repository/gamebase/search/gamebase_search_models.dart';
+import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/chessboard/provider/game_pgn_stream_provider.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/group_event/smart_event/smart_aggregate_event_provider.dart';
+import 'package:chessever2/screens/group_event/widget/filter_popup/filter_popup_state.dart';
 import 'package:chessever2/screens/player_profile/player_profile_screen.dart';
 import 'package:chessever2/screens/standings/player_standing_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
@@ -21,6 +23,7 @@ import 'package:chessever2/widgets/game_filter/game_filter_dialog.dart';
 import 'package:chessever2/widgets/game_filter/game_filter_model.dart';
 import 'package:chessever2/widgets/game_filter/game_search_filter_bar.dart';
 import 'package:chessever2/widgets/generic_error_widget.dart';
+import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:chessever2/widgets/segmented_switcher.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -110,11 +113,14 @@ class _AppBar extends ConsumerWidget {
   }) async {
     final confirmed = await showSmoothConfirmDialog(
       context: context,
-      title: isSaved ? 'Remove smart event?' : 'Save smart event?',
+      title:
+          isSaved
+              ? 'Remove ${request.displayName}?'
+              : 'Save ${request.displayName}?',
       message:
           isSaved
-              ? 'This will remove ${request.displayName} from your For You and Current tabs.'
-              : 'This will add ${request.displayName} to your For You and Current tabs while its events are active.',
+              ? 'This will remove ${request.displayName} from your For You.'
+              : 'This will add ${request.displayName} to your For You tab.',
       confirmText: isSaved ? 'Remove' : 'Save',
       isDangerous: isSaved,
     );
@@ -149,59 +155,12 @@ class _AppBar extends ConsumerWidget {
             ),
             onPressed: () => Navigator.of(context).pop(),
           ),
-          Expanded(
-            child: Center(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Flexible(
-                    child: Text(
-                      '${request.tierLabel} ${request.titleSuffix}',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTypography.textMdMedium.copyWith(
-                        color: context.colors.textPrimary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                  SizedBox(width: 6.w),
-                  Container(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: 6.w,
-                      vertical: 2.h,
-                    ),
-                    decoration: BoxDecoration(
-                      color: kPrimaryColor,
-                      borderRadius: BorderRadius.circular(5.br),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.auto_awesome,
-                          size: 10.sp,
-                          color: kBlackColor,
-                        ),
-                        SizedBox(width: 3.w),
-                        Text(
-                          'SMART',
-                          style: AppTypography.textXxsBold.copyWith(
-                            color: kBlackColor,
-                            fontSize: 9.sp,
-                            letterSpacing: 0.6,
-                            height: 1,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
+          Expanded(child: Center(child: _TitleSelector(request: request))),
           IconButton(
-            tooltip: isSaved ? 'Unsave smart event' : 'Save smart event',
+            tooltip:
+                isSaved
+                    ? 'Remove ${request.displayName}'
+                    : 'Save ${request.displayName}',
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(),
             iconSize: 26.ic,
@@ -236,6 +195,115 @@ class _AppBar extends ConsumerWidget {
             },
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _TitleSelector extends StatelessWidget {
+  const _TitleSelector({required this.request});
+
+  final SmartEventRequest request;
+
+  List<SmartEventRequest> _options() {
+    const tiers = <(String, int)>[
+      ('GM', 2500),
+      ('IM', 2400),
+      ('FM', 2300),
+      ('CM', 2200),
+    ];
+    final options = tiers
+        .map(
+          (tier) => SmartEventRequest(
+            source: request.source,
+            tierLabel: tier.$1,
+            titleSuffix: 'Games',
+            minElo: tier.$2,
+            maxElo: kFilterMaxElo.round(),
+            caption: 'From your ${tier.$2}+ filter',
+            countSingular: 'event',
+            countPlural: 'events',
+            events: request.events,
+          ),
+        )
+        .toList(growable: true);
+    options.add(
+      SmartEventRequest(
+        source: request.source,
+        tierLabel: 'All',
+        titleSuffix: 'Games',
+        minElo: kFilterMinElo.round(),
+        maxElo: kFilterMaxElo.round(),
+        caption: 'From your filters',
+        countSingular: 'event',
+        countPlural: 'events',
+        events: request.events,
+      ),
+    );
+    return options;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final options = _options();
+    return PopupMenuButton<SmartEventRequest>(
+      tooltip: 'Change games level',
+      color: context.colors.surface,
+      initialValue: options.firstWhere(
+        (option) => option.tierLabel == request.tierLabel,
+        orElse: () => request,
+      ),
+      onSelected: (next) {
+        if (next.scopeId == request.scopeId &&
+            next.displayName == request.displayName) {
+          return;
+        }
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute<void>(
+            builder: (_) => SmartEventScreen(request: next),
+          ),
+        );
+      },
+      itemBuilder:
+          (context) => options
+              .map(
+                (option) => PopupMenuItem<SmartEventRequest>(
+                  value: option,
+                  child: Text(option.displayName),
+                ),
+              )
+              .toList(growable: false),
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 6.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(16.br),
+          border: Border.all(
+            color: context.colors.textPrimary.withValues(alpha: 0.12),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(
+              child: Text(
+                request.displayName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.textMdMedium.copyWith(
+                  color: context.colors.textPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            SizedBox(width: 6.w),
+            Icon(
+              Icons.keyboard_arrow_down_rounded,
+              size: 18.ic,
+              color: context.colors.textPrimary,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -296,7 +364,7 @@ class _EmptyState extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              Icons.auto_awesome,
+              Icons.sports_esports_outlined,
               size: 40.sp,
               color: context.colors.textPrimaryMuted,
             ),
@@ -367,6 +435,7 @@ class _GamesTabState extends ConsumerState<_GamesTab> {
                   gameIds: liveGameIds,
                 );
 
+        final rows = _buildDayRows(games);
         return RefreshIndicator(
           color: kPrimaryColor,
           backgroundColor: context.colors.surface,
@@ -379,7 +448,7 @@ class _GamesTabState extends ConsumerState<_GamesTab> {
             physics: const AlwaysScrollableScrollPhysics(
               parent: BouncingScrollPhysics(),
             ),
-            itemCount: games.isEmpty ? 2 : games.length + 1,
+            itemCount: games.isEmpty ? 2 : rows.length + 1,
             itemBuilder: (context, i) {
               if (i == 0) {
                 return Padding(
@@ -400,7 +469,9 @@ class _GamesTabState extends ConsumerState<_GamesTab> {
                         context: context,
                         currentFilter: _filter,
                         showColorFilter: false,
-                        showSortSection: true,
+                        showSortSection: false,
+                        showLevelFilter: false,
+                        showYearFilter: false,
                       );
                       if (result != null && mounted) {
                         setState(() => _filter = result);
@@ -409,21 +480,37 @@ class _GamesTabState extends ConsumerState<_GamesTab> {
                   ),
                 );
               }
-              final gameIndex = i - 1;
               if (games.isEmpty) {
                 return _EmptyState();
               }
+              final row = rows[i - 1];
+              if (row.header != null) {
+                return Padding(
+                  padding: EdgeInsets.fromLTRB(2.sp, 6.sp, 2.sp, 8.sp),
+                  child: Text(
+                    row.header!,
+                    style: AppTypography.textSmBold.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                );
+              }
+              final game = row.game!;
+              final gameIndex = games.indexWhere(
+                (g) => g.gameId == game.gameId,
+              );
               return Padding(
                 padding: EdgeInsets.only(bottom: 12.sp),
                 child: GameCardWrapperWidget(
-                  key: ValueKey('smart_${games[gameIndex].gameId}'),
-                  game: games[gameIndex],
+                  key: ValueKey('smart_${game.gameId}'),
+                  game: game,
                   gamesData: gamesData,
-                  gameIndex: gameIndex,
+                  gameIndex: gameIndex < 0 ? 0 : gameIndex,
                   isChessBoardVisible: false,
                   viewSource: ChessboardView.tour,
                   onReturnFromChessboard: (_) {},
                   liveBatchKey: liveBatchKey,
+                  onBeforeOpen: () => _guardGameOpen(context),
                 ),
               );
             },
@@ -517,6 +604,60 @@ class _GamesTabState extends ConsumerState<_GamesTab> {
     };
   }
 
+  Future<bool> _guardGameOpen(BuildContext context) async {
+    if (ref.read(subscriptionProvider).isSubscribed) return true;
+    if (!context.mounted) return false;
+    return await showPremiumPaywallSheet(context: context);
+  }
+
+  List<_GameListRow> _buildDayRows(List<GamesTourModel> games) {
+    final rows = <_GameListRow>[];
+    DateTime? currentDay;
+    for (final game in games) {
+      final day = _gameDay(game);
+      if (currentDay == null || !_sameDay(currentDay, day)) {
+        currentDay = day;
+        rows.add(_GameListRow.header(_dayLabel(day)));
+      }
+      rows.add(_GameListRow.game(game));
+    }
+    return rows;
+  }
+
+  DateTime _gameDay(GamesTourModel game) {
+    final raw = game.lastMoveTime ?? game.bucketDate ?? DateTime.now();
+    final local = raw.toLocal();
+    return DateTime(local.year, local.month, local.day);
+  }
+
+  bool _sameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  String _dayLabel(DateTime day) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    if (_sameDay(day, today)) return 'Today';
+    if (_sameDay(day, today.subtract(const Duration(days: 1)))) {
+      return 'Yesterday';
+    }
+    const months = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    return '${months[day.month - 1]} ${day.day}';
+  }
+
   int _compareBySortCriterion(
     GamesTourModel a,
     GamesTourModel b,
@@ -543,6 +684,18 @@ class _GamesTabState extends ConsumerState<_GamesTab> {
         ? comparison
         : -comparison;
   }
+}
+
+class _GameListRow {
+  const _GameListRow._({this.header, this.game});
+
+  factory _GameListRow.header(String value) => _GameListRow._(header: value);
+
+  factory _GameListRow.game(GamesTourModel value) =>
+      _GameListRow._(game: value);
+
+  final String? header;
+  final GamesTourModel? game;
 }
 
 class _AboutTab extends ConsumerWidget {
@@ -572,9 +725,9 @@ class _AboutTab extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    'A live smart database that gathers the strongest games '
-                    'from every ongoing broadcast into one place, so you never '
-                    'have to switch between tournaments.',
+                    'This database gathers the strongest games from every '
+                    'ongoing broadcast into one place, so you never have to '
+                    'switch between tournaments.',
                     style: AppTypography.textSmRegular.copyWith(
                       color: context.colors.textPrimary,
                       height: 1.4,

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart
@@ -22,6 +22,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
   final Side? fixedBottomSide;
   final bool allowStockfishFallback;
   final LiveGamesBatchKey? liveBatchKey;
+  final Future<bool> Function()? onBeforeOpen;
 
   const GameCardWrapperWidget({
     super.key,
@@ -35,6 +36,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
     this.fixedBottomSide,
     this.allowStockfishFallback = true,
     this.liveBatchKey,
+    this.onBeforeOpen,
   });
 
   @override
@@ -67,20 +69,25 @@ class GameCardWrapperWidget extends ConsumerWidget {
           .togglePinGame(game.gameId, sourceTourId: game.tourId);
     }
 
+    Future<void> navigateToGame() async {
+      final allowed = await (onBeforeOpen?.call() ?? Future<bool>.value(true));
+      if (!allowed || !context.mounted) return;
+      ref
+          .read(gameCardWrapperProvider)
+          .navigateToChessBoard(
+            context: context,
+            orderedGames: getUpdatedGamesList(),
+            gameIndex: gameIndex,
+            onReturnFromChessboard: onReturnFromChessboard,
+            viewSource: viewSource,
+          );
+    }
+
     return isChessBoardVisible
         ? ChessBoardFromFENNew(
           key: ValueKey(keyValue),
           gamesTourModel: liveGame,
-          onChanged:
-              () => ref
-                  .read(gameCardWrapperProvider)
-                  .navigateToChessBoard(
-                    context: context,
-                    orderedGames: getUpdatedGamesList(),
-                    gameIndex: gameIndex,
-                    onReturnFromChessboard: onReturnFromChessboard,
-                    viewSource: viewSource,
-                  ),
+          onChanged: navigateToGame,
           pinnedIds: gamesData.pinnedGamedIs,
           onPinToggle: handlePinToggle,
           fixedBottomSide: fixedBottomSide,
@@ -96,16 +103,7 @@ class GameCardWrapperWidget extends ConsumerWidget {
           pinnedIds: gamesData.pinnedGamedIs,
           onPinToggle: handlePinToggle,
           allowStockfishFallback: allowStockfishFallback,
-          onTap:
-              () => ref
-                  .read(gameCardWrapperProvider)
-                  .navigateToChessBoard(
-                    context: context,
-                    orderedGames: getUpdatedGamesList(),
-                    gameIndex: gameIndex,
-                    onReturnFromChessboard: onReturnFromChessboard,
-                    viewSource: viewSource,
-                  ),
+          onTap: navigateToGame,
         );
   }
 }

--- a/lib/widgets/event_card/smart_event_card.dart
+++ b/lib/widgets/event_card/smart_event_card.dart
@@ -23,23 +23,17 @@ Color smartEventAccentColor(String stableKey) {
   return palette[hash % palette.length];
 }
 
-/// The "Convergence" smart-event card.
+/// Generated level-games card.
 ///
-/// A synthetic event that gathers the most interesting live games from every
-/// ongoing broadcast into one place — so the user never has to hop between
-/// tournaments. It mirrors the real [EventCard] silhouette (same size, same
-/// image-left + title + meta anatomy) so it sits natively in the For-You feed,
-/// but the rectangle is fractured into primary-tinted facets and self-brands as
-/// SMART so it reads instantly as the special, filter-driven card.
-///
-/// It is shown only when an ELO/tier filter is applied, pinned top-most.
+/// Gathers current games from active broadcasts that match the user's filter,
+/// while keeping the For You surface close to the regular event-card anatomy.
 class SmartEventCard extends StatelessWidget {
   const SmartEventCard({
     required this.tierLabel,
     required this.minElo,
     required this.liveCount,
     required this.avgElo,
-    this.titleSuffix = 'Live Games',
+    this.titleSuffix = 'Games',
     this.caption,
     this.countSingular = 'live event',
     this.countPlural = 'live events',
@@ -123,8 +117,6 @@ class SmartEventCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: context.colors.surface,
         borderRadius: BorderRadius.circular(8.br),
-        // A primary-tinted border + soft primary glow distinguishes the smart
-        // card from the plain divider/shadow of a normal event card.
         border: Border.all(
           color: accentColor.withValues(
             alpha: context.isLightTheme ? 0.45 : 0.35,
@@ -159,10 +151,10 @@ class SmartEventCard extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  _MosaicEmblem(
+                  _LevelEmblem(
+                    tierLabel: tierLabel,
                     width: imageW,
                     height: imageH,
-                    reduceMotion: reduceMotion,
                     accentColor: accentColor,
                   ),
                   SizedBox(width: 10.w),
@@ -211,7 +203,7 @@ class SmartEventCard extends StatelessWidget {
   }
 }
 
-/// Headline row: smart name + the SMART brand pill.
+/// Headline row: level name.
 class _TitleRow extends StatelessWidget {
   const _TitleRow({
     required this.tierLabel,
@@ -229,7 +221,7 @@ class _TitleRow extends StatelessWidget {
       children: [
         Flexible(
           child: Text(
-            '$tierLabel · $titleSuffix',
+            '$tierLabel $titleSuffix',
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: AppTypography.textSmMedium.copyWith(
@@ -241,42 +233,7 @@ class _TitleRow extends StatelessWidget {
           ),
         ),
         SizedBox(width: 6.w),
-        _SmartPill(accentColor: accentColor),
       ],
-    );
-  }
-}
-
-/// Solid-primary SMART badge with a spark glyph.
-class _SmartPill extends StatelessWidget {
-  const _SmartPill({required this.accentColor});
-
-  final Color accentColor;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 6.w, vertical: 2.h),
-      decoration: BoxDecoration(
-        color: accentColor,
-        borderRadius: BorderRadius.circular(5.br),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.auto_awesome, size: 10.sp, color: kBlackColor),
-          SizedBox(width: 3.w),
-          Text(
-            'SMART',
-            style: AppTypography.textXxsBold.copyWith(
-              color: kBlackColor,
-              fontSize: 9.sp,
-              letterSpacing: 0.6,
-              height: 1,
-            ),
-          ),
-        ],
-      ),
     );
   }
 }
@@ -365,7 +322,7 @@ class _FilterCaption extends StatelessWidget {
         SizedBox(width: 5.w),
         Flexible(
           child: Text(
-            caption ?? 'Gathered from your $minElo+ filter',
+            caption ?? 'From your $minElo+ filter',
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: AppTypography.textXxsMedium.copyWith(
@@ -380,69 +337,43 @@ class _FilterCaption extends StatelessWidget {
   }
 }
 
-/// The left tile: a faceted mosaic emblem with a "stacked events" hint and a
-/// central spark — the visual metaphor for many broadcasts folding into one.
-class _MosaicEmblem extends StatelessWidget {
-  const _MosaicEmblem({
+/// The left tile: a restrained level emblem with large, readable letters.
+class _LevelEmblem extends StatelessWidget {
+  const _LevelEmblem({
+    required this.tierLabel,
     required this.width,
     required this.height,
-    required this.reduceMotion,
     required this.accentColor,
   });
 
+  final String tierLabel;
   final double width;
   final double height;
-  final bool reduceMotion;
   final Color accentColor;
 
   @override
   Widget build(BuildContext context) {
-    final spark = Icon(Icons.auto_awesome, size: 22.sp, color: Colors.white);
-
-    return SizedBox(
+    return Container(
       width: width,
       height: height,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          // "Stacked events" hint: two faint offset outlines peeking behind the
-          // tile, reading as a pile of tournaments collapsed into one.
-          Positioned(top: -3, right: -3, child: _stackGhost(width, height)),
-          Positioned.fill(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(6.br),
-              child: CustomPaint(
-                painter: _MosaicTilePainter(accentColor: accentColor),
-                child: Center(
-                  child:
-                      reduceMotion
-                          ? spark
-                          : spark
-                              .animate(onPlay: (c) => c.repeat(reverse: true))
-                              .fadeIn(duration: 1200.ms)
-                              .then()
-                              .shimmer(
-                                duration: 1600.ms,
-                                color: Colors.white.withValues(alpha: 0.8),
-                              ),
-                ),
-              ),
+      decoration: BoxDecoration(
+        color: const Color(0xFF12202B),
+        borderRadius: BorderRadius.circular(6.br),
+        border: Border.all(color: accentColor.withValues(alpha: 0.45)),
+      ),
+      child: CustomPaint(
+        painter: _MosaicTilePainter(accentColor: accentColor),
+        child: Center(
+          child: Text(
+            tierLabel,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.textMdBold.copyWith(
+              color: Colors.white,
+              fontSize: 28.sp,
+              letterSpacing: 0.8,
             ),
           ),
-        ],
-      ),
-    );
-  }
-
-  Widget _stackGhost(double w, double h) {
-    return Container(
-      width: w,
-      height: h,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(6.br),
-        border: Border.all(
-          color: accentColor.withValues(alpha: 0.35),
-          width: 1,
         ),
       ),
     );

--- a/lib/widgets/game_filter/game_filter_dialog.dart
+++ b/lib/widgets/game_filter/game_filter_dialog.dart
@@ -20,6 +20,8 @@ Future<GameFilter?> showGameFilterDialog({
   bool showSortSection = false,
   bool showColorFilter = true,
   bool showSortDirection = true,
+  bool showLevelFilter = true,
+  bool showYearFilter = true,
 }) {
   return showAlertModal<GameFilter>(
     context: context,
@@ -31,6 +33,8 @@ Future<GameFilter?> showGameFilterDialog({
       showSortSection: showSortSection,
       showColorFilter: showColorFilter,
       showSortDirection: showSortDirection,
+      showLevelFilter: showLevelFilter,
+      showYearFilter: showYearFilter,
     ),
   );
 }
@@ -44,6 +48,8 @@ class GameFilterDialog extends StatefulWidget {
     this.showSortSection = false,
     this.showColorFilter = true,
     this.showSortDirection = true,
+    this.showLevelFilter = true,
+    this.showYearFilter = true,
   });
 
   final GameFilter initialFilter;
@@ -55,6 +61,8 @@ class GameFilterDialog extends StatefulWidget {
   // both (defaults true).
   final bool showColorFilter;
   final bool showSortDirection;
+  final bool showLevelFilter;
+  final bool showYearFilter;
 
   @override
   State<GameFilterDialog> createState() => _GameFilterDialogState();
@@ -172,16 +180,18 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                     SizedBox(height: 20.h),
 
                     // 3. Level
-                    _sectionLabel('Level'),
-                    SizedBox(height: 8.h),
-                    RatingTierFilter(
-                      selectedMinRating: _selectedMinRating,
-                      onChanged: (value) {
-                        HapticFeedbackService.selection();
-                        setState(() => _selectedMinRating = value);
-                      },
-                    ),
-                    SizedBox(height: 20.h),
+                    if (widget.showLevelFilter) ...[
+                      _sectionLabel('Level'),
+                      SizedBox(height: 8.h),
+                      RatingTierFilter(
+                        selectedMinRating: _selectedMinRating,
+                        onChanged: (value) {
+                          HapticFeedbackService.selection();
+                          setState(() => _selectedMinRating = value);
+                        },
+                      ),
+                      SizedBox(height: 20.h),
+                    ],
 
                     // 4. Result (box grid)
                     _sectionLabel('Result'),
@@ -241,17 +251,19 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                     ],
 
                     // 7. Year range
-                    _sectionLabel('Year'),
-                    SizedBox(height: 8.h),
-                    _rangeSliderCard(
-                      values: _yearRange,
-                      min: GameFilter.absoluteMinYear.toDouble(),
-                      max: DateTime.now().year.toDouble(),
-                      divisions:
-                          DateTime.now().year - GameFilter.absoluteMinYear,
-                      onChanged: (v) => setState(() => _yearRange = v),
-                    ),
-                    SizedBox(height: 12.h),
+                    if (widget.showYearFilter) ...[
+                      _sectionLabel('Year'),
+                      SizedBox(height: 8.h),
+                      _rangeSliderCard(
+                        values: _yearRange,
+                        min: GameFilter.absoluteMinYear.toDouble(),
+                        max: DateTime.now().year.toDouble(),
+                        divisions:
+                            DateTime.now().year - GameFilter.absoluteMinYear,
+                        onChanged: (v) => setState(() => _yearRange = v),
+                      ),
+                      SizedBox(height: 12.h),
+                    ],
                   ],
                 ),
               ),
@@ -355,9 +367,16 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
       timeControl: _timeControl,
       online: _online,
       live: _live,
-      minYear: _yearRange.start.round(),
-      maxYear: _yearRange.end.round(),
-      minRating: _selectedMinRating ?? GameFilter.defaultMinRating,
+      minYear:
+          widget.showYearFilter
+              ? _yearRange.start.round()
+              : GameFilter.defaultMinYear,
+      maxYear:
+          widget.showYearFilter ? _yearRange.end.round() : DateTime.now().year,
+      minRating:
+          widget.showLevelFilter
+              ? _selectedMinRating ?? GameFilter.defaultMinRating
+              : GameFilter.defaultMinRating,
       maxRating: GameFilter.absoluteMaxRating,
       sorts: widget.showSortSection ? _sorts : const [],
     );

--- a/test/smart_event_provider_test.dart
+++ b/test/smart_event_provider_test.dart
@@ -67,7 +67,7 @@ void main() {
   });
 
   group('SmartEventRequest favorite metadata', () {
-    test('round-trips saved smart events through favorite metadata', () {
+    test('round-trips saved level games through favorite metadata', () {
       final event = _event(
         id: 'event-a',
         start: DateTime.utc(2026, 6, 1),
@@ -76,10 +76,10 @@ void main() {
       final request = SmartEventRequest(
         source: SmartEventSource.forYou,
         tierLabel: 'GM',
-        titleSuffix: 'Live Games',
+        titleSuffix: 'Games',
         minElo: 2500,
         maxElo: 3200,
-        caption: 'Gathered from your 2500+ filter',
+        caption: 'From your 2500+ filter',
         countSingular: 'live event',
         countPlural: 'live events',
         events: [event],
@@ -101,16 +101,18 @@ void main() {
       expect(restored.minElo, 2500);
       expect(restored.maxElo, 3200);
       expect(restored.events.single.id, 'event-a');
+      expect(restored.displayName, 'GM Games');
+      expect(restored.caption, 'From your 2500+ filter');
     });
 
     test(
-      'reports saved smart event finished when all events are completed',
+      'reports saved level games finished when all events are completed',
       () {
         final now = DateTime.now();
         final request = SmartEventRequest(
           source: SmartEventSource.forYou,
           tierLabel: 'GM',
-          titleSuffix: 'Live Games',
+          titleSuffix: 'Games',
           minElo: 2500,
           maxElo: 3200,
           caption: 'Saved',
@@ -132,12 +134,12 @@ void main() {
       },
     );
 
-    test('reports saved smart event inactive when no event is current', () {
+    test('reports saved level games inactive when no event is current', () {
       final now = DateTime.now();
       final request = SmartEventRequest(
         source: SmartEventSource.current,
         tierLabel: 'GM',
-        titleSuffix: 'Live Games',
+        titleSuffix: 'Games',
         minElo: 2500,
         maxElo: 3200,
         caption: 'Saved',


### PR DESCRIPTION
## Summary
- rename generated game cards from Smart/Live wording to GM/IM/FM/CM/All Games language
- update save/remove confirmations to mention the selected Games title and For You only
- keep About/Players tabs intact while changing the About intro copy to start with "This database..."
- group games by day and sort each day by pinned first, then average rating descending
- hide level/year filters inside the generated games page, keep time-control filtering, and gate game open with the premium paywall

## Tests
- flutter analyze --no-pub lib/screens/group_event/smart_event/smart_aggregate_event_provider.dart lib/screens/group_event/smart_event/smart_event_screen.dart lib/widgets/event_card/smart_event_card.dart lib/widgets/game_filter/game_filter_dialog.dart lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_widget.dart lib/screens/group_event/widget/for_you_games_widget.dart lib/screens/group_event/group_event_screen.dart
- flutter test --no-pub test/smart_event_provider_test.dart

## Trello
- https://trello.com/c/65Mz9n3B