### PR TITLE
fix: standardize smart game filters

### DIFF
--- a/lib/screens/premium_games/providers/premium_games_provider.dart
+++ b/lib/screens/premium_games/providers/premium_games_provider.dart
@@ -4,6 +4,7 @@ import 'package:chessever2/providers/country_dropdown_provider.dart';
 import 'package:chessever2/providers/favorite_players_provider.dart';
 import 'package:chessever2/repository/supabase/game/game_repository.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/widgets/game_filter/game_filter_model.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -88,18 +89,27 @@ class PremiumGamesFilter {
   const PremiumGamesFilter({
     this.dateRange = PremiumGamesDateRange.allTime,
     this.result = PremiumGamesResult.all,
+    this.timeControl = GameTimeControlFilter.all,
+    this.eco = GameEcoFilter.all,
+    this.finish = GameFinishFilter.all,
     this.minElo,
     this.maxElo,
   });
 
   final PremiumGamesDateRange dateRange;
   final PremiumGamesResult result;
+  final GameTimeControlFilter timeControl;
+  final GameEcoFilter eco;
+  final GameFinishFilter finish;
   final int? minElo;
   final int? maxElo;
 
   bool get hasActiveFilters {
     return dateRange != PremiumGamesDateRange.allTime ||
         result != PremiumGamesResult.all ||
+        timeControl != GameTimeControlFilter.all ||
+        !eco.isAll ||
+        finish != GameFinishFilter.all ||
         minElo != null ||
         maxElo != null;
   }
@@ -107,6 +117,9 @@ class PremiumGamesFilter {
   PremiumGamesFilter copyWith({
     PremiumGamesDateRange? dateRange,
     PremiumGamesResult? result,
+    GameTimeControlFilter? timeControl,
+    GameEcoFilter? eco,
+    GameFinishFilter? finish,
     int? minElo,
     int? maxElo,
     bool clearElo = false,
@@ -114,6 +127,9 @@ class PremiumGamesFilter {
     return PremiumGamesFilter(
       dateRange: dateRange ?? this.dateRange,
       result: result ?? this.result,
+      timeControl: timeControl ?? this.timeControl,
+      eco: eco ?? this.eco,
+      finish: finish ?? this.finish,
       minElo: clearElo ? null : (minElo ?? this.minElo),
       maxElo: clearElo ? null : (maxElo ?? this.maxElo),
     );
@@ -169,14 +185,15 @@ final premiumGamesFilterProvider =
     );
 
 /// Provider for premium games based on type.
-final premiumGamesProvider = StateNotifierProvider.autoDispose.family<
-  PremiumGamesNotifier,
-  AsyncValue<PremiumGamesState>,
-  PremiumGamesType
->((ref, type) {
-  ref.keepAlive();
-  return PremiumGamesNotifier(ref, type);
-});
+final premiumGamesProvider = StateNotifierProvider.autoDispose
+    .family<
+      PremiumGamesNotifier,
+      AsyncValue<PremiumGamesState>,
+      PremiumGamesType
+    >((ref, type) {
+      ref.keepAlive();
+      return PremiumGamesNotifier(ref, type);
+    });
 
 /// Notifier for managing premium games state.
 class PremiumGamesNotifier
@@ -304,11 +321,10 @@ class PremiumGamesNotifier
     }
 
     // Get FIDE IDs from favorites
-    final fideIds =
-        favorites
-            .where((f) => f.fideId != null && f.fideId!.isNotEmpty)
-            .map((f) => f.fideId!)
-            .toList();
+    final fideIds = favorites
+        .where((f) => f.fideId != null && f.fideId!.isNotEmpty)
+        .map((f) => f.fideId!)
+        .toList();
 
     if (fideIds.isEmpty) {
       debugPrint('[PremiumGames] No FIDE IDs for favorites');
@@ -415,6 +431,16 @@ class PremiumGamesNotifier
 
       // Result filter
       if (!filter.result.matches(game.effectiveGameStatus)) {
+        return false;
+      }
+
+      final gameFilter = GameFilter(
+        result: GameResultFilter.all,
+        timeControl: filter.timeControl,
+        eco: filter.eco,
+        finish: filter.finish,
+      );
+      if (!GameFilterHelper.applyFilter([game], gameFilter).contains(game)) {
         return false;
       }
 

--- a/lib/screens/premium_games/widgets/premium_games_filter.dart
+++ b/lib/screens/premium_games/widgets/premium_games_filter.dart
@@ -5,6 +5,8 @@ import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/alert_dialog/alert_modal.dart';
+import 'package:chessever2/widgets/game_filter/eco_filter_dropdown.dart';
+import 'package:chessever2/widgets/game_filter/game_filter_model.dart';
 import 'package:chessever2/widgets/game_filter/rating_tier_filter.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -42,13 +44,19 @@ class _PremiumGamesFilterDialogState
     extends ConsumerState<PremiumGamesFilterDialog> {
   late PremiumGamesDateRange _dateRange;
   late PremiumGamesResult _result;
+  late GameTimeControlFilter _timeControl;
   late int? _selectedMinElo;
+  late GameEcoFilter _eco;
+  late GameFinishFilter _finish;
 
   @override
   void initState() {
     super.initState();
     _dateRange = widget.initialFilter.dateRange;
     _result = widget.initialFilter.result;
+    _timeControl = widget.initialFilter.timeControl;
+    _eco = widget.initialFilter.eco;
+    _finish = widget.initialFilter.finish;
     _selectedMinElo = RatingTierFilter.normalizeMinRating(
       widget.initialFilter.minElo,
     );
@@ -111,21 +119,57 @@ class _PremiumGamesFilterDialogState
                   ),
                   SizedBox(height: 20.h),
 
-                  // Date Range
-                  _SectionTitle(title: 'Date Range'),
+                  // Standard smart-game filter order.
+                  _SectionTitle(title: 'Time control'),
                   SizedBox(height: 8.h),
                   _ChipGrid(
-                    items: PremiumGamesDateRange.values,
-                    selectedItem: _dateRange,
-                    getLabel: (item) => item.displayText,
+                    items: GameTimeControlFilter.values,
+                    selectedItem: _timeControl,
+                    getLabel: (item) => item == GameTimeControlFilter.all
+                        ? 'All'
+                        : item.displayText,
                     onSelected: (item) {
                       HapticFeedbackService.selection();
-                      setState(() => _dateRange = item);
+                      setState(() => _timeControl = item);
                     },
                   ),
                   SizedBox(height: 20.h),
 
-                  // Result
+                  _SectionTitle(title: 'Avg. Rating'),
+                  SizedBox(height: 8.h),
+                  RatingTierFilter(
+                    selectedMinRating: _selectedMinElo,
+                    onChanged: (value) {
+                      HapticFeedbackService.selection();
+                      setState(() => _selectedMinElo = value);
+                    },
+                  ),
+                  SizedBox(height: 20.h),
+
+                  _SectionTitle(title: 'ECO / Opening'),
+                  SizedBox(height: 8.h),
+                  EcoFilterDropdown(
+                    value: _eco,
+                    onChanged: (value) {
+                      HapticFeedbackService.selection();
+                      setState(() => _eco = value);
+                    },
+                  ),
+                  SizedBox(height: 20.h),
+
+                  _SectionTitle(title: 'Finish'),
+                  SizedBox(height: 8.h),
+                  _ChipGrid(
+                    items: GameFinishFilter.values,
+                    selectedItem: _finish,
+                    getLabel: (item) => item.displayText,
+                    onSelected: (item) {
+                      HapticFeedbackService.selection();
+                      setState(() => _finish = item);
+                    },
+                  ),
+                  SizedBox(height: 20.h),
+
                   _SectionTitle(title: 'Result'),
                   SizedBox(height: 8.h),
                   _ChipGrid(
@@ -139,13 +183,15 @@ class _PremiumGamesFilterDialogState
                   ),
                   SizedBox(height: 20.h),
 
-                  _SectionTitle(title: 'Level'),
+                  _SectionTitle(title: 'Date range'),
                   SizedBox(height: 8.h),
-                  RatingTierFilter(
-                    selectedMinRating: _selectedMinElo,
-                    onChanged: (value) {
+                  _ChipGrid(
+                    items: PremiumGamesDateRange.values,
+                    selectedItem: _dateRange,
+                    getLabel: (item) => item.displayText,
+                    onSelected: (item) {
                       HapticFeedbackService.selection();
-                      setState(() => _selectedMinElo = value);
+                      setState(() => _dateRange = item);
                     },
                   ),
                   SizedBox(height: 16.h),
@@ -217,6 +263,9 @@ class _PremiumGamesFilterDialogState
     setState(() {
       _dateRange = PremiumGamesDateRange.allTime;
       _result = PremiumGamesResult.all;
+      _timeControl = GameTimeControlFilter.all;
+      _eco = GameEcoFilter.all;
+      _finish = GameFinishFilter.all;
       _selectedMinElo = null;
     });
   }
@@ -226,6 +275,9 @@ class _PremiumGamesFilterDialogState
     final filter = PremiumGamesFilter(
       dateRange: _dateRange,
       result: _result,
+      timeControl: _timeControl,
+      eco: _eco,
+      finish: _finish,
       minElo: _selectedMinElo,
       maxElo: null,
     );
@@ -289,10 +341,9 @@ class _ChipGrid<T> extends StatelessWidget {
               color: isSelected ? kPrimaryColor : context.colors.surface,
               borderRadius: BorderRadius.circular(8.br),
               border: Border.all(
-                color:
-                    isSelected
-                        ? kPrimaryColor
-                        : context.colors.surfaceRecessed.withValues(alpha: 0.3),
+                color: isSelected
+                    ? kPrimaryColor
+                    : context.colors.surfaceRecessed.withValues(alpha: 0.3),
                 width: 1,
               ),
             ),

--- a/lib/widgets/game_filter/game_filter_dialog.dart
+++ b/lib/widgets/game_filter/game_filter_dialog.dart
@@ -5,6 +5,7 @@ import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/alert_dialog/alert_modal.dart';
+import 'package:chessever2/widgets/game_filter/eco_filter_dropdown.dart';
 import 'package:chessever2/widgets/game_filter/game_filter_model.dart';
 import 'package:chessever2/widgets/game_filter/rating_tier_filter.dart';
 import 'package:chessever2/widgets/game_filter/wheel_range_filter.dart';
@@ -78,9 +79,11 @@ class GameFilterDialog extends StatefulWidget {
 class _GameFilterDialogState extends State<GameFilterDialog> {
   late GameResultFilter _result;
   late GameColorFilter _color;
+  late GameFinishFilter _finish;
   late GameTimeControlFilter _timeControl;
   late GameOnlineFilter _online;
   late GameLiveFilter _live;
+  late GameEcoFilter _eco;
   late RangeValues _yearRange;
   late int? _selectedMinRating;
   late List<GameSortCriterion> _sorts;
@@ -92,9 +95,11 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
     super.initState();
     _result = widget.initialFilter.result;
     _color = widget.initialFilter.color;
+    _finish = widget.initialFilter.finish;
     _timeControl = widget.initialFilter.timeControl;
     _online = widget.initialFilter.online;
     _live = widget.initialFilter.live;
+    _eco = widget.initialFilter.eco;
     _yearRange = RangeValues(
       widget.initialFilter.minYear.toDouble(),
       widget.initialFilter.maxYear.toDouble(),
@@ -144,44 +149,17 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // 1. Status (Live / Completed) — top priority when shown.
-                    // In database/My-Likes contexts the caller drops this
-                    // (saved games are always finished); Sort controls render
-                    // independently via [showSortSection], so contexts that
-                    // keep Status (e.g. smart events) can still offer Sort.
-                    if (widget.showLiveFilter) ...[
-                      _sectionLabel('Status'),
-                      SizedBox(height: 8.h),
-                      _chipGrid<GameLiveFilter>(
-                        values: GameLiveFilter.values,
-                        selected: _live,
-                        label:
-                            (v) =>
-                                v == GameLiveFilter.all ? 'All' : v.displayText,
-                        onTap: (v) {
-                          HapticFeedbackService.selection();
-                          setState(() => _live = v);
-                        },
-                      ),
-                      SizedBox(height: 20.h),
-                    ],
-                    if (widget.showSortSection) ...[
-                      _buildSortSection(),
-                      SizedBox(height: 20.h),
-                    ],
-
-                    // 2. Time Control
+                    // Standard smart-game filter order:
+                    // Time control → Avg. Rating → ECO / Opening → Finish → Result → Date range.
                     if (widget.showTimeControlFilter) ...[
                       _sectionLabel('Time Control'),
                       SizedBox(height: 8.h),
                       _chipGrid<GameTimeControlFilter>(
                         values: GameTimeControlFilter.values,
                         selected: _timeControl,
-                        label:
-                            (v) =>
-                                v == GameTimeControlFilter.all
-                                    ? 'All'
-                                    : v.displayText,
+                        label: (v) => v == GameTimeControlFilter.all
+                            ? 'All'
+                            : v.displayText,
                         onTap: (v) {
                           HapticFeedbackService.selection();
                           setState(() => _timeControl = v);
@@ -190,9 +168,8 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                       SizedBox(height: 20.h),
                     ],
 
-                    // 3. Level
                     if (widget.showLevelFilter) ...[
-                      _sectionLabel('Level'),
+                      _sectionLabel('Avg. Rating'),
                       SizedBox(height: 8.h),
                       RatingTierFilter(
                         selectedMinRating: _selectedMinRating,
@@ -204,15 +181,37 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                       SizedBox(height: 20.h),
                     ],
 
-                    // 4. Result (box grid)
+                    _sectionLabel('ECO / Opening'),
+                    SizedBox(height: 8.h),
+                    EcoFilterDropdown(
+                      value: _eco,
+                      onChanged: (value) {
+                        HapticFeedbackService.selection();
+                        setState(() => _eco = value);
+                      },
+                    ),
+                    SizedBox(height: 20.h),
+
+                    _sectionLabel('Finish'),
+                    SizedBox(height: 8.h),
+                    _chipGrid<GameFinishFilter>(
+                      values: GameFinishFilter.values,
+                      selected: _finish,
+                      label: (v) => v.displayText,
+                      onTap: (v) {
+                        HapticFeedbackService.selection();
+                        setState(() => _finish = v);
+                      },
+                    ),
+                    SizedBox(height: 20.h),
+
                     _sectionLabel('Result'),
                     SizedBox(height: 8.h),
                     _chipGrid<GameResultFilter>(
                       values: GameResultFilter.values,
                       selected: _result,
-                      label:
-                          (v) =>
-                              v == GameResultFilter.all ? 'All' : v.displayText,
+                      label: (v) =>
+                          v == GameResultFilter.all ? 'All' : v.displayText,
                       onTap: (v) {
                         HapticFeedbackService.selection();
                         setState(() => _result = v);
@@ -220,19 +219,14 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                     ),
                     SizedBox(height: 20.h),
 
-                    // 5. Color (box grid) — hidden in database/My-Likes
-                    // contexts via [showColorFilter].
                     if (widget.showColorFilter) ...[
                       _sectionLabel('Color'),
                       SizedBox(height: 8.h),
                       _chipGrid<GameColorFilter>(
                         values: GameColorFilter.values,
                         selected: _color,
-                        label:
-                            (v) =>
-                                v == GameColorFilter.all
-                                    ? 'All'
-                                    : v.displayText,
+                        label: (v) =>
+                            v == GameColorFilter.all ? 'All' : v.displayText,
                         onTap: (v) {
                           HapticFeedbackService.selection();
                           setState(() => _color = v);
@@ -241,18 +235,35 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                       SizedBox(height: 20.h),
                     ],
 
-                    // 6. Format (online/OTB) — only when caller enables it
+                    if (widget.showLiveFilter) ...[
+                      _sectionLabel('Status'),
+                      SizedBox(height: 8.h),
+                      _chipGrid<GameLiveFilter>(
+                        values: GameLiveFilter.values,
+                        selected: _live,
+                        label: (v) =>
+                            v == GameLiveFilter.all ? 'All' : v.displayText,
+                        onTap: (v) {
+                          HapticFeedbackService.selection();
+                          setState(() => _live = v);
+                        },
+                      ),
+                      SizedBox(height: 20.h),
+                    ],
+
+                    if (widget.showSortSection) ...[
+                      _buildSortSection(),
+                      SizedBox(height: 20.h),
+                    ],
+
                     if (widget.showFormatFilter) ...[
                       _sectionLabel('Format'),
                       SizedBox(height: 8.h),
                       _chipGrid<GameOnlineFilter>(
                         values: GameOnlineFilter.values,
                         selected: _online,
-                        label:
-                            (v) =>
-                                v == GameOnlineFilter.all
-                                    ? 'All'
-                                    : v.displayText,
+                        label: (v) =>
+                            v == GameOnlineFilter.all ? 'All' : v.displayText,
                         onTap: (v) {
                           HapticFeedbackService.selection();
                           setState(() => _online = v);
@@ -263,7 +274,7 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
 
                     // 7. Year range
                     if (widget.showYearFilter) ...[
-                      _sectionLabel('Year'),
+                      _sectionLabel('Date Range'),
                       SizedBox(height: 8.h),
                       _rangeSliderCard(
                         values: _yearRange,
@@ -375,23 +386,23 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
       result: _result,
       // Color hidden → never carry a stale color filter (no UI to clear it).
       color: widget.showColorFilter ? _color : GameColorFilter.all,
+      finish: _finish,
+      eco: _eco,
       // Same rule for a hidden Time Control section.
-      timeControl:
-          widget.showTimeControlFilter
-              ? _timeControl
-              : GameTimeControlFilter.all,
+      timeControl: widget.showTimeControlFilter
+          ? _timeControl
+          : GameTimeControlFilter.all,
       online: _online,
       live: _live,
-      minYear:
-          widget.showYearFilter
-              ? _yearRange.start.round()
-              : GameFilter.defaultMinYear,
-      maxYear:
-          widget.showYearFilter ? _yearRange.end.round() : DateTime.now().year,
-      minRating:
-          widget.showLevelFilter
-              ? _selectedMinRating ?? GameFilter.defaultMinRating
-              : GameFilter.defaultMinRating,
+      minYear: widget.showYearFilter
+          ? _yearRange.start.round()
+          : GameFilter.defaultMinYear,
+      maxYear: widget.showYearFilter
+          ? _yearRange.end.round()
+          : DateTime.now().year,
+      minRating: widget.showLevelFilter
+          ? _selectedMinRating ?? GameFilter.defaultMinRating
+          : GameFilter.defaultMinRating,
       maxRating: GameFilter.absoluteMaxRating,
       sorts: widget.showSortSection ? _sorts : const [],
     );
@@ -420,9 +431,11 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
     setState(() {
       _result = GameResultFilter.all;
       _color = GameColorFilter.all;
+      _finish = GameFinishFilter.all;
       _timeControl = GameTimeControlFilter.all;
       _online = GameOnlineFilter.all;
       _live = GameLiveFilter.all;
+      _eco = GameEcoFilter.all;
       _yearRange = RangeValues(
         GameFilter.defaultMinYear.toDouble(),
         DateTime.now().year.toDouble(),
@@ -503,14 +516,11 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
         ),
         SizedBox(height: 8.h),
         _adaptiveChipLayout(
-          measureLabels:
-              GamebaseSortField.values.map(_sortFieldLabel).toList(),
+          measureLabels: GamebaseSortField.values.map(_sortFieldLabel).toList(),
           extraPerChip: widget.showSortDirection ? 4.w + 12.ic : 0,
-          chipsBuilder:
-              (expanded) =>
-                  GamebaseSortField.values
-                      .map((f) => _buildSortChip(f, expanded: expanded))
-                      .toList(),
+          chipsBuilder: (expanded) => GamebaseSortField.values
+              .map((f) => _buildSortChip(f, expanded: expanded))
+              .toList(),
         ),
       ],
     );
@@ -549,16 +559,15 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
               SizedBox(
                 width: 12.ic,
                 height: 12.ic,
-                child:
-                    isSelected
-                        ? Icon(
-                          criterion!.direction == GamebaseSortDirection.asc
-                              ? Icons.arrow_upward_rounded
-                              : Icons.arrow_downward_rounded,
-                          size: 12.ic,
-                          color: kBlackColor,
-                        )
-                        : null,
+                child: isSelected
+                    ? Icon(
+                        criterion!.direction == GamebaseSortDirection.asc
+                            ? Icons.arrow_upward_rounded
+                            : Icons.arrow_downward_rounded,
+                        size: 12.ic,
+                        color: kBlackColor,
+                      )
+                    : null,
               ),
             ],
           ],
@@ -619,10 +628,9 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
                   Expanded(child: chips[i]),
                   SizedBox(width: 8.w),
                   Expanded(
-                    child:
-                        i + 1 < chips.length
-                            ? chips[i + 1]
-                            : const SizedBox.shrink(),
+                    child: i + 1 < chips.length
+                        ? chips[i + 1]
+                        : const SizedBox.shrink(),
                   ),
                 ],
               ),
@@ -641,42 +649,33 @@ class _GameFilterDialogState extends State<GameFilterDialog> {
   }) {
     return _adaptiveChipLayout(
       measureLabels: values.map(label).toList(),
-      chipsBuilder:
-          (expanded) =>
-              values.map((v) {
-                final isSelected = v == selected;
-                return GestureDetector(
-                  onTap: () => onTap(v),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 150),
-                    padding: EdgeInsets.symmetric(
-                      horizontal: 14.w,
-                      vertical: 10.h,
-                    ),
-                    // Equal-width grid cells center their label; row chips
-                    // hug their content as before.
-                    alignment: expanded ? Alignment.center : null,
-                    decoration: BoxDecoration(
-                      color:
-                          isSelected
-                              ? kPrimaryColor
-                              : context.colors.surfaceRecessed,
-                      borderRadius: BorderRadius.circular(8.br),
-                    ),
-                    child: Text(
-                      label(v),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTypography.textXsMedium.copyWith(
-                        color:
-                            isSelected
-                                ? kBlackColor
-                                : context.colors.textPrimary,
-                      ),
-                    ),
-                  ),
-                );
-              }).toList(),
+      chipsBuilder: (expanded) => values.map((v) {
+        final isSelected = v == selected;
+        return GestureDetector(
+          onTap: () => onTap(v),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 10.h),
+            // Equal-width grid cells center their label; row chips
+            // hug their content as before.
+            alignment: expanded ? Alignment.center : null,
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? kPrimaryColor
+                  : context.colors.surfaceRecessed,
+              borderRadius: BorderRadius.circular(8.br),
+            ),
+            child: Text(
+              label(v),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.textXsMedium.copyWith(
+                color: isSelected ? kBlackColor : context.colors.textPrimary,
+              ),
+            ),
+          ),
+        );
+      }).toList(),
     );
   }
 

--- a/lib/widgets/game_filter/game_filter_model.dart
+++ b/lib/widgets/game_filter/game_filter_model.dart
@@ -46,6 +46,37 @@ extension GameResultFilterX on GameResultFilter {
   }
 }
 
+/// Finish-length filter for miniature-style game collections.
+enum GameFinishFilter { all, byMove25, byMove20, byMove15 }
+
+extension GameFinishFilterX on GameFinishFilter {
+  String get displayText {
+    switch (this) {
+      case GameFinishFilter.all:
+        return 'All';
+      case GameFinishFilter.byMove25:
+        return '≤25';
+      case GameFinishFilter.byMove20:
+        return '≤20';
+      case GameFinishFilter.byMove15:
+        return '≤15';
+    }
+  }
+
+  int? get maxMoveNumber {
+    switch (this) {
+      case GameFinishFilter.all:
+        return null;
+      case GameFinishFilter.byMove25:
+        return 25;
+      case GameFinishFilter.byMove20:
+        return 20;
+      case GameFinishFilter.byMove15:
+        return 15;
+    }
+  }
+}
+
 /// Color filter options
 enum GameColorFilter { all, white, black }
 
@@ -231,6 +262,7 @@ class GameFilter {
   GameFilter({
     this.result = GameResultFilter.all,
     this.color = GameColorFilter.all,
+    this.finish = GameFinishFilter.all,
     this.timeControl = GameTimeControlFilter.all,
     this.online = GameOnlineFilter.all,
     this.live = GameLiveFilter.all,
@@ -246,6 +278,7 @@ class GameFilter {
 
   final GameResultFilter result;
   final GameColorFilter color;
+  final GameFinishFilter finish;
   final GameTimeControlFilter timeControl;
   final GameOnlineFilter online;
   final GameLiveFilter live;
@@ -273,6 +306,7 @@ class GameFilter {
   bool get hasActiveFilters =>
       result != GameResultFilter.all ||
       color != GameColorFilter.all ||
+      finish != GameFinishFilter.all ||
       timeControl != GameTimeControlFilter.all ||
       online != GameOnlineFilter.all ||
       live != GameLiveFilter.all ||
@@ -287,6 +321,7 @@ class GameFilter {
     int count = 0;
     if (result != GameResultFilter.all) count++;
     if (color != GameColorFilter.all) count++;
+    if (finish != GameFinishFilter.all) count++;
     if (timeControl != GameTimeControlFilter.all) count++;
     if (online != GameOnlineFilter.all) count++;
     if (live != GameLiveFilter.all) count++;
@@ -302,6 +337,7 @@ class GameFilter {
   GameFilter copyWith({
     GameResultFilter? result,
     GameColorFilter? color,
+    GameFinishFilter? finish,
     GameTimeControlFilter? timeControl,
     GameOnlineFilter? online,
     GameLiveFilter? live,
@@ -315,6 +351,7 @@ class GameFilter {
     return GameFilter(
       result: result ?? this.result,
       color: color ?? this.color,
+      finish: finish ?? this.finish,
       timeControl: timeControl ?? this.timeControl,
       online: online ?? this.online,
       live: live ?? this.live,
@@ -335,6 +372,7 @@ class GameFilter {
     return other is GameFilter &&
         other.result == result &&
         other.color == color &&
+        other.finish == finish &&
         other.timeControl == timeControl &&
         other.online == online &&
         other.live == live &&
@@ -350,6 +388,7 @@ class GameFilter {
   int get hashCode => Object.hash(
     result,
     color,
+    finish,
     timeControl,
     online,
     live,
@@ -429,6 +468,17 @@ class GameFilterHelper {
 
       // Result filter
       if (!filter.result.matches(game.gameStatus)) return false;
+
+      // Finish filter
+      if (filter.finish != GameFinishFilter.all) {
+        final moveNumber = _estimateFinalMoveNumber(game);
+        final maxMoveNumber = filter.finish.maxMoveNumber;
+        if (moveNumber == null ||
+            maxMoveNumber == null ||
+            moveNumber > maxMoveNumber) {
+          return false;
+        }
+      }
 
       // Time control filter
       if (filter.timeControl != GameTimeControlFilter.all) {
@@ -519,5 +569,32 @@ class GameFilterHelper {
     // No fallback - if timeControl is not set in the database, we can't reliably
     // determine it. Return 'all' which means "unknown" and won't filter out the game.
     return GameTimeControlFilter.all;
+  }
+
+  static int? _estimateFinalMoveNumber(GamesTourModel game) {
+    final pgn = game.pgn;
+    if (pgn != null && pgn.isNotEmpty) {
+      return _estimateMoveNumberFromPgn(pgn);
+    }
+
+    final lastMove = game.lastMove;
+    if (lastMove == null || lastMove.isEmpty) return null;
+    return _estimateMoveNumberFromPgn(lastMove);
+  }
+
+  static int? _estimateMoveNumberFromPgn(String text) {
+    final cleaned = text
+        .replaceAll(RegExp(r'\[[^\]]*\]'), ' ')
+        .replaceAll(RegExp(r'\{[^}]*\}'), ' ')
+        .replaceAll(RegExp(r'\([^)]*\)'), ' ')
+        .replaceAll(RegExp(r'\$\d+'), ' ');
+    final matches = RegExp(r'\b(\d{1,3})\s*\.{1,3}').allMatches(cleaned);
+    int? maxMove;
+    for (final match in matches) {
+      final value = int.tryParse(match.group(1) ?? '');
+      if (value == null) continue;
+      if (maxMove == null || value > maxMove) maxMove = value;
+    }
+    return maxMove;
   }
 }

--- a/lib/widgets/game_filter/rating_tier_filter.dart
+++ b/lib/widgets/game_filter/rating_tier_filter.dart
@@ -18,10 +18,10 @@ class RatingTierFilter extends StatelessWidget {
   final ValueChanged<int?> onChanged;
 
   static const tiers = <RatingTier>[
-    RatingTier(label: 'GM', subtitle: '+2500', minRating: 2500),
-    RatingTier(label: 'IM', subtitle: '+2400', minRating: 2400),
-    RatingTier(label: 'FM', subtitle: '+2300', minRating: 2300),
-    RatingTier(label: 'CM', subtitle: '+2200', minRating: 2200),
+    RatingTier(label: '2500+', subtitle: '', minRating: 2500),
+    RatingTier(label: '2400+', subtitle: '', minRating: 2400),
+    RatingTier(label: '2300+', subtitle: '', minRating: 2300),
+    RatingTier(label: '2200+', subtitle: '', minRating: 2200),
   ];
 
   static int? normalizeMinRating(int? minRating) {
@@ -40,7 +40,7 @@ class RatingTierFilter extends StatelessWidget {
 
     for (final tier in tiers) {
       if (tier.minRating == normalized) {
-        return '${tier.label} ${tier.subtitle}';
+        return tier.label;
       }
     }
 
@@ -60,6 +60,20 @@ class RatingTierFilter extends StatelessWidget {
         constraints: const BoxConstraints(maxWidth: 320),
         child: Column(
           children: [
+            Row(
+              children: [
+                Expanded(
+                  child: _RatingChip(
+                    label: 'Any',
+                    isSelected: selected == null,
+                    onTap: () => onChanged(null),
+                  ),
+                ),
+                SizedBox(width: 8.w),
+                const Expanded(child: SizedBox.shrink()),
+              ],
+            ),
+            SizedBox(height: 8.h),
             for (var i = 0; i < tiers.length; i += 2) ...[
               if (i > 0) SizedBox(height: 8.h),
               Row(
@@ -73,19 +87,56 @@ class RatingTierFilter extends StatelessWidget {
                   ),
                   SizedBox(width: 8.w),
                   Expanded(
-                    child:
-                        i + 1 < tiers.length
-                            ? _TierChip(
-                              tier: tiers[i + 1],
-                              isSelected: selected == tiers[i + 1].minRating,
-                              onChanged: onChanged,
-                            )
-                            : const SizedBox.shrink(),
+                    child: i + 1 < tiers.length
+                        ? _TierChip(
+                            tier: tiers[i + 1],
+                            isSelected: selected == tiers[i + 1].minRating,
+                            onChanged: onChanged,
+                          )
+                        : const SizedBox.shrink(),
                   ),
                 ],
               ),
             ],
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RatingChip extends StatelessWidget {
+  const _RatingChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: EdgeInsets.symmetric(horizontal: 14.w, vertical: 10.h),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: isSelected ? kPrimaryColor : context.colors.surfaceRecessed,
+          borderRadius: BorderRadius.circular(8.br),
+        ),
+        child: Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.textXsMedium.copyWith(
+            color: isSelected ? kBlackColor : context.colors.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
         ),
       ),
     );
@@ -129,20 +180,21 @@ class _TierChip extends StatelessWidget {
                 fontWeight: FontWeight.w600,
               ),
             ),
-            SizedBox(width: 4.w),
-            Flexible(
-              child: Text(
-                tier.subtitle,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.textXsMedium.copyWith(
-                  color:
-                      isSelected
-                          ? kBlackColor.withValues(alpha: 0.7)
-                          : context.colors.textSecondary,
+            if (tier.subtitle.isNotEmpty) ...[
+              SizedBox(width: 4.w),
+              Flexible(
+                child: Text(
+                  tier.subtitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.textXsMedium.copyWith(
+                    color: isSelected
+                        ? kBlackColor.withValues(alpha: 0.7)
+                        : context.colors.textSecondary,
+                  ),
                 ),
               ),
-            ),
+            ],
           ],
         ),
       ),

--- a/test/game_filter_lifecycle_test.dart
+++ b/test/game_filter_lifecycle_test.dart
@@ -40,6 +40,24 @@ void main() {
 
       expect(filtered.map((game) => game.gameStatus), [GameStatus.whiteWins]);
     });
+
+    test('finish filter keeps only games ending by selected move', () {
+      final shortGame = _game(
+        status: GameStatus.whiteWins,
+        pgn: '1. e4 e5 2. Nf3 Nc6 15. Qxf7# 1-0',
+      );
+      final longGame = _game(
+        status: GameStatus.blackWins,
+        pgn: '1. d4 Nf6 2. c4 e6 26. Qb3 Be7 0-1',
+      );
+
+      final filtered = GameFilterHelper.applyFilter([
+        shortGame,
+        longGame,
+      ], GameFilter(finish: GameFinishFilter.byMove20));
+
+      expect(filtered, [shortGame]);
+    });
   });
 }
 
@@ -48,6 +66,7 @@ GamesTourModel _game({
   DateTime? lastMoveTime,
   DateTime? gameDay,
   String? lastMove,
+  String? pgn,
 }) {
   return GamesTourModel(
     gameId: '${status.name}-${lastMoveTime ?? gameDay}',
@@ -65,6 +84,7 @@ GamesTourModel _game({
     lastMoveTime: lastMoveTime,
     gameDay: gameDay,
     lastMove: lastMove,
+    pgn: pgn,
   );
 }
 


### PR DESCRIPTION
## Summary
- standardizes smart-game filter order as Time control → Avg. Rating → ECO / Opening → Finish → Result → Date range
- adds the same time-control, ECO/opening, finish-length, and avg-rating filter controls to Favorites/Countrymen premium game lists
- renames rating UI to Avg. Rating and switches rating presets to clickable numeric chips including Any/2200+/2300+/2400+/2500+
- adds finish-by-move filtering support shared by smart events and premium collections

## Notes
- Scope overlaps smart-event filter surfaces; PR #220 is still open/dirty, so Berkay should review integration carefully before merging.
- Date range remains the last section; no separate Window section added.

## Verification
- dart format lib/widgets/game_filter/game_filter_model.dart lib/widgets/game_filter/game_filter_dialog.dart lib/widgets/game_filter/rating_tier_filter.dart lib/screens/premium_games/providers/premium_games_provider.dart lib/screens/premium_games/widgets/premium_games_filter.dart test/game_filter_lifecycle_test.dart
- flutter analyze --no-pub lib/widgets/game_filter/game_filter_model.dart lib/widgets/game_filter/game_filter_dialog.dart lib/widgets/game_filter/rating_tier_filter.dart lib/screens/premium_games/providers/premium_games_provider.dart lib/screens/premium_games/widgets/premium_games_filter.dart test/game_filter_lifecycle_test.dart
- flutter test --no-pub test/game_filter_lifecycle_test.dart
- git diff --check origin/dev...HEAD