### PR TITLE
fix: hide unknown federation flag placeholders

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -87,7 +87,7 @@ import 'package:chessever2/screens/group_event/model/about_tour_model.dart';
 import 'package:chessever2/repository/supabase/tour/tour.dart';
 import 'package:chessever2/repository/supabase/tour/tour_repository.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessever2/utils/url_launcher_provider.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_mode_provider.dart';
 import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.dart';
@@ -8685,8 +8685,10 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
         // (mirroring the win red tint), redrawing each king above the tint so it
         // stays visible. 0xCCADE1CD is the same mint the old squareHighlight used.
         Widget drawKingTint(Square square, PieceKind kind) {
-          final effectiveFile = widget.isFlipped ? 7 - square.file : square.file;
-          final effectiveRank = widget.isFlipped ? square.rank : 7 - square.rank;
+          final effectiveFile =
+              widget.isFlipped ? 7 - square.file : square.file;
+          final effectiveRank =
+              widget.isFlipped ? square.rank : 7 - square.rank;
           final isLightSquare = (effectiveFile + effectiveRank) % 2 == 0;
           final baseSquareColor =
               isLightSquare ? colorScheme.lightSquare : colorScheme.darkSquare;
@@ -15901,18 +15903,8 @@ class _EventInfoSheet extends ConsumerWidget {
             ),
           ),
           SizedBox(width: 10.w),
-          // Country flag - handle FID (FIDE) specially like PlayerFirstRowDetailWidget
-          if (player.countryCode.toUpperCase() == 'FID') ...[
-            Image.asset(
-              PngAsset.fideLogo,
-              height: 14.h,
-              width: 20.w,
-              fit: BoxFit.cover,
-              cacheWidth: 48,
-              cacheHeight: 36,
-            ),
-            SizedBox(width: 8.w),
-          ] else if (validCountryCode.isNotEmpty) ...[
+          // Show a real country flag only when the country is known.
+          if (validCountryCode.isNotEmpty) ...[
             CountryFlag.fromCountryCode(
               validCountryCode,
               theme: ImageTheme(width: 20.w, height: 14.h),

--- a/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
+++ b/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
@@ -722,18 +722,15 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
                         ? 5.w
                         : 6.w,
               ),
-            FederationFlag(
-              federation:
-                  effectivePlayerCard.countryCode.trim().isNotEmpty
-                      ? effectivePlayerCard.countryCode
-                      : (validCountryCode.isNotEmpty
-                          ? validCountryCode
-                          : 'FID'),
-              height: flagHeight,
-              width: flagWidth,
-              borderRadius: BorderRadius.circular(2.br),
-            ),
-            SizedBox(width: elementSpacing),
+            if (validCountryCode.isNotEmpty) ...[
+              FederationFlag(
+                federation: validCountryCode,
+                height: flagHeight,
+                width: flagWidth,
+                borderRadius: BorderRadius.circular(2.br),
+              ),
+              SizedBox(width: elementSpacing),
+            ],
             Expanded(
               child: LayoutBuilder(
                 builder: (context, constraints) {

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -24,7 +24,7 @@ import 'package:country_flags/country_flags.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:chessever2/screens/chessboard/widgets/evaluation_bar_widget.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessground/chessground.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -1505,18 +1505,8 @@ class _ShareCard extends ConsumerWidget {
             ),
           ),
           SizedBox(width: elementSpacing.w),
-          // Country flag
-          if (playerCountry.toUpperCase() == 'FID') ...[
-            Image.asset(
-              PngAsset.fideLogo,
-              height: flagHeight.h,
-              width: flagWidth.w,
-              fit: BoxFit.cover,
-              cacheWidth: 48,
-              cacheHeight: 36,
-            ),
-            SizedBox(width: elementSpacing.w),
-          ] else if (playerCountry.isNotEmpty) ...[
+          // Show a real country flag only when the country is known.
+          if (playerCountry.isNotEmpty) ...[
             CountryFlag.fromCountryCode(
               playerCountry,
               theme: ImageTheme(height: flagHeight.h, width: flagWidth.w),

--- a/lib/screens/library/widgets/library_game_card.dart
+++ b/lib/screens/library/widgets/library_game_card.dart
@@ -360,8 +360,8 @@ class _PlayerInfo extends StatelessWidget {
 
     // Imported PGNs often omit [WhiteFed]/[BlackFed] but include FideId tags,
     // so BackfilledFederationFlag resolves the country via Supabase's
-    // chess_players lookup and falls back to the FIDE logo only when no
-    // federation and no resolvable fideId are available.
+    // chess_players lookup. If no real country is available, the flag widget
+    // renders nothing rather than a generic placeholder.
     final flag = BackfilledFederationFlag(
       federation: federation,
       fideId: fideId,

--- a/lib/screens/player_profile/player_profile_screen.dart
+++ b/lib/screens/player_profile/player_profile_screen.dart
@@ -17,7 +17,7 @@ import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/country_utils.dart';
 import 'package:chessever2/utils/number_format_utils.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
@@ -686,18 +686,7 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   // Country flag
-                  if (effectiveFederation?.toUpperCase() == 'FID')
-                    Image.asset(
-                      PngAsset.fideLogo,
-                      height: 16.h,
-                      width: 22.w,
-                      fit: BoxFit.cover,
-                      cacheWidth:
-                          (22 * MediaQuery.devicePixelRatioOf(context)).toInt(),
-                      cacheHeight:
-                          (16 * MediaQuery.devicePixelRatioOf(context)).toInt(),
-                    )
-                  else if (countryCode.isNotEmpty)
+                  if (countryCode.isNotEmpty)
                     ClipRRect(
                       borderRadius: BorderRadius.circular(2.br),
                       child: CountryFlag.fromCountryCode(
@@ -706,9 +695,7 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
                       ),
                     ),
 
-                  if (countryCode.isNotEmpty ||
-                      effectiveFederation?.toUpperCase() == 'FID')
-                    SizedBox(width: 8.w),
+                  if (countryCode.isNotEmpty) SizedBox(width: 8.w),
 
                   // Title and name
                   Flexible(

--- a/lib/screens/player_profile/widgets/recent_opponents_list.dart
+++ b/lib/screens/player_profile/widgets/recent_opponents_list.dart
@@ -2,7 +2,7 @@ import 'package:chessever2/screens/player_profile/player_profile_screen.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:country_flags/country_flags.dart';
 import 'package:flutter/material.dart';
@@ -67,7 +67,9 @@ class RecentOpponentsList extends StatelessWidget {
             width: 24.w,
             child: Text(
               '$index',
-              style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimaryMuted),
+              style: AppTypography.textSmMedium.copyWith(
+                color: context.colors.textPrimaryMuted,
+              ),
             ),
           ),
 
@@ -76,22 +78,14 @@ class RecentOpponentsList extends StatelessWidget {
 
           SizedBox(width: 10.w),
 
-          // Country flag
-          opponent.countryCode.toUpperCase() == 'FID'
-              ? Image.asset(
-                PngAsset.fideLogo,
-                height: 14.h,
-                width: 20.w,
-                fit: BoxFit.cover,
-                cacheWidth:
-                    (20 * MediaQuery.devicePixelRatioOf(context)).toInt(),
-                cacheHeight:
-                    (14 * MediaQuery.devicePixelRatioOf(context)).toInt(),
-              )
-              : CountryFlag.fromCountryCode(
+          // Country flag: leave blank for unknown/FID placeholder values.
+          opponent.countryCode.trim().isNotEmpty &&
+                  opponent.countryCode.toUpperCase() != 'FID'
+              ? CountryFlag.fromCountryCode(
                 opponent.countryCode,
                 theme: ImageTheme(height: 14.h, width: 20.w),
-              ),
+              )
+              : SizedBox(width: 20.w, height: 14.h),
 
           SizedBox(width: 8.w),
 
@@ -99,7 +93,9 @@ class RecentOpponentsList extends StatelessWidget {
           Expanded(
             child: Text(
               '${opponent.title != null ? '${opponent.title} ' : ''}${opponent.name}',
-              style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimary),
+              style: AppTypography.textSmMedium.copyWith(
+                color: context.colors.textPrimary,
+              ),
               overflow: TextOverflow.ellipsis,
             ),
           ),
@@ -109,7 +105,9 @@ class RecentOpponentsList extends StatelessWidget {
           // Rating
           Text(
             opponent.rating.toString(),
-            style: AppTypography.textSmMedium.copyWith(color: context.colors.textPrimaryMuted),
+            style: AppTypography.textSmMedium.copyWith(
+              color: context.colors.textPrimaryMuted,
+            ),
           ),
         ],
       ),

--- a/lib/screens/players/widgets/player_card.dart
+++ b/lib/screens/players/widgets/player_card.dart
@@ -1,10 +1,8 @@
-import 'package:chessever2/utils/png_asset.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:country_flags/country_flags.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:flutter/material.dart';
 import '../../../utils/app_typography.dart';
-import '../../../theme/app_theme.dart';
 import '../../../utils/svg_asset.dart';
 import '../../../widgets/svg_widget.dart';
 
@@ -138,7 +136,9 @@ class _PlayerCardState extends State<PlayerCard>
               width: 24.w,
               child: Text(
                 '${widget.rank}.',
-                style: AppTypography.textXsMedium.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textXsMedium.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
             ),
 
@@ -146,20 +146,13 @@ class _PlayerCardState extends State<PlayerCard>
             Container(
               margin: EdgeInsets.only(right: 8.sp),
               child:
-                  widget.countryCode.toUpperCase() == 'FID'
-                      ? Image.asset(
-                        PngAsset.fideLogo,
-                        height: 14.h,
-                        width: 20.w,
-                        fit: BoxFit.cover,
-                        cacheWidth: 48,
-                        cacheHeight: 36,
+                  widget.countryCode.trim().isNotEmpty &&
+                          widget.countryCode.toUpperCase() != 'FID'
+                      ? CountryFlag.fromCountryCode(
+                        widget.countryCode,
+                        theme: ImageTheme(height: 14.h, width: 20.w),
                       )
-                      : CountryFlag.fromCountryCode(
-widget.countryCode,
-  theme: ImageTheme(height: 14.h,
-                        width: 20.w,),
-),
+                      : SizedBox(width: 20.w, height: 14.h),
             ),
 
             // GM prefix and player name
@@ -186,7 +179,9 @@ widget.countryCode,
               child: Text(
                 widget.elo.toString(),
                 textAlign: TextAlign.center,
-                style: AppTypography.textXsMedium.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textXsMedium.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
             ),
 
@@ -196,7 +191,9 @@ widget.countryCode,
               child: Text(
                 widget.age.toString(),
                 textAlign: TextAlign.center,
-                style: AppTypography.textXsMedium.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textXsMedium.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
             ),
 

--- a/lib/screens/tour_detail/games_tour/widgets/match_header_widget.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/match_header_widget.dart
@@ -4,7 +4,7 @@ import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:country_flags/country_flags.dart';
 import 'package:flutter/material.dart';
@@ -307,18 +307,6 @@ Widget? _playerFlag(WidgetRef ref, PlayerCard? player) {
   final countryCode = player.countryCode.trim();
   if (countryCode.isEmpty) return null;
 
-  // Check for FIDE flag
-  if (countryCode.toUpperCase() == 'FID') {
-    return Image.asset(
-      PngAsset.fideLogo,
-      height: 12.h,
-      width: 16.w,
-      fit: BoxFit.cover,
-      cacheWidth: 48,
-      cacheHeight: 36,
-    );
-  }
-
   // Validate country code using the location service
   final validCountryCode = ref
       .read(locationServiceProvider)
@@ -327,8 +315,7 @@ Widget? _playerFlag(WidgetRef ref, PlayerCard? player) {
   if (validCountryCode.isEmpty) return null;
 
   return CountryFlag.fromCountryCode(
-validCountryCode,
-  theme: ImageTheme(height: 12.h,
-    width: 16.w,),
-);
+    validCountryCode,
+    theme: ImageTheme(height: 12.h, width: 16.w),
+  );
 }

--- a/lib/widgets/federation_flag.dart
+++ b/lib/widgets/federation_flag.dart
@@ -1,5 +1,5 @@
 import 'package:chessever2/utils/country_utils.dart';
-import 'package:chessever2/utils/png_asset.dart';
+import 'package:country_picker/country_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_country_flags/flutter_country_flags.dart' as fcf;
 
@@ -46,19 +46,19 @@ class FederationFlag extends StatelessWidget {
     final normalized = raw.toUpperCase();
 
     if (raw.isEmpty) {
-      return _unknownPlaceholder(context);
+      return _noFlag();
     }
 
     final lowerRaw = raw.toLowerCase();
 
     if (_unknownSentinels.contains(lowerRaw)) {
-      return _unknownPlaceholder(context);
+      return _noFlag();
     }
 
-    // Lichess returns the literal "FIDE" for stateless / sanctioned players;
-    // when no real federation can be resolved, render the FIDE logo.
+    // FID/FIDE is not a real country flag. If no better player-profile
+    // backfill is available upstream, show no flag rather than a generic logo.
     if (normalized == 'FID' || normalized == 'FIDE') {
-      return _fideLogo(context);
+      return _noFlag();
     }
 
     // Handle UK subdivisions (England, Scotland, Wales) with their own flags.
@@ -71,9 +71,10 @@ class FederationFlag extends StatelessWidget {
 
     String? iso2;
     if (normalized.length == 2) {
-      iso2 = normalized;
+      iso2 = CountryService().findByCode(normalized)?.countryCode;
     } else if (normalized.length == 3) {
-      iso2 = CountryUtils.toIso2Code(normalized);
+      final mapped = CountryUtils.toIso2Code(normalized);
+      iso2 = CountryService().findByCode(mapped)?.countryCode;
     } else {
       // Country name (e.g. "Norway", "Austria") — use manual mapping first
       // (more reliable), then fall back to country_picker's name lookup.
@@ -82,7 +83,7 @@ class FederationFlag extends StatelessWidget {
     }
 
     if (iso2 == null || iso2.length != 2) {
-      return _unknownPlaceholder(context);
+      return _noFlag();
     }
 
     return _iso2Flag(context, iso2);
@@ -104,7 +105,7 @@ class FederationFlag extends StatelessWidget {
 
   Widget _ukSubdivisionFlag(BuildContext context, String fideCode) {
     final country = _ukSubdivisions[fideCode];
-    if (country == null) return _fallback(context);
+    if (country == null) return _noFlag();
 
     final radius = borderRadius ?? BorderRadius.circular(3);
     return ClipRRect(
@@ -117,58 +118,7 @@ class FederationFlag extends StatelessWidget {
     );
   }
 
-  Widget _fideLogo(BuildContext context) {
-    final w = width;
-    final h = height;
-    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
-    final cacheW = w != null ? (w * pixelRatio).toInt() : null;
-    final cacheH = h != null ? (h * pixelRatio).toInt() : null;
-
-    return ClipRRect(
-      borderRadius: borderRadius ?? BorderRadius.circular(3),
-      child: Image.asset(
-        PngAsset.fideLogo,
-        width: w,
-        height: h,
-        fit: BoxFit.cover,
-        cacheWidth: cacheW,
-        cacheHeight: cacheH,
-        errorBuilder: (_, __, ___) => SizedBox(width: w, height: h),
-      ),
-    );
-  }
-
-  Widget _fallback(BuildContext context) {
-    return _unknownPlaceholder(context);
-  }
-
-  /// Renders a neutral globe placeholder when no real federation can be
-  /// resolved (e.g. TWIC `fed: "Unknown"` or a country name that isn't in any
-  /// of our mapping tables). Previously this returned the FIDE webp logo,
-  /// which is mostly-white and looked like a blank rectangle at flag sizes.
-  Widget _unknownPlaceholder(BuildContext context) {
-    final w = width;
-    final h = height;
-    final iconSize = (h ?? w ?? 16) * 0.85;
-    final brightness = Theme.of(context).brightness;
-    // High-contrast surface so the globe placeholder is clearly visible
-    // against the card body, regardless of the active theme.
-    final bg = brightness == Brightness.light
-        ? const Color(0xFF6B7280)
-        : const Color(0xFF374151);
-    return ClipRRect(
-      borderRadius: borderRadius ?? BorderRadius.circular(3),
-      child: Container(
-        width: w,
-        height: h,
-        alignment: Alignment.center,
-        color: bg,
-        child: Icon(
-          Icons.public_rounded,
-          size: iconSize,
-          color: Colors.white,
-        ),
-      ),
-    );
-  }
+  /// Unknown/missing federation should not render a generic flag-like symbol.
+  /// Cards and player rows should only show a flag when we know the country.
+  Widget _noFlag() => const SizedBox.shrink();
 }

--- a/lib/widgets/figma_player_card.dart
+++ b/lib/widgets/figma_player_card.dart
@@ -4,7 +4,7 @@ import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/player_initials_avatar.dart';
 import 'package:country_flags/country_flags.dart';
@@ -19,6 +19,7 @@ import 'package:skeletonizer/skeletonizer.dart' as skel;
 /// - [showFavoriteButton] = false: Shows score on the right (for standings)
 class FigmaPlayerCard extends ConsumerWidget {
   final PlayerStandingModel player;
+
   /// Nullable so search results can render immediately while the overall
   /// standing rank is still being resolved asynchronously. A shimmer
   /// placeholder is shown in the rank slot until the number arrives.
@@ -72,7 +73,7 @@ class FigmaPlayerCard extends ConsumerWidget {
       onLongPressStart: onLongPress,
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 12.h),
-        decoration:  BoxDecoration(
+        decoration: BoxDecoration(
           border: Border(
             bottom: BorderSide(color: Color(0xFF1F1F1F), width: 1),
           ),
@@ -83,28 +84,29 @@ class FigmaPlayerCard extends ConsumerWidget {
             // standing rank is still resolving for remote search results.
             SizedBox(
               width: 24.w,
-              child: rank != null
-                  ? Text(
-                      rank.toString(),
-                      style: AppTypography.textSmMedium.copyWith(
-                        color: context.colors.textTertiary,
-                      ),
-                      textAlign: TextAlign.center,
-                    )
-                  : skel.Skeletonizer(
-                      enabled: true,
-                      effect: const skel.ShimmerEffect(
-                        baseColor: Color(0xFF2A2A2A),
-                        highlightColor: Color(0xFF3A3A3A),
-                      ),
-                      child: Text(
-                        '00',
+              child:
+                  rank != null
+                      ? Text(
+                        rank.toString(),
                         style: AppTypography.textSmMedium.copyWith(
                           color: context.colors.textTertiary,
                         ),
                         textAlign: TextAlign.center,
+                      )
+                      : skel.Skeletonizer(
+                        enabled: true,
+                        effect: const skel.ShimmerEffect(
+                          baseColor: Color(0xFF2A2A2A),
+                          highlightColor: Color(0xFF3A3A3A),
+                        ),
+                        child: Text(
+                          '00',
+                          style: AppTypography.textSmMedium.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
                       ),
-                    ),
             ),
             SizedBox(width: 12.w),
             // Player photo with title badge overlay
@@ -162,31 +164,20 @@ class FigmaPlayerCard extends ConsumerWidget {
                   Row(
                     children: [
                       // Country flag
-                      if (player.countryCode.isNotEmpty)
+                      if (validCountryCode.isNotEmpty)
                         Padding(
                           padding: EdgeInsets.only(right: 6.w),
                           child: SizedBox(
                             width: 18.w,
                             height: 12.h,
-                            child:
-                                player.countryCode.toUpperCase() == 'FID'
-                                    ? Image.asset(
-                                      PngAsset.fideLogo,
-                                      height: 12.h,
-                                      width: 18.w,
-                                      fit: BoxFit.contain,
-                                      cacheWidth: 48,
-                                      cacheHeight: 36,
-                                    )
-                                    : validCountryCode.isNotEmpty
-                                    ? CountryFlag.fromCountryCode(
-validCountryCode,
-  theme: ImageTheme(height: 12.h,
-                                      width: 18.w,
-                                      shape: RoundedRectangle(2.br),
-),
-                                    )
-                                    : null,
+                            child: CountryFlag.fromCountryCode(
+                              validCountryCode,
+                              theme: ImageTheme(
+                                height: 12.h,
+                                width: 18.w,
+                                shape: RoundedRectangle(2.br),
+                              ),
+                            ),
                           ),
                         ),
                       // Rating

--- a/lib/widgets/standing_score_card.dart
+++ b/lib/widgets/standing_score_card.dart
@@ -1,5 +1,5 @@
 import 'package:chessever2/utils/location_service_provider.dart';
-import 'package:chessever2/utils/png_asset.dart';
+
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/widgets/svg_widget.dart';
@@ -99,21 +99,11 @@ class StandingScoreCard extends ConsumerWidget {
               width: 16.w,
               height: 12.h,
               child:
-                  countryCode.toUpperCase() == 'FID'
-                      ? Image.asset(
-                        PngAsset.fideLogo,
-                        height: 12.h,
-                        width: 16.w,
-                        fit: BoxFit.contain,
-                        cacheWidth: 48,
-                        cacheHeight: 36,
-                      )
-                      : validCountryCode.isNotEmpty
+                  validCountryCode.isNotEmpty
                       ? CountryFlag.fromCountryCode(
-validCountryCode,
-  theme: ImageTheme(height: 12.h,
-                        width: 16.w,),
-)
+                        validCountryCode,
+                        theme: ImageTheme(height: 12.h, width: 16.w),
+                      )
                       : null,
             ),
             SizedBox(width: 8.w), // Gap between flag and name

--- a/test/federation_flag_test.dart
+++ b/test/federation_flag_test.dart
@@ -1,0 +1,41 @@
+import 'package:chessever2/widgets/federation_flag.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_country_flags/flutter_country_flags.dart' as fcf;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpFlag(WidgetTester tester, String? federation) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FederationFlag(federation: federation, width: 16, height: 12),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders a real flag when federation resolves', (tester) async {
+    await pumpFlag(tester, 'CHN');
+
+    expect(find.byType(fcf.FlutterCountryFlags), findsOneWidget);
+  });
+
+  testWidgets('renders no placeholder for missing or sentinel federation', (
+    tester,
+  ) async {
+    await pumpFlag(tester, '');
+    expect(find.byType(Icon), findsNothing);
+    expect(find.byType(Image), findsNothing);
+    expect(find.byType(fcf.FlutterCountryFlags), findsNothing);
+
+    await pumpFlag(tester, 'FIDE');
+    expect(find.byType(Icon), findsNothing);
+    expect(find.byType(Image), findsNothing);
+    expect(find.byType(fcf.FlutterCountryFlags), findsNothing);
+
+    await pumpFlag(tester, 'Unknown');
+    expect(find.byType(Icon), findsNothing);
+    expect(find.byType(Image), findsNothing);
+    expect(find.byType(fcf.FlutterCountryFlags), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- renders no flag at all for missing, sentinel, FID/FIDE, or invalid federation values
- keeps real country flags when federation values resolve cleanly, including FIDE alpha-3 codes like CHN
- updates the imported/database game-card comment and adds widget coverage for no-placeholder behavior

## Validation
- `dart format --output=none --set-exit-if-changed lib/widgets/federation_flag.dart lib/screens/library/widgets/library_game_card.dart test/federation_flag_test.dart`
- `flutter test test/federation_flag_test.dart`
- `flutter analyze --no-fatal-infos lib/widgets/federation_flag.dart lib/screens/library/widgets/library_game_card.dart test/federation_flag_test.dart`
- `git diff --check`

## Notes
This targets the copied/imported database-card flag polish Vasif reported. It is intentionally broader at the shared `FederationFlag` level so unknown/default flags do not appear elsewhere either. Related open PR #241 also touches flag backfill for live board profile rows; this PR is the shared no-placeholder rule and may need merge coordination with that branch.
