### PR TITLE
Fix live board flag fallback

### DIFF
--- a/lib/providers/player_backfill_provider.dart
+++ b/lib/providers/player_backfill_provider.dart
@@ -12,6 +12,29 @@ final chessPlayerByFideIdProvider = FutureProvider.family
       return ref.read(chessPlayerRepositoryProvider).getPlayerByFideId(fideId);
     });
 
+/// Best-effort profile lookup by player name for broadcasts that omit a stable
+/// FIDE ID/federation on a game row. Only exact normalized-name matches are
+/// returned so a missing event flag never gets replaced by a speculative match.
+final chessPlayerByNameProvider = FutureProvider.family
+    .autoDispose<ChessPlayer?, String>((ref, rawName) async {
+      final query = rawName.trim();
+      if (query.isEmpty) return null;
+
+      final repository = ref.read(chessPlayerRepositoryProvider);
+      final target = _normalizePlayerName(query);
+      final candidates = await repository.searchAllPlayers(
+        query: query,
+        limit: 10,
+      );
+
+      for (final candidate in candidates) {
+        if (_normalizePlayerName(candidate.name) == target) {
+          return candidate;
+        }
+      }
+      return null;
+    });
+
 /// Backfills missing scorecard player fields (title/federation/rating)
 /// using the canonical `chess_players` row for the player's FIDE ID.
 final backfilledStandingPlayerProvider = FutureProvider.family

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -10009,6 +10009,7 @@ class _FenPositionPlayerCell extends StatelessWidget {
                 child: BackfilledFederationFlag(
                   federation: federation,
                   fideId: player.fideId,
+                  playerName: player.name,
                   width: 12.w,
                   height: 8.h,
                   borderRadius: BorderRadius.circular(1.5.br),

--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -1189,12 +1189,16 @@ class ChessBoardScreenNotifierNew
         final blackElo =
             int.tryParse(gameData.headers['BlackElo']?.toString() ?? '') ??
             game.blackPlayer.rating;
-        final whiteFed =
-            (gameData.headers['WhiteFed'] ?? game.whitePlayer.federation)
-                .trim();
-        final blackFed =
-            (gameData.headers['BlackFed'] ?? game.blackPlayer.federation)
-                .trim();
+        final whiteFed = _resolvePlayerFederation(
+          gameData.headers['WhiteFed'],
+          game.whitePlayer.countryCode,
+          game.whitePlayer.federation,
+        );
+        final blackFed = _resolvePlayerFederation(
+          gameData.headers['BlackFed'],
+          game.blackPlayer.countryCode,
+          game.blackPlayer.federation,
+        );
         final whiteTitle =
             (gameData.headers['WhiteTitle'] ?? game.whitePlayer.title).trim();
         final blackTitle =
@@ -7523,6 +7527,29 @@ List<Map<String, dynamic>> _analysisLinesWorker(Map<String, dynamic> payload) {
   } catch (_) {
     return const [];
   }
+}
+
+String _resolvePlayerFederation(
+  Object? eventFederation,
+  String profileCountryCode,
+  String profileFederation,
+) {
+  final event = eventFederation?.toString().trim() ?? '';
+  if (!_needsFederationFallback(event)) return event;
+
+  final profileCountry = profileCountryCode.trim();
+  if (!_needsFederationFallback(profileCountry)) return profileCountry;
+
+  final profileFed = profileFederation.trim();
+  if (!_needsFederationFallback(profileFed)) return profileFed;
+
+  return event;
+}
+
+bool _needsFederationFallback(String value) {
+  if (value.isEmpty) return true;
+  final upper = value.toUpperCase();
+  return upper == 'FID' || upper == 'FIDE' || upper == '?';
 }
 
 const int kVariationCommentMaxChars = 280;

--- a/lib/widgets/backfilled_federation_flag.dart
+++ b/lib/widgets/backfilled_federation_flag.dart
@@ -6,15 +6,16 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// [FederationFlag] variant that resolves the flag from Supabase's
 /// `chess_players` table when the supplied federation is missing.
 ///
-/// Imported PGNs frequently carry `[WhiteFideId]`/`[BlackFideId]` but omit
-/// `[WhiteFed]`/`[BlackFed]`, which would otherwise leave the card showing the
-/// generic FIDE logo. When [fideId] is present we look up the player's
-/// country and render the real flag once it loads.
+/// Event/broadcast federation remains the source of truth when present and
+/// valid. If the broadcast omits a flag (or sends a known placeholder such as
+/// FIDE/?), we fall back to the matched ChessEver player profile by FIDE ID and
+/// then by exact normalized name.
 class BackfilledFederationFlag extends ConsumerWidget {
   const BackfilledFederationFlag({
     super.key,
     required this.federation,
     required this.fideId,
+    this.playerName,
     this.width,
     this.height,
     this.borderRadius,
@@ -22,6 +23,7 @@ class BackfilledFederationFlag extends ConsumerWidget {
 
   final String? federation;
   final int? fideId;
+  final String? playerName;
   final double? width;
   final double? height;
   final BorderRadius? borderRadius;
@@ -29,8 +31,8 @@ class BackfilledFederationFlag extends ConsumerWidget {
   bool _needsBackfill(String value) {
     if (value.isEmpty) return true;
     final upper = value.toUpperCase();
-    // Lichess returns the literal "FIDE" for sanctioned RU/BY players; treat
-    // it as missing so we backfill from chess_players.country.
+    // Lichess returns placeholders for some broadcast rows; treat them as
+    // missing so we backfill from ChessEver's player profile.
     return upper == 'FID' || upper == 'FIDE' || upper == '?';
   }
 
@@ -39,9 +41,16 @@ class BackfilledFederationFlag extends ConsumerWidget {
     final raw = (federation ?? '').trim();
     var resolved = raw;
 
-    if (_needsBackfill(raw) && fideId != null && fideId! > 0) {
-      final async = ref.watch(chessPlayerByFideIdProvider(fideId));
-      final country = async.valueOrNull?.country?.trim() ?? '';
+    if (_needsBackfill(raw)) {
+      var country = '';
+      if (fideId != null && fideId! > 0) {
+        final async = ref.watch(chessPlayerByFideIdProvider(fideId));
+        country = async.valueOrNull?.country?.trim() ?? '';
+      }
+      if (country.isEmpty && (playerName?.trim().isNotEmpty ?? false)) {
+        final async = ref.watch(chessPlayerByNameProvider(playerName!.trim()));
+        country = async.valueOrNull?.country?.trim() ?? '';
+      }
       if (country.isNotEmpty) resolved = country;
     }
 


### PR DESCRIPTION
## Summary\n- keep event/broadcast federation as the source of truth when it is present and valid\n- when a live-board player flag is missing/placeholder (empty, FID/FIDE/?), backfill from ChessEver player profile by FIDE ID, then exact normalized player name\n- preserve profile country/federation fallback when PGN headers are missing or placeholders\n- pass the player name into the phone board flag resolver for weak Lichess identity rows\n\n## Validation\n- flutter analyze lib/providers/player_backfill_provider.dart lib/widgets/backfilled_federation_flag.dart lib/screens/chessboard/chess_board_screen_new.dart lib/screens/chessboard/provider/chess_board_screen_provider_new.dart\n- git diff --check\n\n## Notes\nThis preserves valid Lichess/event flags and only improves missing/placeholder cases.