### PR TITLE
feat: add player event profile share image

### DIFF
--- a/lib/screens/standings/score_card_screen.dart
+++ b/lib/screens/standings/score_card_screen.dart
@@ -44,7 +44,8 @@ import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/utils/favorite_limit_guard.dart';
 import 'package:chessever2/widgets/auth/auth_upgrade_sheet.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
-import 'package:chessever2/widgets/event_card/event_context_menu.dart' show buildEventShareUrl;
+import 'package:chessever2/widgets/event_card/event_context_menu.dart'
+    show buildEventShareUrl;
 import 'package:path_provider/path_provider.dart';
 import 'package:screenshot/screenshot.dart';
 import 'package:share_plus/share_plus.dart';
@@ -76,6 +77,47 @@ final scoreCardPlayerProfileDataSourceProvider =
     StateProvider<PlayerProfileDataSource>(
       (ref) => PlayerProfileDataSource.supabase,
     );
+
+enum ScoreCardSwipeDirection { previous, next }
+
+bool _isSameStandingPlayer(PlayerStandingModel a, PlayerStandingModel b) {
+  if (a.fideId != null && b.fideId != null) {
+    return a.fideId == b.fideId;
+  }
+  if (a.gamebasePlayerId != null &&
+      a.gamebasePlayerId!.isNotEmpty &&
+      b.gamebasePlayerId != null &&
+      b.gamebasePlayerId!.isNotEmpty) {
+    return a.gamebasePlayerId == b.gamebasePlayerId;
+  }
+  return a.name == b.name;
+}
+
+int findScoreCardPlayerIndex(
+  List<PlayerStandingModel> players,
+  PlayerStandingModel selectedPlayer,
+) {
+  return players.indexWhere(
+    (player) => _isSameStandingPlayer(player, selectedPlayer),
+  );
+}
+
+PlayerStandingModel? adjacentScoreCardPlayerForSwipe({
+  required List<PlayerStandingModel> players,
+  required PlayerStandingModel selectedPlayer,
+  required ScoreCardSwipeDirection direction,
+}) {
+  if (players.length < 2) return null;
+  final currentIndex = findScoreCardPlayerIndex(players, selectedPlayer);
+  if (currentIndex < 0) return null;
+
+  final targetIndex = switch (direction) {
+    ScoreCardSwipeDirection.previous => currentIndex - 1,
+    ScoreCardSwipeDirection.next => currentIndex + 1,
+  };
+  if (targetIndex < 0 || targetIndex >= players.length) return null;
+  return players[targetIndex];
+}
 
 final playerGamesProvider = FutureProvider.family<
   List<GamesTourModel>,
@@ -627,6 +669,18 @@ class ScoreCardScreen extends ConsumerWidget {
     // Gap between rating boxes
     final ratingBoxGap = ResponsiveHelper.adaptive(phone: 6.w, tablet: 10.sp);
 
+    void selectAdjacentPlayer(ScoreCardSwipeDirection direction) {
+      final players = ref.read(playerTourScreenProvider).valueOrNull;
+      if (players == null || players.length < 2) return;
+      final nextPlayer = adjacentScoreCardPlayerForSwipe(
+        players: players,
+        selectedPlayer: player,
+        direction: direction,
+      );
+      if (nextPlayer == null) return;
+      ref.read(selectedPlayerProvider.notifier).state = nextPlayer;
+    }
+
     return Scaffold(
       key: e2eKey(E2eIds.scorecardRoot),
       backgroundColor: context.colors.background,
@@ -640,269 +694,285 @@ class ScoreCardScreen extends ConsumerWidget {
             constraints: BoxConstraints(
               maxWidth: ResponsiveHelper.contentMaxWidth,
             ),
-            child: CustomScrollView(
-              slivers: [
-                _SliverScoreboardAppBar(onShareProfile: sharePlayerProfile),
-                SliverToBoxAdapter(
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: horizontalPadding,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        SizedBox(height: 10.h),
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            _PlayerAvatarTile(
-                              photoFuture: photoFuture,
-                              initials: initials,
-                              title: player.title,
-                              fideId: player.fideId?.toString(),
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onHorizontalDragEnd: (details) {
+                final velocity = details.primaryVelocity ?? 0;
+                if (velocity.abs() < 250) return;
+                selectAdjacentPlayer(
+                  velocity < 0
+                      ? ScoreCardSwipeDirection.next
+                      : ScoreCardSwipeDirection.previous,
+                );
+              },
+              child: CustomScrollView(
+                slivers: [
+                  _SliverScoreboardAppBar(onShareProfile: sharePlayerProfile),
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: horizontalPadding,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(height: 10.h),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              _PlayerAvatarTile(
+                                photoFuture: photoFuture,
+                                initials: initials,
+                                title: player.title,
+                                fideId: player.fideId?.toString(),
+                              ),
+                              SizedBox(width: avatarRatingGap),
+                              Expanded(
+                                child: IntrinsicHeight(
+                                  child: Row(
+                                    children: [
+                                      Expanded(
+                                        child: _RatingDisplay(
+                                          label: 'Classical',
+                                          playerName: player.name,
+                                          fideId: player.fideId,
+                                          timeControlType: "standard",
+                                          assetPath: PngAsset.classicalIcon,
+                                          onTap:
+                                              () => _navigateToPlayerProfile(
+                                                context,
+                                                ref,
+                                                player,
+                                              ),
+                                        ),
+                                      ),
+                                      SizedBox(width: ratingBoxGap),
+                                      Expanded(
+                                        child: _RatingDisplay(
+                                          label: 'Rapid',
+                                          playerName: player.name,
+                                          fideId: player.fideId,
+                                          timeControlType: "rapid",
+                                          assetPath: PngAsset.rapidIcon,
+                                          onTap:
+                                              () => _navigateToPlayerProfile(
+                                                context,
+                                                ref,
+                                                player,
+                                              ),
+                                        ),
+                                      ),
+                                      SizedBox(width: ratingBoxGap),
+                                      Expanded(
+                                        child: _RatingDisplay(
+                                          label: 'Blitz',
+                                          playerName: player.name,
+                                          fideId: player.fideId,
+                                          timeControlType: "blitz",
+                                          assetPath: PngAsset.blitzIcon,
+                                          onTap:
+                                              () => _navigateToPlayerProfile(
+                                                context,
+                                                ref,
+                                                player,
+                                              ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          SizedBox(height: 12.h),
+                          GestureDetector(
+                            onTap:
+                                () => _navigateToPlayerProfile(
+                                  context,
+                                  ref,
+                                  player,
+                                ),
+                            child: PerformanceStatsRow(
+                              performanceRating: performanceRating,
+                              score: eventScore,
+                              totalGames: eventTotalGames,
+                              // Prefer server-provided ratingDiff (accounts for FIDE K-factor history);
+                              // fall back to locally calculated sum when server value is unavailable.
+                              ratingDiff:
+                                  hasEventContext
+                                      ? (player.scoreChange != 0
+                                          ? player.scoreChange
+                                          : (totalRatingDiff != 0.0
+                                              ? totalRatingDiff.round()
+                                              : null))
+                                      : null,
                             ),
-                            SizedBox(width: avatarRatingGap),
-                            Expanded(
-                              child: IntrinsicHeight(
-                                child: Row(
-                                  children: [
-                                    Expanded(
-                                      child: _RatingDisplay(
-                                        label: 'Classical',
-                                        playerName: player.name,
-                                        fideId: player.fideId,
-                                        timeControlType: "standard",
-                                        assetPath: PngAsset.classicalIcon,
-                                        onTap:
-                                            () => _navigateToPlayerProfile(
-                                              context,
-                                              ref,
-                                              player,
-                                            ),
-                                      ),
-                                    ),
-                                    SizedBox(width: ratingBoxGap),
-                                    Expanded(
-                                      child: _RatingDisplay(
-                                        label: 'Rapid',
-                                        playerName: player.name,
-                                        fideId: player.fideId,
-                                        timeControlType: "rapid",
-                                        assetPath: PngAsset.rapidIcon,
-                                        onTap:
-                                            () => _navigateToPlayerProfile(
-                                              context,
-                                              ref,
-                                              player,
-                                            ),
-                                      ),
-                                    ),
-                                    SizedBox(width: ratingBoxGap),
-                                    Expanded(
-                                      child: _RatingDisplay(
-                                        label: 'Blitz',
-                                        playerName: player.name,
-                                        fideId: player.fideId,
-                                        timeControlType: "blitz",
-                                        assetPath: PngAsset.blitzIcon,
-                                        onTap:
-                                            () => _navigateToPlayerProfile(
-                                              context,
-                                              ref,
-                                              player,
-                                            ),
-                                      ),
-                                    ),
-                                  ],
+                          ),
+                          SizedBox(height: 10.h),
+                          _ProfileNavigationButton(
+                            onTap:
+                                () => _navigateToPlayerProfile(
+                                  context,
+                                  ref,
+                                  player,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  SliverToBoxAdapter(child: SizedBox(height: 12.h)),
+                  if (isLoadingGames)
+                    const SliverFillRemaining(
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  else if (playerGames.isEmpty)
+                    SliverFillRemaining(
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.info_outline,
+                              size: 40.ic,
+                              color: context.colors.textPrimary.withValues(
+                                alpha: 0.5,
+                              ),
+                            ),
+                            SizedBox(height: 12.h),
+                            Text(
+                              hasEventContext
+                                  ? 'No games in this tournament'
+                                  : 'No games available',
+                              style: AppTypography.textSmMedium.copyWith(
+                                color: context.colors.textPrimary.withValues(
+                                  alpha: 0.7,
+                                ),
+                              ),
+                            ),
+                            SizedBox(height: 6.h),
+                            Text(
+                              hasEventContext
+                                  ? 'This player has not played in this tournament yet'
+                                  : 'Games will appear once they are played',
+                              textAlign: TextAlign.center,
+                              style: AppTypography.textXsRegular.copyWith(
+                                color: context.colors.textPrimary.withValues(
+                                  alpha: 0.5,
                                 ),
                               ),
                             ),
                           ],
                         ),
-                        SizedBox(height: 12.h),
-                        GestureDetector(
-                          onTap:
-                              () => _navigateToPlayerProfile(
-                                context,
-                                ref,
-                                player,
-                              ),
-                          child: PerformanceStatsRow(
-                            performanceRating: performanceRating,
-                            score: eventScore,
-                            totalGames: eventTotalGames,
-                            // Prefer server-provided ratingDiff (accounts for FIDE K-factor history);
-                            // fall back to locally calculated sum when server value is unavailable.
-                            ratingDiff:
-                                hasEventContext
-                                    ? (player.scoreChange != 0
-                                        ? player.scoreChange
-                                        : (totalRatingDiff != 0.0
-                                            ? totalRatingDiff.round()
-                                            : null))
-                                    : null,
-                          ),
-                        ),
-                        SizedBox(height: 10.h),
-                        _ProfileNavigationButton(
-                          onTap:
-                              () => _navigateToPlayerProfile(
-                                context,
-                                ref,
-                                player,
-                              ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                SliverToBoxAdapter(child: SizedBox(height: 12.h)),
-                if (isLoadingGames)
-                  const SliverFillRemaining(
-                    child: Center(child: CircularProgressIndicator()),
-                  )
-                else if (playerGames.isEmpty)
-                  SliverFillRemaining(
-                    child: Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            Icons.info_outline,
-                            size: 40.ic,
-                            color: context.colors.textPrimary.withValues(
-                              alpha: 0.5,
-                            ),
-                          ),
-                          SizedBox(height: 12.h),
-                          Text(
-                            hasEventContext
-                                ? 'No games in this tournament'
-                                : 'No games available',
-                            style: AppTypography.textSmMedium.copyWith(
-                              color: context.colors.textPrimary.withValues(
-                                alpha: 0.7,
-                              ),
-                            ),
-                          ),
-                          SizedBox(height: 6.h),
-                          Text(
-                            hasEventContext
-                                ? 'This player has not played in this tournament yet'
-                                : 'Games will appear once they are played',
-                            textAlign: TextAlign.center,
-                            style: AppTypography.textXsRegular.copyWith(
-                              color: context.colors.textPrimary.withValues(
-                                alpha: 0.5,
-                              ),
-                            ),
-                          ),
-                        ],
                       ),
-                    ),
-                  )
-                else
-                  SliverList(
-                    delegate: SliverChildBuilderDelegate((context, index) {
-                      final game = playerGames[index];
-                      // Fide-first, fuzzy-name-fallback match — see note in
-                      // the performance loop above.
-                      final isWhite = playerUtils.isSamePlayerWithFideId(
-                        game.whitePlayer.name,
-                        player.name,
-                        fideId1: game.whitePlayer.fideId,
-                        fideId2: player.fideId,
-                      );
-                      final opponent =
-                          isWhite ? game.blackPlayer : game.whitePlayer;
-                      final result = _getPlayerResult(game, isWhite);
-
-                      final playerRating = _getPlayerRatingForSide(
-                        game,
-                        isWhite,
-                      );
-                      final opponentRating = _getPlayerRatingForSide(
-                        game,
-                        !isWhite,
-                      );
-
-                      double ratingChange = 0.0;
-                      if (playerRating > 0 && opponentRating > 0) {
-                        final tc = game.timeControl;
-                        final fideK =
-                            tc != null ? playerRatings?.getK(tc) : null;
-                        final fidePlayerRating =
-                            tc != null
-                                ? playerRatings?.getRating(tc)?.toDouble()
-                                : null;
-                        ratingChange = _calculateFideRatingChange(
-                          playerRating,
-                          opponentRating,
-                          game.gameStatus,
-                          isWhite,
-                          game,
-                          fideK: fideK,
-                          playerRatingOverride: fidePlayerRating,
+                    )
+                  else
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        final game = playerGames[index];
+                        // Fide-first, fuzzy-name-fallback match — see note in
+                        // the performance loop above.
+                        final isWhite = playerUtils.isSamePlayerWithFideId(
+                          game.whitePlayer.name,
+                          player.name,
+                          fideId1: game.whitePlayer.fideId,
+                          fideId2: player.fideId,
                         );
-                      }
+                        final opponent =
+                            isWhite ? game.blackPlayer : game.whitePlayer;
+                        final result = _getPlayerResult(game, isWhite);
 
-                      return Padding(
-                        padding: EdgeInsets.symmetric(
-                          horizontal: horizontalPadding,
-                        ),
-                        child: ScoreboardCardWidget(
-                          roundLabel:
-                              hasEventContext ? _buildRoundLabel(game) : null,
-                          countryCode: opponent.countryCode,
-                          title: opponent.title,
-                          name: opponent.name,
-                          score: opponent.rating,
-                          scoreChange:
-                              ratingChange != 0.0 ? ratingChange : null,
-                          matchScore: result,
-                          isWhite: isWhite,
-                          index: index,
-                          isFirst: index == 0,
-                          isLast: index == playerGames.length - 1,
-                          onTap: () {
-                            if (ref.read(selectedBroadcastModelProvider) ==
-                                null) {
-                              ref
-                                  .read(chessboardViewFromProviderNew.notifier)
-                                  .state = ChessboardView.favScorecard;
-                            } else {
-                              ref
-                                  .read(chessboardViewFromProviderNew.notifier)
-                                  .state = ChessboardView.tour;
-                            }
+                        final playerRating = _getPlayerRatingForSide(
+                          game,
+                          isWhite,
+                        );
+                        final opponentRating = _getPlayerRatingForSide(
+                          game,
+                          !isWhite,
+                        );
 
-                            // Pass playerGames (filtered for this player) instead of allGames
-                            // so swiping in chessboard only shows this player's games
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder:
-                                    (_) => ChessBoardScreenNew(
-                                      games: playerGames,
-                                      currentIndex: index,
-                                      playerProfileDataSource:
-                                          profileDataSource,
-                                    ),
-                              ),
-                            );
-                          },
-                        ),
-                      );
-                    }, childCount: playerGames.length),
+                        double ratingChange = 0.0;
+                        if (playerRating > 0 && opponentRating > 0) {
+                          final tc = game.timeControl;
+                          final fideK =
+                              tc != null ? playerRatings?.getK(tc) : null;
+                          final fidePlayerRating =
+                              tc != null
+                                  ? playerRatings?.getRating(tc)?.toDouble()
+                                  : null;
+                          ratingChange = _calculateFideRatingChange(
+                            playerRating,
+                            opponentRating,
+                            game.gameStatus,
+                            isWhite,
+                            game,
+                            fideK: fideK,
+                            playerRatingOverride: fidePlayerRating,
+                          );
+                        }
+
+                        return Padding(
+                          padding: EdgeInsets.symmetric(
+                            horizontal: horizontalPadding,
+                          ),
+                          child: ScoreboardCardWidget(
+                            roundLabel:
+                                hasEventContext ? _buildRoundLabel(game) : null,
+                            countryCode: opponent.countryCode,
+                            title: opponent.title,
+                            name: opponent.name,
+                            score: opponent.rating,
+                            scoreChange:
+                                ratingChange != 0.0 ? ratingChange : null,
+                            matchScore: result,
+                            isWhite: isWhite,
+                            index: index,
+                            isFirst: index == 0,
+                            isLast: index == playerGames.length - 1,
+                            onTap: () {
+                              if (ref.read(selectedBroadcastModelProvider) ==
+                                  null) {
+                                ref
+                                    .read(
+                                      chessboardViewFromProviderNew.notifier,
+                                    )
+                                    .state = ChessboardView.favScorecard;
+                              } else {
+                                ref
+                                    .read(
+                                      chessboardViewFromProviderNew.notifier,
+                                    )
+                                    .state = ChessboardView.tour;
+                              }
+
+                              // Pass playerGames (filtered for this player) instead of allGames
+                              // so swiping in chessboard only shows this player's games
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder:
+                                      (_) => ChessBoardScreenNew(
+                                        games: playerGames,
+                                        currentIndex: index,
+                                        playerProfileDataSource:
+                                            profileDataSource,
+                                      ),
+                                ),
+                              );
+                            },
+                          ),
+                        );
+                      }, childCount: playerGames.length),
+                    ),
+                  // Bottom breathing room + restored home-indicator clearance
+                  // (SafeArea bottom was disabled to stop scroll cutoffs).
+                  SliverToBoxAdapter(
+                    child: SizedBox(
+                      height: 24.h + MediaQuery.of(context).padding.bottom,
+                    ),
                   ),
-                // Bottom breathing room + restored home-indicator clearance
-                // (SafeArea bottom was disabled to stop scroll cutoffs).
-                SliverToBoxAdapter(
-                  child: SizedBox(
-                    height: 24.h + MediaQuery.of(context).padding.bottom,
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
@@ -970,7 +1040,6 @@ class ScoreCardScreen extends ConsumerWidget {
 
     return null;
   }
-
 
   List<PlayerEventShareGameRow> _buildPlayerEventShareRows({
     required List<GamesTourModel> playerGames,

--- a/lib/screens/standings/score_card_screen.dart
+++ b/lib/screens/standings/score_card_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:io' as io;
 import 'dart:math' as math;
 import 'package:chessever2/e2e/e2e_ids.dart';
 import 'package:chessever2/providers/player_backfill_provider.dart';
@@ -10,6 +11,7 @@ import 'package:chessever2/screens/standings/providers/twic_scorecard_event_game
 import 'package:chessever2/screens/standings/providers/player_utils_provider.dart';
 import 'package:chessever2/screens/standings/utils/fide_rating_change.dart';
 import 'package:chessever2/screens/standings/widget/scoreboard_card_widget.dart';
+import 'package:chessever2/screens/standings/widgets/player_event_share_image_card.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
 import 'package:chessever2/screens/player_profile/widgets/performance_stats_row.dart';
@@ -42,6 +44,10 @@ import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/utils/favorite_limit_guard.dart';
 import 'package:chessever2/widgets/auth/auth_upgrade_sheet.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
+import 'package:chessever2/widgets/event_card/event_context_menu.dart' show buildEventShareUrl;
+import 'package:path_provider/path_provider.dart';
+import 'package:screenshot/screenshot.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:motor/motor.dart';
 
 final selectedPlayerProvider = StateProvider<PlayerStandingModel?>(
@@ -571,6 +577,42 @@ class ScoreCardScreen extends ConsumerWidget {
     final photoFuture = FidePhotoService.getPhotoUrlOrNull(
       player.fideId?.toString(),
     );
+    final eventName = selectedBroadcast?.name ?? contextEvent;
+    final shareRows = _buildPlayerEventShareRows(
+      playerGames: playerGames,
+      player: player,
+      playerUtils: playerUtils,
+      playerRatings: playerRatings,
+      hasEventContext: hasEventContext,
+    );
+    Future<void> sharePlayerProfile() => _sharePlayerEventProfile(
+      context: context,
+      player: player,
+      photoFuture: photoFuture,
+      initials: initials,
+      eventName: eventName,
+      performanceRating: performanceRating,
+      eventScore: eventScore,
+      eventTotalGames: eventTotalGames,
+      ratingDiff:
+          hasEventContext
+              ? (player.scoreChange != 0
+                  ? player.scoreChange
+                  : (totalRatingDiff != 0.0 ? totalRatingDiff.round() : null))
+              : null,
+      standardRating:
+          playerRatings?.getRating('standard') ?? player.score.round(),
+      rapidRating: playerRatings?.getRating('rapid'),
+      blitzRating: playerRatings?.getRating('blitz'),
+      rows: shareRows,
+      shareUrl:
+          selectedBroadcast == null
+              ? null
+              : buildEventShareUrl(
+                id: selectedBroadcast.id,
+                title: selectedBroadcast.name,
+              ),
+    );
 
     // Consistent horizontal padding - matches chessboard screen patterns
     final horizontalPadding = ResponsiveHelper.adaptive(
@@ -600,7 +642,7 @@ class ScoreCardScreen extends ConsumerWidget {
             ),
             child: CustomScrollView(
               slivers: [
-                const _SliverScoreboardAppBar(),
+                _SliverScoreboardAppBar(onShareProfile: sharePlayerProfile),
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: EdgeInsets.symmetric(
@@ -929,6 +971,128 @@ class ScoreCardScreen extends ConsumerWidget {
     return null;
   }
 
+
+  List<PlayerEventShareGameRow> _buildPlayerEventShareRows({
+    required List<GamesTourModel> playerGames,
+    required PlayerStandingModel player,
+    required dynamic playerUtils,
+    required dynamic playerRatings,
+    required bool hasEventContext,
+  }) {
+    return [
+      for (final game in playerGames)
+        _playerEventShareRowFor(
+          game: game,
+          player: player,
+          playerUtils: playerUtils,
+          playerRatings: playerRatings,
+          hasEventContext: hasEventContext,
+        ),
+    ];
+  }
+
+  PlayerEventShareGameRow _playerEventShareRowFor({
+    required GamesTourModel game,
+    required PlayerStandingModel player,
+    required dynamic playerUtils,
+    required dynamic playerRatings,
+    required bool hasEventContext,
+  }) {
+    final isWhite = playerUtils.isSamePlayerWithFideId(
+      game.whitePlayer.name,
+      player.name,
+      fideId1: game.whitePlayer.fideId,
+      fideId2: player.fideId,
+    );
+    final opponent = isWhite ? game.blackPlayer : game.whitePlayer;
+    final playerRating = _getPlayerRatingForSide(game, isWhite);
+    final opponentRating = _getPlayerRatingForSide(game, !isWhite);
+    double ratingChange = 0.0;
+    if (playerRating > 0 && opponentRating > 0) {
+      final tc = game.timeControl;
+      final fideK = tc != null ? playerRatings?.getK(tc) : null;
+      final fidePlayerRating =
+          tc != null ? playerRatings?.getRating(tc)?.toDouble() : null;
+      ratingChange = _calculateFideRatingChange(
+        playerRating,
+        opponentRating,
+        game.gameStatus,
+        isWhite,
+        game,
+        fideK: fideK,
+        playerRatingOverride: fidePlayerRating,
+      );
+    }
+
+    return PlayerEventShareGameRow(
+      roundLabel: hasEventContext ? _buildRoundLabel(game) : null,
+      countryCode: opponent.countryCode,
+      title: opponent.title,
+      name: opponent.name,
+      rating: opponent.rating,
+      ratingChange: ratingChange != 0.0 ? ratingChange : null,
+      result: _getPlayerResult(game, isWhite),
+      isWhite: isWhite,
+    );
+  }
+
+  Future<void> _sharePlayerEventProfile({
+    required BuildContext context,
+    required PlayerStandingModel player,
+    required Future<String?>? photoFuture,
+    required String initials,
+    required String? eventName,
+    required int? performanceRating,
+    required double? eventScore,
+    required int? eventTotalGames,
+    required int? ratingDiff,
+    required int? standardRating,
+    required int? rapidRating,
+    required int? blitzRating,
+    required List<PlayerEventShareGameRow> rows,
+    required String? shareUrl,
+  }) async {
+    try {
+      final logicalWidth = math.min(MediaQuery.of(context).size.width, 430.0);
+      final imageBytes = await ScreenshotController().captureFromWidget(
+        PlayerEventShareImageCard(
+          width: logicalWidth,
+          player: player,
+          photoFuture: photoFuture,
+          initials: initials,
+          eventName: eventName,
+          performanceRating: performanceRating,
+          eventScore: eventScore,
+          eventTotalGames: eventTotalGames,
+          ratingDiff: ratingDiff,
+          standardRating: standardRating,
+          rapidRating: rapidRating,
+          blitzRating: blitzRating,
+          rows: rows,
+        ),
+        context: context,
+        pixelRatio: 3.0,
+        delay: const Duration(milliseconds: 250),
+      );
+      final tempDir = await getTemporaryDirectory();
+      final file = io.File('${tempDir.path}/chessever_player_profile.png');
+      await file.writeAsBytes(imageBytes);
+      if (!context.mounted) return;
+      await Share.shareXFiles(
+        [XFile(file.path, mimeType: 'image/png')],
+        text: shareUrl,
+        subject: eventName?.trim().isNotEmpty == true ? eventName : 'ChessEver',
+        sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
+      );
+    } catch (error) {
+      debugPrint('Failed to share player profile: $error');
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to share player profile')),
+      );
+    }
+  }
+
   void _navigateToPlayerProfile(
     BuildContext context,
     WidgetRef ref,
@@ -1108,7 +1272,7 @@ class _PlayerHeaderRow extends StatelessWidget {
         ),
         if (hasTournamentContext)
           Icon(
-            Icons.keyboard_arrow_down,
+            Icons.more_horiz,
             color: context.colors.textPrimaryMuted,
             size: 20.ic,
           ),
@@ -1170,7 +1334,9 @@ class _PlayerAvatarTile extends StatelessWidget {
 }
 
 class _SliverScoreboardAppBar extends ConsumerStatefulWidget {
-  const _SliverScoreboardAppBar();
+  const _SliverScoreboardAppBar({this.onShareProfile});
+
+  final Future<void> Function()? onShareProfile;
 
   @override
   ConsumerState<_SliverScoreboardAppBar> createState() =>
@@ -1281,7 +1447,11 @@ class _SliverScoreboardAppBarState
         maxHeight: MediaQuery.of(context).size.height * 0.6,
         maxWidth: ResponsiveHelper.bottomSheetMaxWidth,
       ),
-      builder: (context) => _PlayerSelectionSheet(players: players),
+      builder:
+          (context) => _PlayerSelectionSheet(
+            players: players,
+            onShareProfile: widget.onShareProfile,
+          ),
     );
   }
 
@@ -1499,8 +1669,9 @@ class _RatingDisplay extends ConsumerWidget {
 /// Bottom sheet for selecting a player from the tournament
 class _PlayerSelectionSheet extends ConsumerWidget {
   final List<PlayerStandingModel> players;
+  final Future<void> Function()? onShareProfile;
 
-  const _PlayerSelectionSheet({required this.players});
+  const _PlayerSelectionSheet({required this.players, this.onShareProfile});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -1519,6 +1690,34 @@ class _PlayerSelectionSheet extends ConsumerWidget {
             borderRadius: BorderRadius.circular(2.br),
           ),
         ),
+        if (onShareProfile != null) ...[
+          InkWell(
+            onTap: () {
+              Navigator.pop(context);
+              onShareProfile!();
+            },
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.sp, vertical: 10.h),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.ios_share,
+                    color: context.colors.brand,
+                    size: 18.ic,
+                  ),
+                  SizedBox(width: 10.w),
+                  Text(
+                    'Share Profile',
+                    style: AppTypography.textSmBold.copyWith(
+                      color: context.colors.textPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Divider(color: context.colors.surfaceRecessed, height: 1.h),
+        ],
         // Title
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 16.sp, vertical: 10.h),
@@ -1598,7 +1797,7 @@ class _PlayerSelectionSheet extends ConsumerWidget {
                           style: AppTypography.textSmMedium.copyWith(
                             color:
                                 isSelected
-                                    ? kGreenColor
+                                    ? context.colors.brand
                                     : context.colors.textPrimary,
                           ),
                           overflow: TextOverflow.ellipsis,
@@ -1608,14 +1807,12 @@ class _PlayerSelectionSheet extends ConsumerWidget {
                       Text(
                         player.score.toStringAsFixed(0),
                         style: AppTypography.textXsMedium.copyWith(
-                          color: context.colors.textPrimaryMuted,
+                          color:
+                              isSelected
+                                  ? context.colors.brand
+                                  : context.colors.textPrimaryMuted,
                         ),
                       ),
-                      // Selected indicator
-                      if (isSelected) ...[
-                        SizedBox(width: 6.w),
-                        Icon(Icons.check, color: kGreenColor, size: 18.ic),
-                      ],
                     ],
                   ),
                 ),

--- a/lib/screens/standings/widgets/player_event_share_image_card.dart
+++ b/lib/screens/standings/widgets/player_event_share_image_card.dart
@@ -1,0 +1,541 @@
+import 'package:chessever2/screens/standings/player_standing_model.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/png_asset.dart';
+import 'package:chessever2/widgets/federation_flag.dart';
+import 'package:chessever2/widgets/player_initials_avatar.dart';
+import 'package:flutter/material.dart';
+
+@visibleForTesting
+bool playerEventShareShouldShowFooter(int rowCount) => rowCount <= 11;
+
+@visibleForTesting
+double playerEventShareRowHeight(int rowCount) =>
+    rowCount >= 13
+        ? 47.0
+        : rowCount >= 11
+        ? 50.0
+        : 54.0;
+
+class PlayerEventShareGameRow {
+  const PlayerEventShareGameRow({
+    required this.roundLabel,
+    required this.countryCode,
+    required this.title,
+    required this.name,
+    required this.rating,
+    required this.ratingChange,
+    required this.result,
+    required this.isWhite,
+  });
+
+  final String? roundLabel;
+  final String countryCode;
+  final String? title;
+  final String name;
+  final int rating;
+  final double? ratingChange;
+  final String result;
+  final bool isWhite;
+}
+
+class PlayerEventShareImageCard extends StatelessWidget {
+  const PlayerEventShareImageCard({
+    super.key,
+    required this.width,
+    required this.player,
+    required this.photoFuture,
+    required this.initials,
+    required this.eventName,
+    required this.performanceRating,
+    required this.eventScore,
+    required this.eventTotalGames,
+    required this.ratingDiff,
+    required this.standardRating,
+    required this.rapidRating,
+    required this.blitzRating,
+    required this.rows,
+  });
+
+  final double width;
+  final PlayerStandingModel player;
+  final Future<String?>? photoFuture;
+  final String initials;
+  final String? eventName;
+  final int? performanceRating;
+  final double? eventScore;
+  final int? eventTotalGames;
+  final int? ratingDiff;
+  final int? standardRating;
+  final int? rapidRating;
+  final int? blitzRating;
+  final List<PlayerEventShareGameRow> rows;
+
+  static const _background = Color(0xFF0B0B0E);
+  static const _surface = Color(0xFF18191D);
+  static const _topSurface = Color(0xFF12161B);
+  static const _divider = Color(0xFF2B2D31);
+  static const _muted = Color(0xFFBABCC5);
+
+  @override
+  Widget build(BuildContext context) {
+    final showFooter = playerEventShareShouldShowFooter(rows.length);
+    final rowHeight = playerEventShareRowHeight(rows.length);
+    final ratingAreaHeight = rows.length >= 13 ? 118.0 : 128.0;
+    final statsHeight = rows.length >= 13 ? 76.0 : 86.0;
+    final rowsHeight = rows.length * rowHeight;
+    final footerHeight = showFooter ? 28.0 : 8.0;
+    final totalHeight =
+        48.0 +
+        58.0 +
+        12.0 +
+        ratingAreaHeight +
+        12.0 +
+        statsHeight +
+        12.0 +
+        rowsHeight +
+        footerHeight;
+
+    return MediaQuery(
+      data: MediaQueryData(
+        size: Size(width, totalHeight),
+        padding: EdgeInsets.zero,
+      ),
+      child: Material(
+        color: _background,
+        child: SizedBox(
+          width: width,
+          height: totalHeight,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildEventStrip(),
+              _buildPlayerHeader(context),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: _buildRatingsRow(context, ratingAreaHeight),
+              ),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: _buildStatsRow(context, statsHeight),
+              ),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: _buildGamesList(context, rowHeight),
+              ),
+              if (showFooter)
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      'ChessEver · Follow Chess Better',
+                      style: AppTypography.textXsMedium.copyWith(
+                        color: _muted.withValues(alpha: 0.6),
+                        fontSize: 11,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                const SizedBox(height: 8),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEventStrip() {
+    final title = eventName?.trim();
+    return Container(
+      height: 48,
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(horizontal: 18),
+      color: const Color(0xFF07080B),
+      child: Text(
+        title == null || title.isEmpty ? 'ChessEver Event' : title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        textAlign: TextAlign.center,
+        style: AppTypography.textSmBold.copyWith(color: _muted, fontSize: 14),
+      ),
+    );
+  }
+
+  Widget _buildPlayerHeader(BuildContext context) {
+    final titleText = (player.title ?? '').trim();
+    final countryCode = player.countryCode.trim();
+    return Container(
+      height: 58,
+      color: _topSurface,
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        children: [
+          if (countryCode.isNotEmpty)
+            FederationFlag(
+              federation: countryCode,
+              height: 16,
+              width: 22,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          if (countryCode.isNotEmpty) const SizedBox(width: 10),
+          Expanded(
+            child: RichText(
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              text: TextSpan(
+                children: [
+                  if (titleText.isNotEmpty)
+                    TextSpan(
+                      text: '$titleText ',
+                      style: AppTypography.textMdBold.copyWith(
+                        color: kLightYellowColor,
+                        fontSize: 20,
+                      ),
+                    ),
+                  TextSpan(
+                    text: player.name,
+                    style: AppTypography.textMdBold.copyWith(
+                      color: Colors.white,
+                      fontSize: 20,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRatingsRow(BuildContext context, double height) {
+    return SizedBox(
+      height: height,
+      child: Row(
+        children: [
+          SizedBox(
+            width: height,
+            child: FutureBuilder<String?>(
+              future: photoFuture,
+              builder: (context, snapshot) {
+                return PlayerInitialsAvatar(
+                  photoUrl: snapshot.data,
+                  initials: initials,
+                  size: height,
+                  borderRadius: 12,
+                  title: player.title,
+                );
+              },
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: _ShareRatingTile(
+              label: 'Classical',
+              icon: PngAsset.classicalIcon,
+              rating: standardRating,
+              height: height,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: _ShareRatingTile(
+              label: 'Rapid',
+              icon: PngAsset.rapidIcon,
+              rating: rapidRating,
+              height: height,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: _ShareRatingTile(
+              label: 'Blitz',
+              icon: PngAsset.blitzIcon,
+              rating: blitzRating,
+              height: height,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatsRow(BuildContext context, double height) {
+    final scoreText =
+        eventScore != null && eventTotalGames != null
+            ? _formatScore(eventScore!, eventTotalGames!)
+            : '-';
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: _surface,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          _ShareStat(
+            label: 'Performance',
+            value: performanceRating?.toString() ?? '-',
+          ),
+          _ShareStat(label: 'Score', value: scoreText),
+          _ShareStat(
+            label: 'Rating',
+            value:
+                ratingDiff == null
+                    ? '-'
+                    : (ratingDiff! >= 0 ? '+$ratingDiff' : '$ratingDiff'),
+            valueColor:
+                ratingDiff == null
+                    ? Colors.white
+                    : ratingDiff! >= 0
+                    ? context.colors.brand
+                    : kRedColor,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGamesList(BuildContext context, double rowHeight) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        color: const Color(0xFF161719),
+        child: Column(
+          children: [
+            for (final entry in rows.asMap().entries)
+              _ShareGameRow(
+                row: entry.value,
+                index: entry.key,
+                height: rowHeight,
+                isLast: entry.key == rows.length - 1,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _formatScore(double score, int totalGames) {
+    final scoreStr =
+        score == score.truncate()
+            ? score.truncate().toString()
+            : score.toString();
+    return '$scoreStr/$totalGames';
+  }
+}
+
+class _ShareRatingTile extends StatelessWidget {
+  const _ShareRatingTile({
+    required this.label,
+    required this.icon,
+    required this.rating,
+    required this.height,
+  });
+
+  final String label;
+  final String icon;
+  final int? rating;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: PlayerEventShareImageCard._surface,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Image.asset(icon, width: 18, height: 18),
+          const SizedBox(height: 5),
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.textXsMedium.copyWith(
+              color: PlayerEventShareImageCard._muted,
+              fontSize: 11,
+            ),
+          ),
+          const SizedBox(height: 5),
+          Text(
+            rating?.toString() ?? '-',
+            style: AppTypography.textMdBold.copyWith(
+              color: Colors.white,
+              fontSize: 18,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ShareStat extends StatelessWidget {
+  const _ShareStat({required this.label, required this.value, this.valueColor});
+
+  final String label;
+  final String value;
+  final Color? valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          label,
+          style: AppTypography.textXsMedium.copyWith(
+            color: PlayerEventShareImageCard._muted,
+            fontSize: 12,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: AppTypography.textLgBold.copyWith(
+            color: valueColor ?? Colors.white,
+            fontSize: 21,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ShareGameRow extends StatelessWidget {
+  const _ShareGameRow({
+    required this.row,
+    required this.index,
+    required this.height,
+    required this.isLast,
+  });
+
+  final PlayerEventShareGameRow row;
+  final int index;
+  final double height;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    final nameFontSize = height <= 48 ? 14.2 : 15.2;
+    final titleText = (row.title ?? '').trim();
+    return Container(
+      height: height,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      decoration: BoxDecoration(
+        border:
+            isLast
+                ? null
+                : const Border(
+                  bottom: BorderSide(
+                    color: PlayerEventShareImageCard._divider,
+                    width: 0.7,
+                  ),
+                ),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 30,
+            child: Text(
+              row.roundLabel ?? '${index + 1}.',
+              style: AppTypography.textMdBold.copyWith(
+                color: Colors.white,
+                fontSize: nameFontSize,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (row.countryCode.trim().isNotEmpty)
+            FederationFlag(
+              federation: row.countryCode,
+              height: 14,
+              width: 20,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          if (row.countryCode.trim().isNotEmpty) const SizedBox(width: 9),
+          Expanded(
+            child: RichText(
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              text: TextSpan(
+                children: [
+                  if (titleText.isNotEmpty)
+                    TextSpan(
+                      text: '$titleText ',
+                      style: AppTypography.textMdBold.copyWith(
+                        color: kLightYellowColor,
+                        fontSize: nameFontSize,
+                      ),
+                    ),
+                  TextSpan(
+                    text: row.name,
+                    style: AppTypography.textMdBold.copyWith(
+                      color: Colors.white,
+                      fontSize: nameFontSize,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Text(
+            row.rating.toString(),
+            style: AppTypography.textMdMedium.copyWith(
+              color: Colors.white,
+              fontSize: 15,
+            ),
+          ),
+          if (row.ratingChange != null && row.ratingChange != 0.0) ...[
+            const SizedBox(width: 4),
+            Text(
+              row.ratingChange! > 0
+                  ? '+${row.ratingChange!.toStringAsFixed(0)}'
+                  : row.ratingChange!.toStringAsFixed(0),
+              style: AppTypography.textXsMedium.copyWith(
+                color: row.ratingChange! > 0 ? context.colors.brand : kRedColor,
+                fontSize: 11,
+              ),
+            ),
+          ],
+          const SizedBox(width: 12),
+          Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              color: row.isWhite ? Colors.white : Colors.black,
+              shape: BoxShape.circle,
+              border:
+                  row.isWhite
+                      ? null
+                      : Border.all(
+                        color: Colors.white.withValues(alpha: 0.35),
+                        width: 1.1,
+                      ),
+            ),
+            child: Center(
+              child: Text(
+                row.result,
+                textAlign: TextAlign.center,
+                style: AppTypography.textMdBold.copyWith(
+                  color: row.isWhite ? Colors.black : Colors.white,
+                  fontSize: 15,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/screens/standings/player_event_share_image_card_test.dart
+++ b/test/screens/standings/player_event_share_image_card_test.dart
@@ -1,0 +1,19 @@
+import 'package:chessever2/screens/standings/widgets/player_event_share_image_card.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('player event share image sizing rules', () {
+    test('keeps footer only when it does not compete with many rows', () {
+      expect(playerEventShareShouldShowFooter(10), isTrue);
+      expect(playerEventShareShouldShowFooter(11), isTrue);
+      expect(playerEventShareShouldShowFooter(12), isFalse);
+      expect(playerEventShareShouldShowFooter(13), isFalse);
+    });
+
+    test('compresses rows for 11 and 13 round events without hiding rows', () {
+      expect(playerEventShareRowHeight(9), 54.0);
+      expect(playerEventShareRowHeight(11), 50.0);
+      expect(playerEventShareRowHeight(13), 47.0);
+    });
+  });
+}

--- a/test/screens/standings/score_card_swipe_navigation_test.dart
+++ b/test/screens/standings/score_card_swipe_navigation_test.dart
@@ -1,0 +1,82 @@
+import 'package:chessever2/screens/standings/player_standing_model.dart';
+import 'package:chessever2/screens/standings/score_card_screen.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  PlayerStandingModel player({
+    required String name,
+    int? fideId,
+    String? gamebasePlayerId,
+  }) {
+    return PlayerStandingModel(
+      countryCode: 'AZE',
+      name: name,
+      score: 2500,
+      scoreChange: 0,
+      matchScore: '0 / 0',
+      fideId: fideId,
+      gamebasePlayerId: gamebasePlayerId,
+    );
+  }
+
+  group('score card swipe navigation', () {
+    test('selects adjacent players in standings order', () {
+      final players = [
+        player(name: 'First, Player', fideId: 1),
+        player(name: 'Second, Player', fideId: 2),
+        player(name: 'Third, Player', fideId: 3),
+      ];
+
+      expect(
+        adjacentScoreCardPlayerForSwipe(
+          players: players,
+          selectedPlayer: players[1],
+          direction: ScoreCardSwipeDirection.previous,
+        ),
+        players[0],
+      );
+      expect(
+        adjacentScoreCardPlayerForSwipe(
+          players: players,
+          selectedPlayer: players[1],
+          direction: ScoreCardSwipeDirection.next,
+        ),
+        players[2],
+      );
+    });
+
+    test('does not wrap past the first or last player', () {
+      final players = [
+        player(name: 'First, Player', fideId: 1),
+        player(name: 'Second, Player', fideId: 2),
+      ];
+
+      expect(
+        adjacentScoreCardPlayerForSwipe(
+          players: players,
+          selectedPlayer: players.first,
+          direction: ScoreCardSwipeDirection.previous,
+        ),
+        isNull,
+      );
+      expect(
+        adjacentScoreCardPlayerForSwipe(
+          players: players,
+          selectedPlayer: players.last,
+          direction: ScoreCardSwipeDirection.next,
+        ),
+        isNull,
+      );
+    });
+
+    test('matches equivalent selected player by fide id before name', () {
+      final players = [
+        player(name: 'Displayed, Name', fideId: 42),
+        player(name: 'Other, Player', fideId: 43),
+      ];
+      final selected = player(name: 'Slightly Different, Name', fideId: 42);
+
+      expect(findScoreCardPlayerIndex(players, selected), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a screenshot-style `Share Profile` action to the player selector sheet on the scorecard/player event screen
- replace the player header dropdown chevron with a 3-dot affordance and keep selected player styling in ChessEver blue instead of green/checkmark
- generate a share-safe player event image that keeps the current screen style, removes navigation/profile chrome, puts the event name at the top, prioritizes readable opponent rows, and drops footer branding when 12+ rows need the space

## Validation
- `git diff --check`
- `flutter analyze --no-pub lib/screens/standings/score_card_screen.dart lib/screens/standings/widgets/player_event_share_image_card.dart test/screens/standings/player_event_share_image_card_test.dart`
- `flutter test --no-pub test/standings/fide_rating_change_test.dart test/screens/standings/player_event_share_image_card_test.dart`

Not shipped until reviewed/merged.
