### PR TITLE
fix: simplify phone analysis action menus

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -8685,8 +8685,10 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
         // (mirroring the win red tint), redrawing each king above the tint so it
         // stays visible. 0xCCADE1CD is the same mint the old squareHighlight used.
         Widget drawKingTint(Square square, PieceKind kind) {
-          final effectiveFile = widget.isFlipped ? 7 - square.file : square.file;
-          final effectiveRank = widget.isFlipped ? square.rank : 7 - square.rank;
+          final effectiveFile =
+              widget.isFlipped ? 7 - square.file : square.file;
+          final effectiveRank =
+              widget.isFlipped ? square.rank : 7 - square.rank;
           final isLightSquare = (effectiveFile + effectiveRank) % 2 == 0;
           final baseSquareColor =
               isLightSquare ? colorScheme.lightSquare : colorScheme.darkSquare;

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -10932,7 +10932,7 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
                                     ),
                                   ),
                                   SizedBox(height: 12.sp),
-                                  // Promote main variant button
+                                  // Promote button
                                   Material(
                                     color: Colors.transparent,
                                     child: InkWell(
@@ -10996,7 +10996,7 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
                                             ),
                                             SizedBox(width: 8.sp),
                                             Text(
-                                              'Promote main variant',
+                                              'Promote',
                                               style: AppTypography.textSmMedium
                                                   .copyWith(
                                                     color:
@@ -11238,7 +11238,6 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
           token.text,
           token.node?.move.san == '--',
           token.node?.isMainline ?? false,
-          _variantHeadPointerForToken(token),
         );
       },
       child: Stack(
@@ -12253,13 +12252,9 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
     String moveText,
     bool isNullMove,
     bool isMainlineMove,
-    ChessMovePointer? variantHeadOverride,
   ) async {
     final hostContext = context;
     final notifier = ref.read(chessBoardScreenProviderNew(params).notifier);
-    final variantHeadPointer =
-        variantHeadOverride ?? _variantHeadPointerForMove(pointer);
-    final canModifyVariant = variantHeadPointer != null && !isMainlineMove;
     final pointerId = NotationPointer.encode(pointer);
     final currentComment = widget.state.variationComments[pointerId] ?? '';
     final timeSpentLabel = _buildTimeSpentLabel(pointer, isMainlineMove);
@@ -12291,27 +12286,25 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
     );
 
     final actions = <_NotationActionItem>[
+      if (!isMainlineMove)
+        _NotationActionItem(
+          icon: Icons.upgrade_rounded,
+          label: 'Promote',
+          color: kPrimaryColor,
+          onSelected: (_) async {
+            await notifier.promoteBranchToMainVariant(List<Number>.of(pointer));
+          },
+        ),
       _NotationActionItem(
-        icon: Icons.delete_outline,
-        label: 'Delete from here',
-        color: kRedColor,
-        onSelected: (_) async {
-          await notifier.deleteContinuationFromPointer(
-            List<Number>.of(pointer),
-          );
-        },
-      ),
-      _NotationActionItem(
-        icon: Icons.block,
-        label: 'Add null move after',
-        color: kPrimaryColor,
-        onSelected: (_) async {
-          await notifier.insertNullMoveAfterPointer(List<Number>.of(pointer));
-        },
+        icon: Icons.add_comment_outlined,
+        label: 'Comment',
+        color: context.colors.textPrimary,
+        triggersCommentEditor: true,
+        onSelected: (_) async {},
       ),
       _NotationActionItem(
         icon: Icons.label_important_outline_rounded,
-        label: 'Annotate (!?, ±, …)',
+        label: 'Annotate (!? ± ∞ =)',
         color: const Color(0xFF22AC38),
         onSelected: (_) async {
           if (!mounted) return;
@@ -12324,36 +12317,15 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
         },
       ),
       _NotationActionItem(
-        icon: Icons.add_comment_outlined,
-        label: 'Add comment',
-        color: context.colors.textPrimary,
-        triggersCommentEditor: true,
-        onSelected: (_) async {},
+        icon: Icons.delete_outline,
+        label: 'Delete',
+        color: kRedColor,
+        onSelected: (_) async {
+          await notifier.deleteContinuationFromPointer(
+            List<Number>.of(pointer),
+          );
+        },
       ),
-      if (canModifyVariant)
-        _NotationActionItem(
-          icon: Icons.delete_forever,
-          label: 'Delete variant',
-          color: kRedColor,
-          onSelected: (_) async {
-            final snapshot = notifier.navigatorStateSnapshot();
-            await notifier.deleteVariationAtPointer(
-              List<Number>.of(variantHeadPointer),
-            );
-            if (!context.mounted) return;
-            final currentContext = context;
-            if (snapshot != null) {
-              _showUndoSnackBar(
-                currentContext,
-                params,
-                snapshot,
-                'Variant removed',
-              );
-            } else {
-              _showInfoSnack(currentContext, 'Variant removed');
-            }
-          },
-        ),
       // if (canModifyVariant)
       //   _NotationActionItem(
       //     icon: Icons.trending_up_rounded,
@@ -12365,15 +12337,6 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
       //       );
       //     },
       //   ),
-      if (!isMainlineMove)
-        _NotationActionItem(
-          icon: Icons.upgrade_rounded,
-          label: 'Promote main variant',
-          color: kPrimaryColor,
-          onSelected: (_) async {
-            await notifier.promoteBranchToMainVariant(List<Number>.of(pointer));
-          },
-        ),
     ];
 
     final hasExpandedOptions = actions.length > 3;
@@ -12440,15 +12403,25 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
     );
     final actions = <_NotationActionItem>[
       _NotationActionItem(
+        icon: Icons.upgrade_rounded,
+        label: 'Promote',
+        color: kPrimaryColor,
+        onSelected: (_) async {
+          await notifier.promoteBranchToMainVariant(
+            List<Number>.of(headPointer),
+          );
+        },
+      ),
+      _NotationActionItem(
         icon: Icons.add_comment_outlined,
-        label: 'Add comment',
+        label: 'Comment',
         color: context.colors.textPrimary,
         onSelected: (_) async {},
         triggersCommentEditor: true,
       ),
       _NotationActionItem(
         icon: Icons.delete_forever,
-        label: 'Delete variant',
+        label: 'Delete',
         color: kRedColor,
         onSelected: (_) async {
           final snapshot = notifier.navigatorStateSnapshot();
@@ -12465,16 +12438,6 @@ class _MovesDisplayState extends ConsumerState<_MovesDisplay> {
           } else {
             _showInfoSnack(currentContext, 'Variation removed');
           }
-        },
-      ),
-      _NotationActionItem(
-        icon: Icons.upgrade_rounded,
-        label: 'Promote main variant',
-        color: kPrimaryColor,
-        onSelected: (_) async {
-          await notifier.promoteBranchToMainVariant(
-            List<Number>.of(headPointer),
-          );
         },
       ),
     ];
@@ -13380,10 +13343,8 @@ class _PrincipalVariationListState
             context,
             focusToken.text,
             line,
-            variantIndex,
             focusToken.moveIndex!,
             notifier,
-            activeVariantColor,
           );
         },
         child: AnimatedScale(
@@ -13883,10 +13844,8 @@ class _PrincipalVariationListState
                 context,
                 token.text,
                 line,
-                variantIndex,
                 token.moveIndex!,
                 notifier,
-                variantColor,
               );
             },
             child: Material(color: Colors.transparent, child: moveContent),
@@ -13933,26 +13892,12 @@ class _PrincipalVariationListState
     BuildContext context,
     String moveLabel,
     AnalysisLine line,
-    int variantIndex,
     int moveIndex,
     ChessBoardScreenNotifierNew notifier,
-    Color accentColor,
   ) async {
     final hostContext = context;
     final isThreatsMode = widget.state.isThreatsMode;
     final actions = <_NotationActionItem>[
-      _NotationActionItem(
-        icon: Icons.visibility_rounded,
-        label: 'Preview from here',
-        color: accentColor,
-        onSelected: (_) async {
-          notifier.previewPrincipalVariationMoveAt(
-            line,
-            variantIndex,
-            moveIndex,
-          );
-        },
-      ),
       _NotationActionItem(
         icon: Icons.playlist_add_check_circle_rounded,
         label: 'Insert entire line',
@@ -13968,6 +13913,14 @@ class _PrincipalVariationListState
         color: Colors.red,
         onSelected: (_) async {
           notifier.toggleThreatsMode();
+        },
+      ),
+      _NotationActionItem(
+        icon: Icons.block,
+        label: 'Add null move after',
+        color: kPrimaryColor,
+        onSelected: (_) async {
+          await notifier.insertNullMoveAfterPvMove(line, moveIndex);
         },
       ),
     ];

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -4084,9 +4084,7 @@ class ChessBoardScreenNotifierNew
     // the navigator sync below preserves it via copyWith otherwise.
     if (currentState.analysisState.promotionMove != null) {
       currentState = currentState.copyWith(
-        analysisState: currentState.analysisState.copyWith(
-          promotionMove: null,
-        ),
+        analysisState: currentState.analysisState.copyWith(promotionMove: null),
       );
       state = AsyncValue.data(currentState);
     }
@@ -4226,9 +4224,7 @@ class ChessBoardScreenNotifierNew
     if (currentState.analysisState.promotionMove == null) return;
     state = AsyncValue.data(
       currentState.copyWith(
-        analysisState: currentState.analysisState.copyWith(
-          promotionMove: null,
-        ),
+        analysisState: currentState.analysisState.copyWith(promotionMove: null),
       ),
     );
   }
@@ -4646,7 +4642,6 @@ class ChessBoardScreenNotifierNew
     _clearActiveEvalState();
     _updateEvaluation(force: force);
   }
-
 
   String _getSamplePgnData() {
     return '''
@@ -6894,9 +6889,7 @@ class ChessBoardScreenNotifierNew
           // through progressive opacity and arrow/head scale.
           final isThreatsMode = state.value?.isThreatsMode ?? false;
           final baseArrowColor =
-              isThreatsMode
-                  ? const Color(0xFFFF0000)
-                  : const Color(0xFF98B39A);
+              isThreatsMode ? const Color(0xFFFF0000) : const Color(0xFF98B39A);
           final arrowColor = _engineArrowColorForRank(baseArrowColor, i);
           final arrowScale = _engineArrowScaleForRank(i);
 
@@ -6958,12 +6951,7 @@ class ChessBoardScreenNotifierNew
             }
 
             arrowShapes.add(
-              Arrow(
-                color: arrowColor,
-                orig: from,
-                dest: to,
-                scale: arrowScale,
-              ),
+              Arrow(color: arrowColor, orig: from, dest: to, scale: arrowScale),
             );
           }
         } catch (e) {
@@ -7040,7 +7028,10 @@ class ChessBoardScreenNotifierNew
   /// priority on the board.
   Color getVariantArrowColor(int variantIndex) {
     if (variantIndex >= 0 && variantIndex < _variantColors.length) {
-      return _engineArrowColorForRank(_variantColors[variantIndex], variantIndex);
+      return _engineArrowColorForRank(
+        _variantColors[variantIndex],
+        variantIndex,
+      );
     }
     final colorIndex = variantIndex % _variantColors.length;
     return _engineArrowColorForRank(_variantColors[colorIndex], variantIndex);

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -1947,6 +1947,46 @@ class ChessBoardScreenNotifierNew
     });
   }
 
+  Future<void> insertNullMoveAfterPvMove(
+    AnalysisLine line,
+    int moveIndex,
+  ) async {
+    if (_isEditingBlockedByPreview(reason: 'insert null move after PV move')) {
+      return;
+    }
+    _exitPvPreviewIfActive();
+    final currentState = state.value;
+    if (currentState == null || line.moves.isEmpty) return;
+
+    final navigator = _analysisNavigator;
+    if (navigator == null) {
+      _releaseLog('🎯 INSERT PV NULL MOVE: No navigator available');
+      return;
+    }
+
+    final lastMoveIndex = moveIndex.clamp(0, line.moves.length - 1);
+    final pvPrefix = line.copyWith(
+      moves: line.moves.take(lastMoveIndex + 1).toList(growable: false),
+      sanMoves: line.sanMoves.take(lastMoveIndex + 1).toList(growable: false),
+    );
+
+    if (pvPrefix.moves.isEmpty || pvPrefix.sanMoves.isEmpty) return;
+
+    _releaseLog(
+      '🎯 INSERT PV NULL MOVE: Inserting ${pvPrefix.moves.length} PV moves, then null move',
+    );
+
+    navigator.appendMovesFromPv(
+      moves: pvPrefix.moves,
+      sanMoves: pvPrefix.sanMoves,
+    );
+    navigator.insertNullMoveAtPointer();
+    HapticFeedback.mediumImpact();
+    _syncAnalysisFromNavigator(navigator.state);
+    _updateEvaluation(force: true);
+    await _persistAnalysisState();
+  }
+
   void updateVariationComment({
     required String variationId,
     required String comment,


### PR DESCRIPTION
## Summary
- Simplifies phone move long-press menus by making mainline moves show Comment, Annotate, Delete only.
- Makes variation move menus show Promote, Comment, Annotate, Delete, with Promote hidden for mainline moves.
- Moves Add null move after from the move menu to the engine line hold menu, after Show Threats.
- Removes Preview from here from the engine line hold menu.
- Shortens related wording: Add comment → Comment, Promote main variant → Promote, Delete from here/Delete variation → Delete.

## Validation
- `flutter analyze --no-pub lib/screens/chessboard/chess_board_screen_new.dart lib/screens/chessboard/provider/chess_board_screen_provider_new.dart`
- `git diff --check`

## Notes
- Phone/frontend UI cleanup for analysis/notation action sheets.
- Review requested from Berkay.
