### PR TITLE
feat: add standings share image

### DIFF
--- a/lib/screens/tour_detail/widgets/standings_share_image_card.dart
+++ b/lib/screens/tour_detail/widgets/standings_share_image_card.dart
@@ -1,0 +1,273 @@
+import 'package:chessever2/screens/favorites/tabs/favorites_players_tab.dart';
+import 'package:chessever2/screens/standings/player_standing_model.dart';
+import 'package:chessever2/utils/location_service_provider.dart';
+import 'package:chessever2/utils/png_asset.dart';
+import 'package:chessever2/widgets/player_initials_avatar.dart';
+import 'package:country_flags/country_flags.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+const Size standingsShareImageSize = Size(574, 1280);
+
+int standingsShareRowLimit(int standingsCount) {
+  if (standingsCount <= 10) return standingsCount;
+  return standingsCount < 12 ? standingsCount : 12;
+}
+
+bool standingsShareShowsFooter(int standingsCount) => standingsCount <= 10;
+
+class StandingsShareImageCard extends StatelessWidget {
+  const StandingsShareImageCard({
+    super.key,
+    required this.eventName,
+    required this.standings,
+  });
+
+  final String eventName;
+  final List<PlayerStandingModel> standings;
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = standings.take(standingsShareRowLimit(standings.length));
+    final showFooter = standingsShareShowsFooter(standings.length);
+
+    return MediaQuery(
+      data: const MediaQueryData(size: standingsShareImageSize),
+      child: Material(
+        color: const Color(0xFF070708),
+        child: SizedBox.fromSize(
+          size: standingsShareImageSize,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 24, 24, 18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  height: 44,
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      eventName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 26,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: -0.2,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                for (final player in rows)
+                  _ShareStandingRow(
+                    player: player,
+                    rank: player.overallRank ?? standings.indexOf(player) + 1,
+                  ),
+                if (showFooter) const Spacer(),
+                if (showFooter) const _ShareFooter(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ShareStandingRow extends ConsumerWidget {
+  const _ShareStandingRow({required this.player, required this.rank});
+
+  final PlayerStandingModel player;
+  final int rank;
+
+  String _initials(String name) {
+    final parts = name.split(',');
+    if (parts.length > 1) {
+      final last = parts[0].trim();
+      final first = parts[1].trim();
+      return '${last.isNotEmpty ? last[0] : ''}${first.isNotEmpty ? first[0] : ''}'
+          .toUpperCase();
+    }
+    final words = name.trim().split(RegExp(r'\s+'));
+    if (words.length >= 2) {
+      return '${words[0].isNotEmpty ? words[0][0] : ''}${words[1].isNotEmpty ? words[1][0] : ''}'
+          .toUpperCase();
+    }
+    return name.isEmpty
+        ? ''
+        : name.substring(0, name.length >= 2 ? 2 : 1).toUpperCase();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final photoAsync = ref.watch(playerPhotoProvider(player.fideId));
+    final validCountryCode = ref
+        .read(locationServiceProvider)
+        .getValidCountryCode(player.countryCode);
+
+    return Container(
+      height: 98,
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Color(0xFF17171A), width: 1)),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 48,
+            child: Text(
+              rank.toString(),
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Color(0xFF8A8A90),
+                fontSize: 20,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          const SizedBox(width: 14),
+          photoAsync.when(
+            data:
+                (photoUrl) => PlayerInitialsAvatar(
+                  photoUrl: photoUrl,
+                  initials: _initials(player.name),
+                  size: 64,
+                  borderRadius: 12,
+                  title: player.title,
+                ),
+            loading:
+                () => PlayerInitialsAvatar(
+                  initials: _initials(player.name),
+                  size: 64,
+                  borderRadius: 12,
+                  title: player.title,
+                ),
+            error:
+                (_, __) => PlayerInitialsAvatar(
+                  initials: _initials(player.name),
+                  size: 64,
+                  borderRadius: 12,
+                  title: player.title,
+                ),
+          ),
+          const SizedBox(width: 28),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  player.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: -0.1,
+                  ),
+                ),
+                const SizedBox(height: 7),
+                Row(
+                  children: [
+                    if (player.countryCode.isNotEmpty) ...[
+                      SizedBox(
+                        width: 22,
+                        height: 15,
+                        child:
+                            player.countryCode.toUpperCase() == 'FID'
+                                ? Image.asset(
+                                  PngAsset.fideLogo,
+                                  fit: BoxFit.contain,
+                                )
+                                : validCountryCode.isNotEmpty
+                                ? CountryFlag.fromCountryCode(
+                                  validCountryCode,
+                                  theme: const ImageTheme(
+                                    height: 15,
+                                    width: 22,
+                                  ),
+                                )
+                                : const SizedBox.shrink(),
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                    Text(
+                      player.score.toString(),
+                      style: const TextStyle(
+                        color: Color(0xFFA0A0A8),
+                        fontSize: 17,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    if (player.scoreChange != 0) ...[
+                      const SizedBox(width: 6),
+                      Text(
+                        player.scoreChange > 0
+                            ? '+${player.scoreChange}'
+                            : '${player.scoreChange}',
+                        style: TextStyle(
+                          color:
+                              player.scoreChange > 0
+                                  ? const Color(0xFF22C55E)
+                                  : const Color(0xFFEF4444),
+                          fontSize: 17,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 14),
+          Text(
+            player.matchScore ?? '',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.w800,
+              letterSpacing: -0.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ShareFooter extends StatelessWidget {
+  const _ShareFooter();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: double.infinity,
+      height: 72,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'ChessEver',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          SizedBox(height: 7),
+          Text(
+            'Follow Chess Better',
+            style: TextStyle(
+              color: Color(0xFFA5A5AD),
+              fontSize: 18,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/tour_detail/widgets/tournament_menu_button.dart
+++ b/lib/screens/tour_detail/widgets/tournament_menu_button.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:io';
+
 import 'package:chessever2/providers/auth_state_provider.dart';
 import 'package:chessever2/providers/event_mute_provider.dart';
 import 'package:chessever2/screens/group_event/model/tour_detail_view_model.dart';
 import 'package:chessever2/screens/group_event/widget/appbar_icons_widget.dart';
+import 'package:chessever2/screens/standings/player_standing_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/event_no_spoilers_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_app_bar_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_pin_provider.dart';
@@ -10,7 +13,9 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_s
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/match_expansion_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/round_expansion_provider.dart';
+import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
+import 'package:chessever2/screens/tour_detail/widgets/standings_share_image_card.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/svg_asset.dart';
@@ -19,6 +24,8 @@ import 'package:chessever2/widgets/event_card/event_context_menu.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
 
 enum TournamentMenuAction {
@@ -31,6 +38,7 @@ enum TournamentMenuAction {
   expandAllRounds,
   disableNotifications,
   enableNotifications,
+  shareStandings,
   shareEvent,
 }
 
@@ -376,16 +384,38 @@ class TournamentMenuButton extends ConsumerWidget {
       );
     }
 
-    // 5. Share event
-    // We have the active tour (id + slug) in hand here, so we can build the
-    // Lichess-mirror URL `<tour.slug>/<tour.id>` directly without an extra
-    // database round-trip. `groupBroadcastId` is passed only as the fallback
-    // path id used when slug/tourId are missing (legacy events).
+    // 5. Share standings
     final aboutModel = tourData.aboutTourModel;
     final fallbackId =
         aboutModel.groupBroadcastId?.isNotEmpty == true
             ? aboutModel.groupBroadcastId!
             : aboutModel.id;
+    if (fallbackId.isNotEmpty && aboutModel.name.isNotEmpty) {
+      items.add(
+        PopupMenuItem<TournamentMenuAction>(
+          value: TournamentMenuAction.shareStandings,
+          padding: EdgeInsets.zero,
+          height: 36.h,
+          onTap: () {
+            unawaited(_shareStandings(ref, context, tourData));
+          },
+          child: _MenuDropDownItem(
+            text: "Share standings",
+            icon: Icon(
+              Icons.leaderboard_outlined,
+              color: context.colors.textPrimary,
+              size: 16,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // 6. Share event
+    // We have the active tour (id + slug) in hand here, so we can build the
+    // Lichess-mirror URL `<tour.slug>/<tour.id>` directly without an extra
+    // database round-trip. `groupBroadcastId` is passed only as the fallback
+    // path id used when slug/tourId are missing (legacy events).
     if (fallbackId.isNotEmpty && aboutModel.name.isNotEmpty) {
       items.add(
         PopupMenuItem<TournamentMenuAction>(
@@ -414,6 +444,101 @@ class TournamentMenuButton extends ConsumerWidget {
               size: 16,
             ),
           ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _shareStandings(
+    WidgetRef ref,
+    BuildContext context,
+    TourDetailViewModel tourData,
+  ) async {
+    late final List<PlayerStandingModel> standings;
+    try {
+      standings = await ref.read(playerTourScreenProvider.future);
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not load standings. Please try again.'),
+          duration: Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+    if (!context.mounted) return;
+    if (standings.isEmpty) {
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Standings are still loading. Try again in a moment.'),
+          duration: Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    final aboutModel = tourData.aboutTourModel;
+    final fallbackId =
+        aboutModel.groupBroadcastId?.isNotEmpty == true
+            ? aboutModel.groupBroadcastId!
+            : aboutModel.id;
+    final url = buildEventShareUrl(
+      id: fallbackId,
+      title: aboutModel.name,
+      tourId: aboutModel.id,
+      tourSlug: aboutModel.slug,
+    );
+
+    final box = context.findRenderObject() as RenderBox?;
+    final origin =
+        box != null
+            ? box.localToGlobal(Offset.zero) & box.size
+            : const Rect.fromLTWH(0, 0, 1, 1);
+
+    try {
+      final bytes = await ScreenshotController().captureFromWidget(
+        UncontrolledProviderScope(
+          container: ProviderScope.containerOf(context, listen: false),
+          child: StandingsShareImageCard(
+            eventName: aboutModel.name,
+            standings: standings,
+          ),
+        ),
+        context: context,
+        targetSize: standingsShareImageSize,
+        pixelRatio: 1,
+      );
+      final tempDir = await getTemporaryDirectory();
+      final safeName =
+          aboutModel.name
+              .replaceAll(RegExp(r'[^A-Za-z0-9]+'), '-')
+              .replaceAll(RegExp(r'^-+|-+$'), '')
+              .toLowerCase();
+      final file = File(
+        '${tempDir.path}/${safeName.isEmpty ? 'chessever-event' : safeName}-standings.png',
+      );
+      await file.writeAsBytes(bytes, flush: true);
+
+      if (!context.mounted) return;
+      await Share.shareXFiles(
+        [XFile(file.path, mimeType: 'image/png')],
+        text: url,
+        subject: '${aboutModel.name} standings',
+        sharePositionOrigin: origin,
+      );
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not share standings. Please try again.'),
+          duration: Duration(seconds: 2),
+          behavior: SnackBarBehavior.floating,
         ),
       );
     }

--- a/test/screens/tour_detail/widgets/standings_share_image_card_test.dart
+++ b/test/screens/tour_detail/widgets/standings_share_image_card_test.dart
@@ -1,0 +1,21 @@
+import 'package:chessever2/screens/tour_detail/widgets/standings_share_image_card.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('standings share image row rules', () {
+    test('keeps footer for events with ten or fewer players', () {
+      expect(standingsShareRowLimit(10), 10);
+      expect(standingsShareShowsFooter(10), isTrue);
+    });
+
+    test('fits all twelve-player round robins without forcing footer', () {
+      expect(standingsShareRowLimit(12), 12);
+      expect(standingsShareShowsFooter(12), isFalse);
+    });
+
+    test('caps larger events at twelve clean rows', () {
+      expect(standingsShareRowLimit(14), 12);
+      expect(standingsShareShowsFooter(14), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a `Share standings` action to the event overflow menu.
- Generates a clean portrait standings image with the full event name, player rows, photos/avatars, flags, ratings/rating changes, and scores.
- Shares the generated image together with the event link, matching the existing event/game share flow.
- Keeps the image simple: no app chrome, search, tabs, column headers, or extra round text; footer only appears for 10-player-or-smaller standings.

## Validation
- `git diff --check`
- `flutter test --no-pub test/screens/tour_detail/widgets/tournament_menu_button_test.dart test/screens/tour_detail/widgets/standings_share_image_card_test.dart`
- `flutter analyze --no-pub lib/screens/tour_detail/widgets/tournament_menu_button.dart lib/screens/tour_detail/widgets/standings_share_image_card.dart test/screens/tour_detail/widgets/standings_share_image_card_test.dart`

## Notes
- The share image caps larger events at 12 clean rows so it does not cut/cramp the last visible row.
- Review owner: Berkay / mobile frontend.
