### PR TITLE
fix: link mobile Desktop menu to desktop page

### DIFF
--- a/lib/widgets/hamburger_menu/hamburger_menu.dart
+++ b/lib/widgets/hamburger_menu/hamburger_menu.dart
@@ -190,7 +190,9 @@ class HamburgerMenu extends HookConsumerWidget {
                           height: 20.h / 14.h,
                         ),
                         onPressed: () async {
-                          final uri = Uri.parse('https://chessever.com');
+                          final uri = Uri.parse(
+                            'https://chessever.com/desktop',
+                          );
                           if (await canLaunchUrl(uri)) {
                             await launchUrl(
                               uri,


### PR DESCRIPTION
## Summary
- Updates the mobile sidebar/hamburger `Desktop` item to open the dedicated Desktop landing page.
- Changes the target from `https://chessever.com` to `https://chessever.com/desktop`.

## Validation
- `dart format --set-exit-if-changed lib/widgets/hamburger_menu/hamburger_menu.dart`
- `git diff --check`
- `flutter analyze --no-pub lib/widgets/hamburger_menu/hamburger_menu.dart`

## QA
- On phone, open the sidebar and tap **Desktop**.
- Confirm it opens `https://chessever.com/desktop` in the external browser.
