### PR TITLE
Fix cramped player profile W/D/L counts

### DIFF
--- a/lib/screens/player_profile/tabs/player_about_tab.dart
+++ b/lib/screens/player_profile/tabs/player_about_tab.dart
@@ -13,6 +13,7 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/country_utils.dart';
 import 'package:chessever2/utils/png_asset.dart';
+import 'package:chessever2/utils/number_format_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/string_utils.dart';
 import 'package:chessever2/utils/user_error_message.dart';
@@ -1476,23 +1477,7 @@ class _OverallStatsSection extends StatelessWidget {
                     ),
                   ),
                   Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Text(
-                          '${resultStats.wins}W / ${resultStats.draws}D / ${resultStats.losses}L',
-                          style: AppTypography.textSmMedium.copyWith(
-                            color: context.colors.textPrimary,
-                          ),
-                        ),
-                        Text(
-                          'W / D / L',
-                          style: AppTypography.textXsRegular.copyWith(
-                            color: context.colors.textPrimary.withValues(alpha: 0.5),
-                          ),
-                        ),
-                      ],
-                    ),
+                    child: _ResultCountTriplet(resultStats: resultStats),
                   ),
                   if (avgOpponentRating > 0)
                     Expanded(
@@ -1521,6 +1506,66 @@ class _OverallStatsSection extends StatelessWidget {
         ),
       ],
     ).animate().fadeIn(duration: 300.ms, delay: 100.ms);
+  }
+}
+
+class _ResultCountTriplet extends StatelessWidget {
+  const _ResultCountTriplet({required this.resultStats});
+
+  final ResultStatistics resultStats;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _ResultCountColumn(
+          value: formatTightStatCount(resultStats.wins),
+          label: 'W',
+        ),
+        _ResultCountColumn(
+          value: formatTightStatCount(resultStats.draws),
+          label: 'D',
+        ),
+        _ResultCountColumn(
+          value: formatTightStatCount(resultStats.losses),
+          label: 'L',
+        ),
+      ],
+    );
+  }
+}
+
+class _ResultCountColumn extends StatelessWidget {
+  const _ResultCountColumn({required this.value, required this.label});
+
+  final String value;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              value,
+              maxLines: 1,
+              style: AppTypography.textSmMedium.copyWith(
+                color: context.colors.textPrimary,
+              ),
+            ),
+          ),
+          Text(
+            label,
+            style: AppTypography.textXsRegular.copyWith(
+              color: context.colors.textPrimary.withValues(alpha: 0.5),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/utils/number_format_utils.dart
+++ b/lib/utils/number_format_utils.dart
@@ -28,3 +28,31 @@ String formatCompactCount(int count) {
 
   return _decimalCountFormatter.format(count);
 }
+
+/// Formats tight player stat counts for narrow mobile dashboard columns.
+///
+/// W/D/L counts stay exact while they fit comfortably, then switch to compact
+/// K notation at 10,000+ where exact comma values become cramped.
+///
+/// Examples:
+///   2323   → "2,323"
+///   8250   → "8,250"
+///   10000  → "10.0K"
+///   10149  → "10.1K"
+///   12953  → "13.0K"
+///   100000 → "100K"
+String formatTightStatCount(int count) {
+  if (count < 10000) {
+    return _decimalCountFormatter.format(count);
+  }
+
+  if (count < 100000) {
+    return '${(count / 1000).toStringAsFixed(1)}K';
+  }
+
+  if (count < 1000000) {
+    return '${(count / 1000).round()}K';
+  }
+
+  return formatCompactCount(count);
+}

--- a/test/number_format_utils_test.dart
+++ b/test/number_format_utils_test.dart
@@ -1,0 +1,24 @@
+import 'package:chessever2/utils/number_format_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('formatTightStatCount', () {
+    test('keeps exact comma counts below 10k', () {
+      expect(formatTightStatCount(828), '828');
+      expect(formatTightStatCount(2323), '2,323');
+      expect(formatTightStatCount(8250), '8,250');
+    });
+
+    test('uses one-decimal K for five-digit counts', () {
+      expect(formatTightStatCount(10000), '10.0K');
+      expect(formatTightStatCount(10149), '10.1K');
+      expect(formatTightStatCount(11520), '11.5K');
+      expect(formatTightStatCount(12953), '13.0K');
+    });
+
+    test('uses whole K for 100k+ counts', () {
+      expect(formatTightStatCount(100000), '100K');
+      expect(formatTightStatCount(250400), '250K');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- replace the cramped `2323W / 828D / 1078L` profile stat string with three equal W/D/L columns
- keep exact comma-formatted counts below 10,000 and switch to compact K notation at 10,000+
- add formatter coverage for the mobile stat display thresholds

## Validation
- `flutter test test/number_format_utils_test.dart`
- `flutter analyze lib/utils/number_format_utils.dart lib/screens/player_profile/tabs/player_about_tab.dart test/number_format_utils_test.dart`

## Context
Requested from Vasif's phone profile screenshot: percentages are already shown above, so W/D/L counts should be compact and future-proof for larger numbers.