### PR TITLE
fix: adjust phone live widget notification defaults

### DIFF
--- a/lib/providers/board_settings_provider_new.dart
+++ b/lib/providers/board_settings_provider_new.dart
@@ -37,8 +37,8 @@ class BoardSettingsNew {
         true, // Use chess piece symbols (♔♕♖♗♘) instead of letters
     this.showCoordinates = true,
     this.rawPgnMode = false,
-    this.pipModeIndex = 0, // PipMode.off (default)
-    this.liveActivityModeIndex = 0, // LiveActivityMode.off (default)
+    this.pipModeIndex = 1, // PipMode.live (default)
+    this.liveActivityModeIndex = 1, // LiveActivityMode.live (default)
   });
 
   /// DEPRECATED: Kept for backwards compatibility migration only
@@ -67,14 +67,14 @@ class BoardSettingsNew {
   final bool rawPgnMode;
 
   /// Picture-in-Picture eligibility, stored as the PipMode index
-  /// (0=off, 1=completed, 2=live, 3=both). Premium-gated.
+  /// (0=off, 1=live).
   final int pipModeIndex;
 
   /// Picture-in-Picture mode as an enum.
   PipMode get pipMode => PipModeInfo.fromIndex(pipModeIndex);
 
   /// Live Activity / live-notification eligibility, stored as the
-  /// LiveActivityMode index (0=off, 1=live, 2=all).
+  /// LiveActivityMode index (0=off, 1=live).
   final int liveActivityModeIndex;
 
   /// Live Activity mode as an enum.
@@ -246,8 +246,11 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         rawPgnMode: model.rawPgnMode,
         // pip_mode isn't part of BoardSettingsModel's mapper; read it straight
         // from the row so we don't need to regenerate the dart_mappable code.
-        pipModeIndex: (response['pip_mode'] as int?) ?? 0,
-        liveActivityModeIndex: (response['live_activity_mode'] as int?) ?? 0,
+        // Older rows without live-widget preferences should start on live games.
+        pipModeIndex: (response['pip_mode'] as int?) ?? PipMode.live.index,
+        liveActivityModeIndex:
+            (response['live_activity_mode'] as int?) ??
+            LiveActivityMode.live.index,
       );
 
       // Cache locally
@@ -390,9 +393,7 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
   Future<void> toggleShowCoordinates(bool value) async {
     final currentState = state.valueOrNull ?? const BoardSettingsNew();
     final newSettings = currentState.copyWith(showCoordinates: value);
-    debugPrint(
-      '🔤 BoardSettings: Coordinates ${value ? 'shown' : 'hidden'}',
-    );
+    debugPrint('🔤 BoardSettings: Coordinates ${value ? 'shown' : 'hidden'}');
     state = AsyncValue.data(newSettings);
     await _persist(newSettings);
   }
@@ -535,8 +536,9 @@ class BoardSettingsNotifierNew extends AsyncNotifier<BoardSettingsNew> {
         useFigurine: map['useFigurine'] as bool? ?? true,
         showCoordinates: map['showCoordinates'] as bool? ?? true,
         rawPgnMode: map['rawPgnMode'] as bool? ?? false,
-        pipModeIndex: map['pipModeIndex'] as int? ?? 0,
-        liveActivityModeIndex: map['liveActivityModeIndex'] as int? ?? 0,
+        pipModeIndex: map['pipModeIndex'] as int? ?? PipMode.live.index,
+        liveActivityModeIndex:
+            map['liveActivityModeIndex'] as int? ?? LiveActivityMode.live.index,
       );
       debugPrint('[BoardSettings] Loaded settings from cache');
       return settings;

--- a/lib/providers/live_activity_mode_provider.dart
+++ b/lib/providers/live_activity_mode_provider.dart
@@ -1,10 +1,10 @@
 /// Which games may post a Live Activity (iOS) / live notification (Android).
 ///
 /// Persisted in board settings (`user_engine_settings.live_activity_mode`,
-/// synced). Enum order is the stored integer: off=0 (default), live=1.
-/// "live" posts only while the game is ongoing. (A legacy "all"=2 value is
-/// mapped down to live by [fromIndex]; the option was removed.) Mirrors
-/// [PipMode].
+/// synced). Enum order is the stored integer: off=0, live=1 (default when no
+/// preference is stored). "live" posts only while the game is ongoing. A legacy
+/// "all"=2 value is mapped down to live by [fromIndex]; the option was removed.
+/// Mirrors [PipMode].
 enum LiveActivityMode { off, live }
 
 extension LiveActivityModeInfo on LiveActivityMode {
@@ -14,8 +14,11 @@ extension LiveActivityModeInfo on LiveActivityMode {
   };
 
   static LiveActivityMode fromIndex(int? index) {
-    if (index == null || index < 0) {
-      return LiveActivityMode.off; // default: off (opt-in only)
+    if (index == null) {
+      return LiveActivityMode.live;
+    }
+    if (index < 0) {
+      return LiveActivityMode.off;
     }
     // Legacy "all" (2) collapses to live now that the option is gone.
     if (index >= LiveActivityMode.values.length) return LiveActivityMode.live;

--- a/lib/providers/notification_preferences_provider.dart
+++ b/lib/providers/notification_preferences_provider.dart
@@ -16,7 +16,7 @@ class NotificationPreferences {
   final bool dailyDigest;
   final bool callToActionAlerts;
   final bool bookUpdateAlerts;
-  // Favourite Players time-control filters (opt-out — default true)
+  // Favourite Players time-control filters (opt-out; blitz defaults off)
   final bool fpClassical;
   final bool fpRapid;
   final bool fpBlitz;
@@ -88,7 +88,7 @@ class NotificationPreferences {
     bookUpdateAlerts: true,
     fpClassical: true,
     fpRapid: true,
-    fpBlitz: true,
+    fpBlitz: false,
     seClassical: true,
     seRapid: true,
     seBlitz: true,

--- a/lib/providers/pip_mode_provider.dart
+++ b/lib/providers/pip_mode_provider.dart
@@ -2,8 +2,9 @@
 ///
 /// Persisted in board settings (`user_engine_settings.pip_mode`, synced) and
 /// premium-gated at the eligibility check + settings UI. Enum order is the
-/// stored integer: off=0 (default), live=1. (A legacy "all"=2 value is mapped
-/// down to live by [fromIndex]; the option was removed.)
+/// stored integer: off=0, live=1 (default when no preference is stored). A
+/// legacy "all"=2 value is mapped down to live by [fromIndex]; the option was
+/// removed.
 enum PipMode { off, live }
 
 extension PipModeInfo on PipMode {
@@ -13,8 +14,11 @@ extension PipModeInfo on PipMode {
   };
 
   static PipMode fromIndex(int? index) {
-    if (index == null || index < 0) {
-      return PipMode.off; // default: off (opt-in only)
+    if (index == null) {
+      return PipMode.live;
+    }
+    if (index < 0) {
+      return PipMode.off;
     }
     // Legacy "all" (2) collapses to live now that the option is gone.
     if (index >= PipMode.values.length) return PipMode.live;

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -1579,7 +1579,7 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
   bool _isPipEligible(GamesTourModel game) {
     // PiP is free for everyone; eligibility depends only on the chosen mode.
     final mode =
-        ref.read(boardSettingsProviderNew).valueOrNull?.pipMode ?? PipMode.off;
+        ref.read(boardSettingsProviderNew).valueOrNull?.pipMode ?? PipMode.live;
     switch (mode) {
       case PipMode.off:
         return false;
@@ -1921,7 +1921,7 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     // Live Activity mode gate (off / live / all), mirrors PiP.
     final boardSettings = ref.read(boardSettingsProviderNew).valueOrNull;
     final liveActivityMode =
-        boardSettings?.liveActivityMode ?? LiveActivityMode.off;
+        boardSettings?.liveActivityMode ?? LiveActivityMode.live;
     if (liveActivityMode == LiveActivityMode.off) return;
 
     final isOngoing = game.gameStatus.isOngoing;

--- a/lib/services/push_notifications_service.dart
+++ b/lib/services/push_notifications_service.dart
@@ -42,18 +42,21 @@ class PushNotificationsService {
     await LiveUpdatesService.instance.setup();
 
     // Apply opt-in state based on local preference and current OS permission.
-    // This prevents release builds from forcing users into opt-out when iOS
-    // permission is already granted but no local preference exists yet.
+    // Missing local preference means the app default is ON: new users should be
+    // eligible for push/live updates as soon as OS permission is granted. Only an
+    // explicit in-app opt-out should call OneSignal optOut().
     final hasPermission = OneSignal.Notifications.permission;
     final storedEnabled = await _loadLocalEnabledNullable();
+    final enabledByDefault = storedEnabled ?? true;
 
-    if (storedEnabled == null && hasPermission) {
+    if (storedEnabled == null) {
       await _persistLocalEnabled(true);
       await _syncPreferenceToSupabase(true);
+    }
+
+    if (enabledByDefault && hasPermission) {
       OneSignal.User.pushSubscription.optIn();
-    } else if (storedEnabled == true && hasPermission) {
-      OneSignal.User.pushSubscription.optIn();
-    } else {
+    } else if (!enabledByDefault) {
       OneSignal.User.pushSubscription.optOut();
     }
 
@@ -184,7 +187,7 @@ class PushNotificationsService {
   }
 
   Future<bool> _loadLocalEnabled() async {
-    return await _loadLocalEnabledNullable() ?? false;
+    return await _loadLocalEnabledNullable() ?? true;
   }
 
   Future<bool?> _loadLocalEnabledNullable() async {
@@ -248,7 +251,7 @@ class PushNotificationsService {
               'book_update_alerts': true,
               'fp_classical': true,
               'fp_rapid': true,
-              'fp_blitz': true,
+              'fp_blitz': false,
               'se_classical': true,
               'se_rapid': true,
               'se_blitz': true,

--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -1105,6 +1105,26 @@ function normaliseTimeControl(
   return null;
 }
 
+function inferTimeControlFromText(
+  raw: string | null | undefined,
+): "classical" | "rapid" | "blitz" | null {
+  if (!raw) return null;
+  const text = raw.trim().toLowerCase();
+  if (!text) return null;
+
+  // Chess.com Titled Tuesday rows have historically arrived without a reliable
+  // tours.time_class value. It is always a blitz event, and failing open here
+  // bypasses users who explicitly disabled favourite-player blitz alerts.
+  if (text.includes("titled tuesday") || text.includes("titled-tuesday")) {
+    return "blitz";
+  }
+
+  if (/\b(bullet|blitz|speed chess)\b/.test(text)) return "blitz";
+  if (/\brapid\b/.test(text)) return "rapid";
+  if (/\b(classical|standard)\b/.test(text)) return "classical";
+  return null;
+}
+
 // Fetch the time-control class for a tour. Returns null when unknown so that
 // the preference filter is skipped (fail-open — users always get the push).
 async function resolveGameTimeControl(
@@ -1114,10 +1134,12 @@ async function resolveGameTimeControl(
   try {
     const { data } = await supabase
       .from("tours")
-      .select("time_class")
+      .select("time_class,name,slug")
       .eq("id", tourId)
       .maybeSingle();
-    return normaliseTimeControl(data?.time_class as string | null);
+    return normaliseTimeControl(data?.time_class as string | null) ??
+      inferTimeControlFromText(data?.name as string | null) ??
+      inferTimeControlFromText(data?.slug as string | null);
   } catch (_) {
     // Column may not exist yet — fail-open.
     return null;

--- a/test/notification_defaults_test.dart
+++ b/test/notification_defaults_test.dart
@@ -1,0 +1,28 @@
+import 'package:chessever2/providers/board_settings_provider_new.dart';
+import 'package:chessever2/providers/live_activity_mode_provider.dart';
+import 'package:chessever2/providers/notification_preferences_provider.dart';
+import 'package:chessever2/providers/pip_mode_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('phone notification defaults', () {
+    test('keeps favorite player blitz alerts off by default', () {
+      expect(NotificationPreferences.defaults.favoritePlayerAlerts, isTrue);
+      expect(NotificationPreferences.defaults.fpClassical, isTrue);
+      expect(NotificationPreferences.defaults.fpRapid, isTrue);
+      expect(NotificationPreferences.defaults.fpBlitz, isFalse);
+    });
+
+    test('defaults live widgets to live games for new users', () {
+      const settings = BoardSettingsNew();
+
+      expect(settings.pipMode, PipMode.live);
+      expect(settings.liveActivityMode, LiveActivityMode.live);
+    });
+
+    test('missing persisted live widget modes use live game defaults', () {
+      expect(PipModeInfo.fromIndex(null), PipMode.live);
+      expect(LiveActivityModeInfo.fromIndex(null), LiveActivityMode.live);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Keeps favorite-player blitz alerts off by default while leaving favorite-player classical/rapid alerts on.
- Defaults PiP and Live Activity modes to live games when no stored preference exists.
- Ensures Titled Tuesday still resolves as blitz in the OneSignal dispatch path when `tours.time_class` is missing, so users who turned off favorite-player blitz alerts do not receive Titled Tuesday pushes just because a favorite player is playing.
- Adds focused defaults coverage for notification preferences and live-widget modes.

## Test Plan
- `flutter test --no-pub test/notification_defaults_test.dart`
- `flutter analyze --no-pub lib/providers/notification_preferences_provider.dart lib/providers/pip_mode_provider.dart lib/providers/live_activity_mode_provider.dart lib/providers/board_settings_provider_new.dart lib/services/push_notifications_service.dart test/notification_defaults_test.dart`
- `npx -y deno check supabase/functions/onesignal-dispatch/index.ts`
- `node` heuristic smoke check for Titled Tuesday / slug / rapid / classical inference cases
- `git diff --check`

## Notes
- `npx -y deno fmt --check supabase/functions/onesignal-dispatch/index.ts` still reports pre-existing repo-wide formatting churn in this legacy Edge Function; I did not commit broad formatter noise.
- Base: `release/19.7-live-activity-pip` for the current live Activity/PiP release line.
