### PR TITLE
fix: sort calendar events by start date

### DIFF
--- a/lib/screens/calendar/provider/calendar_search_isolate.dart
+++ b/lib/screens/calendar/provider/calendar_search_isolate.dart
@@ -185,7 +185,7 @@ CalendarSearchResult filterCalendarEventsIsolate(CalendarSearchParams params) {
 
   final summaries = <MonthEventsData>[];
   for (int i = 1; i <= 12; i++) {
-    final sorted = _sortEvents(monthEvents[i]!, filterMode: params.filterMode);
+    final sorted = _sortEvents(monthEvents[i]!);
     summaries.add(
       MonthEventsData(
         monthName: params.monthNames[i - 1],
@@ -340,48 +340,15 @@ void _addDateTokens(Set<String> tokens, DateTime date) {
   return (singleDate, singleDate);
 }
 
-List<CalendarEventData> _sortEvents(
-  List<CalendarEventData> events, {
-  required String filterMode,
-}) {
+List<CalendarEventData> _sortEvents(List<CalendarEventData> events) {
   if (events.isEmpty) return events;
 
   final sorted = List<CalendarEventData>.from(events);
 
-  if (filterMode == 'favorites') {
-    // Favorites: starred events sorted by newest date first
-    sorted.sort((a, b) => _compareByDate(a, b, descending: true));
-  } else if (filterMode == 'upcoming') {
-    // Upcoming: date ascending (soonest first)
-    sorted.sort(_compareByDate);
-  } else {
-    // Category-based sorting for regular view
-    const categoryOrder = {
-      'live': 0,
-      'ongoing': 1,
-      'upcoming': 2,
-      'completed': 3,
-    };
-
-    sorted.sort((a, b) {
-      final catA = categoryOrder[a.tourEventCategory] ?? 3;
-      final catB = categoryOrder[b.tourEventCategory] ?? 3;
-
-      if (catA != catB) return catA.compareTo(catB);
-
-      // For upcoming events, sort by start date ascending
-      if (a.tourEventCategory == 'upcoming') {
-        final dateA = a.startDate ?? a.endDate;
-        final dateB = b.startDate ?? b.endDate;
-        if (dateA != null && dateB != null) {
-          return dateA.compareTo(dateB);
-        }
-      }
-
-      // For other categories, sort by ELO descending
-      return b.maxAvgElo.compareTo(a.maxAvgElo);
-    });
-  }
+  // Calendar lists should read chronologically inside each month/filter.
+  // Do not rank by title, category, or ELO here: users expect July events to
+  // progress by their actual start date even when an event began in June.
+  sorted.sort(_compareByDate);
 
   return sorted;
 }
@@ -495,7 +462,7 @@ DetailSearchResult filterDetailEventsIsolate(DetailSearchParams params) {
   }
 
   return DetailSearchResult(
-    events: _sortEvents(filteredEvents, filterMode: params.filterMode),
+    events: _sortEvents(filteredEvents),
     eventsToPrime: eventsToPrime,
   );
 }

--- a/test/screens/calendar/calendar_search_isolate_test.dart
+++ b/test/screens/calendar/calendar_search_isolate_test.dart
@@ -1,0 +1,214 @@
+import 'package:chessever2/screens/calendar/provider/calendar_search_isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('calendar event sorting', () {
+    test('month summaries sort events by start date ascending', () {
+      final result = filterCalendarEventsIsolate(
+        CalendarSearchParams(
+          events: [
+            _event(
+              id: 'jul-23-a',
+              title: '30.Battle of Senta',
+              startDate: DateTime.utc(2026, 7, 23),
+              endDate: DateTime.utc(2026, 7, 29),
+              category: 'live',
+              maxAvgElo: 2700,
+            ),
+            _event(
+              id: 'jun-27',
+              title: '32. Open Klatovy',
+              startDate: DateTime.utc(2026, 6, 27),
+              endDate: DateTime.utc(2026, 7, 5),
+              category: 'completed',
+              maxAvgElo: 1800,
+            ),
+            _event(
+              id: 'jul-9',
+              title: '34th National Men Chess Championship 2026',
+              startDate: DateTime.utc(2026, 7, 9),
+              endDate: DateTime.utc(2026, 7, 13),
+              category: 'upcoming',
+              maxAvgElo: 2100,
+            ),
+            _event(
+              id: 'jul-18',
+              title: '3rd Dole Open 2026',
+              startDate: DateTime.utc(2026, 7, 18),
+              endDate: DateTime.utc(2026, 7, 26),
+              category: 'ongoing',
+              maxAvgElo: 2400,
+            ),
+          ],
+          searchQuery: '',
+          timeControl: null,
+          selectedYear: 2026,
+          today: DateTime.utc(2026, 7),
+          filterMode: 'all',
+          favoriteEventIds: const {},
+          favoritePlayersMap: const {},
+          monthNames: _monthNames,
+        ),
+      );
+
+      final julyTitles = result.summaries[6].events.map((e) => e.title);
+
+      expect(julyTitles, [
+        '32. Open Klatovy',
+        '34th National Men Chess Championship 2026',
+        '3rd Dole Open 2026',
+        '30.Battle of Senta',
+      ]);
+    });
+
+    test('detail results sort by start date ascending across categories', () {
+      final result = filterDetailEventsIsolate(
+        DetailSearchParams(
+          events: [
+            _event(
+              id: 'later-live',
+              title: 'Later Live Event',
+              startDate: DateTime.utc(2026, 7, 23),
+              category: 'live',
+              maxAvgElo: 2700,
+            ),
+            _event(
+              id: 'early-completed',
+              title: 'Early Completed Event',
+              startDate: DateTime.utc(2026, 7, 7),
+              category: 'completed',
+              maxAvgElo: 1500,
+            ),
+            _event(
+              id: 'middle-upcoming',
+              title: 'Middle Upcoming Event',
+              startDate: DateTime.utc(2026, 7, 18),
+              category: 'upcoming',
+              maxAvgElo: 2600,
+            ),
+          ],
+          searchQuery: '',
+          timeControl: null,
+          month: 7,
+          year: 2026,
+          today: DateTime.utc(2026, 7),
+          filterMode: 'all',
+          favoriteEventIds: const {},
+          favoritePlayersMap: const {},
+        ),
+      );
+
+      expect(result.events.map((e) => e.id), [
+        'early-completed',
+        'middle-upcoming',
+        'later-live',
+      ]);
+    });
+
+    test('favorites and upcoming filters keep start-date ascending order', () {
+      final favoriteResult = filterDetailEventsIsolate(
+        DetailSearchParams(
+          events: [
+            _event(
+              id: 'favorite-later',
+              title: 'Favorite Later Event',
+              startDate: DateTime.utc(2026, 7, 20),
+              category: 'upcoming',
+            ),
+            _event(
+              id: 'favorite-earlier',
+              title: 'Favorite Earlier Event',
+              startDate: DateTime.utc(2026, 7, 10),
+              category: 'upcoming',
+            ),
+          ],
+          searchQuery: '',
+          timeControl: null,
+          month: 7,
+          year: 2026,
+          today: DateTime.utc(2026, 7),
+          filterMode: 'favorites',
+          favoriteEventIds: const {'favorite-later', 'favorite-earlier'},
+          favoritePlayersMap: const {},
+        ),
+      );
+      final upcomingResult = filterDetailEventsIsolate(
+        DetailSearchParams(
+          events: [
+            _event(
+              id: 'upcoming-later',
+              title: 'Upcoming Later Event',
+              startDate: DateTime.utc(2026, 7, 20),
+              category: 'upcoming',
+              isMajorUpcoming: true,
+            ),
+            _event(
+              id: 'upcoming-earlier',
+              title: 'Upcoming Earlier Event',
+              startDate: DateTime.utc(2026, 7, 10),
+              category: 'upcoming',
+              isMajorUpcoming: true,
+            ),
+          ],
+          searchQuery: '',
+          timeControl: null,
+          month: 7,
+          year: 2026,
+          today: DateTime.utc(2026, 7),
+          filterMode: 'upcoming',
+          favoriteEventIds: const {},
+          favoritePlayersMap: const {},
+        ),
+      );
+
+      expect(favoriteResult.events.map((e) => e.id), [
+        'favorite-earlier',
+        'favorite-later',
+      ]);
+      expect(upcomingResult.events.map((e) => e.id), [
+        'upcoming-earlier',
+        'upcoming-later',
+      ]);
+    });
+  });
+}
+
+CalendarEventData _event({
+  required String id,
+  required String title,
+  required DateTime startDate,
+  DateTime? endDate,
+  required String category,
+  int maxAvgElo = 0,
+  bool isMajorUpcoming = false,
+}) {
+  return CalendarEventData(
+    id: id,
+    title: title,
+    location: 'Test location',
+    timeControl: 'Standard',
+    startDate: startDate,
+    endDate: endDate ?? startDate,
+    dates: '${startDate.month}/${startDate.day}',
+    maxAvgElo: maxAvgElo,
+    timeUntilStart: '',
+    tourEventCategory: category,
+    eventSource: 'communityEvent',
+    isMajorUpcoming: isMajorUpcoming,
+  );
+}
+
+const _monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];


### PR DESCRIPTION
## Summary
- Sort Calendar event lists by start date ascending instead of category/ELO ordering.
- Applies only to Calendar month/detail filtering via `calendar_search_isolate.dart`.
- Keeps events that overlap a month chronological by their actual start date, including events that began in the previous month.

## Test plan
- `dart format --set-exit-if-changed lib/screens/calendar/provider/calendar_search_isolate.dart test/screens/calendar/calendar_search_isolate_test.dart`
- `flutter test --no-pub test/screens/calendar/calendar_search_isolate_test.dart`
- `flutter analyze --no-pub lib/screens/calendar/provider/calendar_search_isolate.dart test/screens/calendar/calendar_search_isolate_test.dart`
- `git diff --check`

## Scope note
This does not change sorting for For You, Favorites tab, Countrymen, Smart Events, tournament detail pages, Player Profile events, or global event cards.
