### PR TITLE
Replace player games event star with collapse toggle

### DIFF
--- a/lib/screens/player_profile/tabs/player_games_tab.dart
+++ b/lib/screens/player_profile/tabs/player_games_tab.dart
@@ -88,9 +88,19 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
   bool _liveCardsPausedForScroll = false;
   late final StateController<Set<String>> _liveGameCardsPauseReasons;
   final Set<String> _selectedGameIds = <String>{};
+  final Set<String> _collapsedEventKeys = <String>{};
   static const Duration _scrollIdleDelay = Duration(milliseconds: 180);
 
   String get _liveCardsPauseReason => 'player_games_scroll_$hashCode';
+
+  void _toggleEventCollapsed(String eventKey) {
+    HapticFeedback.lightImpact();
+    setState(() {
+      if (!_collapsedEventKeys.add(eventKey)) {
+        _collapsedEventKeys.remove(eventKey);
+      }
+    });
+  }
   // Keep rendering while backgrounded so the OS app-switcher snapshot is not
   // blank. Route coverage still removes the tab from active provider work.
   bool get _isActiveOnScreen => _routeIsCurrent;
@@ -1225,9 +1235,14 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
           playerScore: playerScore,
           site: eventData?.site ?? siteFromPgn(eventGames.first.pgn),
           isFirstEvent: isFirstEvent,
+          isCollapsed: _collapsedEventKeys.contains(tourId),
         ),
       );
       isFirstEvent = false;
+
+      if (_collapsedEventKeys.contains(tourId)) {
+        continue;
+      }
 
       // Games under this event
       if (isGridMode) {
@@ -1331,6 +1346,8 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
           site: entry.site,
           gameCount: entry.gameCount,
           playerScore: entry.playerScore,
+          isCollapsed: entry.isCollapsed,
+          onToggleCollapsed: () => _toggleEventCollapsed(entry.tourId),
         ),
       );
     }
@@ -1863,6 +1880,7 @@ class _PlayerEventHeaderEntry extends _PlayerGamesListEntry {
     required this.playerScore,
     required this.site,
     required this.isFirstEvent,
+    required this.isCollapsed,
   });
 
   final PlayerEventData? eventData;
@@ -1872,6 +1890,7 @@ class _PlayerEventHeaderEntry extends _PlayerGamesListEntry {
   final double playerScore;
   final String? site;
   final bool isFirstEvent;
+  final bool isCollapsed;
 }
 
 class _PlayerGridRowEntry extends _PlayerGamesListEntry {
@@ -1916,6 +1935,38 @@ class _PlayerCardGameEntry extends _PlayerGamesListEntry {
 
 class _PlayerPaginationFooterEntry extends _PlayerGamesListEntry {
   const _PlayerPaginationFooterEntry();
+}
+
+class _PlayerEventCollapseToggle extends StatelessWidget {
+  const _PlayerEventCollapseToggle({
+    required this.isCollapsed,
+    required this.onTap,
+  });
+
+  final bool isCollapsed;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: isCollapsed ? 'Expand event games' : 'Collapse event games',
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8.br),
+        onTap: onTap,
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(4.w, 4.h, 0, 4.h),
+          child: Icon(
+            isCollapsed
+                ? Icons.keyboard_arrow_down_rounded
+                : Icons.keyboard_arrow_up_rounded,
+            size: 18.sp,
+            color: context.colors.textPrimary.withValues(alpha: 0.65),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _SelectionActionButton extends StatelessWidget {
@@ -1998,6 +2049,8 @@ class _EventSection extends ConsumerWidget {
     this.site,
     required this.gameCount,
     required this.playerScore,
+    required this.isCollapsed,
+    required this.onToggleCollapsed,
   });
 
   final PlayerEventData? eventData;
@@ -2007,6 +2060,8 @@ class _EventSection extends ConsumerWidget {
   final String? site;
   final int gameCount;
   final double playerScore;
+  final bool isCollapsed;
+  final VoidCallback onToggleCollapsed;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -2026,6 +2081,10 @@ class _EventSection extends ConsumerWidget {
       heroTagSuffix: '_player_games_$tourId',
       crossAxisAlignment: CrossAxisAlignment.stretch,
       onTap: (displayCard) => _navigateToEvent(context, ref, displayCard),
+      trailingWidget: _PlayerEventCollapseToggle(
+        isCollapsed: isCollapsed,
+        onTap: onToggleCollapsed,
+      ),
       statsRow: _buildStatsRow(context),
     );
   }

--- a/lib/screens/player_profile/tabs/player_games_tab.dart
+++ b/lib/screens/player_profile/tabs/player_games_tab.dart
@@ -101,6 +101,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
       }
     });
   }
+
   // Keep rendering while backgrounded so the OS app-switcher snapshot is not
   // blank. Route coverage still removes the tab from active provider work.
   bool get _isActiveOnScreen => _routeIsCurrent;

--- a/lib/screens/player_profile/widgets/player_profile_resolved_event_card.dart
+++ b/lib/screens/player_profile/widgets/player_profile_resolved_event_card.dart
@@ -12,6 +12,7 @@ class PlayerProfileResolvedEventCard extends ConsumerWidget {
     required this.heroTagSuffix,
     required this.onTap,
     required this.statsRow,
+    this.trailingWidget,
     this.crossAxisAlignment = CrossAxisAlignment.center,
   });
 
@@ -20,6 +21,7 @@ class PlayerProfileResolvedEventCard extends ConsumerWidget {
   final String heroTagSuffix;
   final ValueChanged<GroupEventCardModel> onTap;
   final Widget statsRow;
+  final Widget? trailingWidget;
   final CrossAxisAlignment crossAxisAlignment;
 
   @override
@@ -38,6 +40,7 @@ class PlayerProfileResolvedEventCard extends ConsumerWidget {
             fallbackCard: fallbackCard,
             resolvedCard: resolvedCard,
             heroTagSuffix: heroTagSuffix,
+            trailingWidget: trailingWidget,
           ),
           statsRow,
         ],
@@ -51,11 +54,13 @@ class _ResolvedEventCardFade extends StatelessWidget {
     required this.fallbackCard,
     required this.resolvedCard,
     required this.heroTagSuffix,
+    required this.trailingWidget,
   });
 
   final GroupEventCardModel fallbackCard;
   final GroupEventCardModel? resolvedCard;
   final String heroTagSuffix;
+  final Widget? trailingWidget;
 
   @override
   Widget build(BuildContext context) {
@@ -69,6 +74,7 @@ class _ResolvedEventCardFade extends StatelessWidget {
           tourEventCardModel: fallbackCard,
           heroTagSuffix: heroTagSuffix,
           forceCompactLayout: true,
+          trailingWidget: trailingWidget,
         ),
         if (resolved != null)
           Positioned.fill(
@@ -85,6 +91,7 @@ class _ResolvedEventCardFade extends StatelessWidget {
                   tourEventCardModel: resolved,
                   heroTagSuffix: heroTagSuffix,
                   forceCompactLayout: true,
+                  trailingWidget: trailingWidget,
                 ),
               ),
             ),

--- a/lib/widgets/event_card/event_card.dart
+++ b/lib/widgets/event_card/event_card.dart
@@ -33,6 +33,10 @@ class EventCard extends ConsumerWidget {
   final bool showHeartIndicator;
   final EventFavoritePlayersSource favoritePlayersSource;
 
+  /// Overrides the right-side star affordance for surfaces that use EventCard
+  /// as a section header rather than an event-favorite entry point.
+  final Widget? trailingWidget;
+
   /// Optional suffix to make hero tag unique when same event appears in multiple lists
   final String? heroTagSuffix;
 
@@ -48,6 +52,7 @@ class EventCard extends ConsumerWidget {
     this.onTap,
     this.showHeartIndicator = false,
     this.favoritePlayersSource = EventFavoritePlayersSource.automatic,
+    this.trailingWidget,
     this.heroTagSuffix,
     this.forceCompactLayout = false,
     super.key,
@@ -185,12 +190,13 @@ class EventCard extends ConsumerWidget {
                         onLight: true,
                       ),
                     ),
-                    // Star icon
-                    _StarWidget(
-                      tourEventCardModel: tourEventCardModel,
-                      showHeartIndicator: showHeartIndicator,
-                      favoritePlayersSource: favoritePlayersSource,
-                    ),
+                    // Right-side action (favorite star by default).
+                    trailingWidget ??
+                        _StarWidget(
+                          tourEventCardModel: tourEventCardModel,
+                          showHeartIndicator: showHeartIndicator,
+                          favoritePlayersSource: favoritePlayersSource,
+                        ),
                   ],
                 ),
                 _NextRoundLine(
@@ -294,13 +300,15 @@ class EventCard extends ConsumerWidget {
               ),
             ),
 
-            // Star icon on the right — relies on its own horizontal padding
-            // for spacing, which keeps more room for title/meta to breathe.
-            _StarWidget(
-              tourEventCardModel: tourEventCardModel,
-              showHeartIndicator: showHeartIndicator,
-              favoritePlayersSource: favoritePlayersSource,
-            ),
+            // Right-side action (favorite star by default). The player Games
+            // tab overrides this with a smaller collapse affordance so the
+            // title/meta line keeps more breathing room.
+            trailingWidget ??
+                _StarWidget(
+                  tourEventCardModel: tourEventCardModel,
+                  showHeartIndicator: showHeartIndicator,
+                  favoritePlayersSource: favoritePlayersSource,
+                ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- Replaces the Player Profile → Games event-card favorite star with a compact expand/collapse chevron.
- Collapses an event section by hiding only that event's game rows/grid; the event card and existing bottom stats row stay visible.
- Keeps the existing bottom-right player score (for example `6.5/10`) and bottom-left game count unchanged.

## Validation
- `flutter analyze --no-pub lib/widgets/event_card/event_card.dart lib/screens/player_profile/widgets/player_profile_resolved_event_card.dart lib/screens/player_profile/tabs/player_games_tab.dart`
- `flutter test --no-pub test/twic_event_identity_test.dart`
- `git diff --check`

## QA
- On Player Profile → Games, tap the new chevron on an event card.
- Expanded state should show the games and an up chevron.
- Collapsed state should hide that event's games and show a down chevron.
- Tapping the rest of the event card should still open the event.
