### PR TITLE
fix: hydrate board selector event context

### DIFF
--- a/lib/screens/player_profile/tabs/player_games_tab.dart
+++ b/lib/screens/player_profile/tabs/player_games_tab.dart
@@ -1171,12 +1171,6 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
 
     final games = state.filteredGames;
 
-    // Build a mapping of game IDs to their indices for reliable lookup
-    final gameIdToIndex = <String, int>{};
-    for (int i = 0; i < games.length; i++) {
-      gameIdToIndex[games[i].gameId] = i;
-    }
-
     if (games.isEmpty) {
       final isTwic = widget.dataSource == PlayerProfileDataSource.twic;
       if (isTwic &&
@@ -1257,6 +1251,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
           listEntries.add(
             _PlayerGridRowEntry(
               games: rowGames,
+              eventGames: eventGames,
               gridColumns: gridColumns,
               isLast: isLast,
             ),
@@ -1266,7 +1261,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
         for (int i = 0; i < eventGames.length; i++) {
           final game = eventGames[i];
           final isLast = i == eventGames.length - 1;
-          final globalIndex = gameIdToIndex[game.gameId] ?? 0;
+          final eventGameIndex = i;
           final showHint =
               isFirstGameCard && viewMode == GamesListViewMode.gamesCard;
           if (isFirstGameCard) isFirstGameCard = false;
@@ -1275,7 +1270,8 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
             listEntries.add(
               _PlayerBoardGameEntry(
                 game: game,
-                gameIndex: globalIndex,
+                eventGames: eventGames,
+                gameIndex: eventGameIndex,
                 isLast: isLast,
               ),
             );
@@ -1283,7 +1279,8 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
             listEntries.add(
               _PlayerCardGameEntry(
                 game: game,
-                gameIndex: globalIndex,
+                eventGames: eventGames,
+                gameIndex: eventGameIndex,
                 animationIndex: listEntries.length,
                 showHint: showHint,
                 isLast: isLast,
@@ -1312,9 +1309,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
           (context, index) => _buildListEntry(
             listEntries[index],
             state: state,
-            games: games,
             isSelectionMode: isSelectionMode,
-            gameIdToIndex: gameIdToIndex,
           ),
           childCount: listEntries.length,
         ),
@@ -1325,9 +1320,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
   Widget _buildListEntry(
     _PlayerGamesListEntry entry, {
     required PlayerProfileGamesState state,
-    required List<GamesTourModel> games,
     required bool isSelectionMode,
-    required Map<String, int> gameIdToIndex,
   }) {
     if (entry is _PlayerEventHeaderEntry) {
       return Padding(
@@ -1361,8 +1354,10 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
                     j < entry.games.length
                         ? _buildGridGame(
                           entry.games[j],
-                          gameIdToIndex[entry.games[j].gameId] ?? 0,
-                          games,
+                          entry.eventGames.indexWhere(
+                            (game) => game.gameId == entry.games[j].gameId,
+                          ),
+                          entry.eventGames,
                         )
                         : const SizedBox.shrink(),
               ),
@@ -1378,7 +1373,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
         child: BoardGameCardWrapperWidget(
           key: ValueKey('player_board_game_${entry.game.gameId}'),
           game: entry.game,
-          orderedGames: games,
+          orderedGames: entry.eventGames,
           gameIndex: entry.gameIndex,
           allowStockfishFallback: true,
           streamEnabled: true,
@@ -1407,7 +1402,7 @@ class _PlayerGamesTabState extends ConsumerState<PlayerGamesTab>
       final isSelected = _selectedGameIds.contains(entry.game.gameId);
       Widget gameCard = LiveGamebaseSearchGameCard(
         game: entry.game,
-        allGames: games,
+        allGames: entry.eventGames,
         gameIndex: entry.gameIndex,
         animationIndex: entry.animationIndex,
         showRound: true,
@@ -1893,11 +1888,13 @@ class _PlayerEventHeaderEntry extends _PlayerGamesListEntry {
 class _PlayerGridRowEntry extends _PlayerGamesListEntry {
   const _PlayerGridRowEntry({
     required this.games,
+    required this.eventGames,
     required this.gridColumns,
     required this.isLast,
   });
 
   final List<GamesTourModel> games;
+  final List<GamesTourModel> eventGames;
   final int gridColumns;
   final bool isLast;
 }
@@ -1905,11 +1902,13 @@ class _PlayerGridRowEntry extends _PlayerGamesListEntry {
 class _PlayerBoardGameEntry extends _PlayerGamesListEntry {
   const _PlayerBoardGameEntry({
     required this.game,
+    required this.eventGames,
     required this.gameIndex,
     required this.isLast,
   });
 
   final GamesTourModel game;
+  final List<GamesTourModel> eventGames;
   final int gameIndex;
   final bool isLast;
 }
@@ -1917,6 +1916,7 @@ class _PlayerBoardGameEntry extends _PlayerGamesListEntry {
 class _PlayerCardGameEntry extends _PlayerGamesListEntry {
   const _PlayerCardGameEntry({
     required this.game,
+    required this.eventGames,
     required this.gameIndex,
     required this.animationIndex,
     required this.showHint,
@@ -1924,6 +1924,7 @@ class _PlayerCardGameEntry extends _PlayerGamesListEntry {
   });
 
   final GamesTourModel game;
+  final List<GamesTourModel> eventGames;
   final int gameIndex;
   final int animationIndex;
   final bool showHint;

--- a/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_provider.dart
+++ b/lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_provider.dart
@@ -1,6 +1,8 @@
 import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/chessboard/provider/chess_board_screen_provider_new.dart';
 import 'package:chessever2/screens/chessboard/provider/game_pgn_stream_provider.dart';
+import 'package:chessever2/providers/for_you_games_logic.dart';
+import 'package:chessever2/repository/local_storage/tournament/games/games_local_storage.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +21,46 @@ class _ResolvedNavigation {
   const _ResolvedNavigation({required this.games, required this.index});
 }
 
+@visibleForTesting
+Future<List<GamesTourModel>> loadFullTourGamesForBoardSelector({
+  required List<GamesTourModel> currentGames,
+  required int currentIndex,
+  required GamesLocalStorage gamesStorage,
+}) async {
+  if (currentGames.isEmpty) return currentGames;
+
+  final safeIndex = currentIndex.clamp(0, currentGames.length - 1);
+  final selectedGame = currentGames[safeIndex];
+  final tourId = selectedGame.tourId.trim();
+  if (tourId.isEmpty) return currentGames;
+
+  try {
+    final rawGames = await gamesStorage.fetchAndSaveGames(tourId);
+    final fullGames = sortGamesForGamesTab(
+      games: rawGames,
+      pinnedIds: const [],
+    );
+    if (fullGames.length <= currentGames.length) {
+      return currentGames;
+    }
+
+    final selectedIndex = fullGames.indexWhere(
+      (game) => game.gameId == selectedGame.gameId,
+    );
+    if (selectedIndex < 0) return currentGames;
+
+    // Preserve the just-rendered live card snapshot for the selected board so
+    // opening from For You does not briefly rewind the tapped game while the
+    // full selector list is hydrated.
+    return List<GamesTourModel>.from(fullGames)..[selectedIndex] = selectedGame;
+  } catch (error) {
+    debugPrint(
+      '[GameCardWrapper] Falling back to source games for tour $tourId: $error',
+    );
+    return currentGames;
+  }
+}
+
 class _GameCardWrapperProvider {
   _GameCardWrapperProvider(this._ref);
 
@@ -29,16 +71,29 @@ class _GameCardWrapperProvider {
     required int gameIndex,
     required ChessboardView viewSource,
   }) async {
-    if (viewSource != ChessboardView.forYou) {
-      return _ResolvedNavigation(games: orderedGames, index: gameIndex);
-    }
-
     if (orderedGames.isEmpty) {
       return _ResolvedNavigation(games: orderedGames, index: gameIndex);
     }
 
     final safeIndex = gameIndex.clamp(0, orderedGames.length - 1);
-    return _ResolvedNavigation(games: orderedGames, index: safeIndex);
+    if (viewSource != ChessboardView.forYou) {
+      return _ResolvedNavigation(games: orderedGames, index: safeIndex);
+    }
+
+    final resolvedGames = await loadFullTourGamesForBoardSelector(
+      currentGames: orderedGames,
+      currentIndex: safeIndex,
+      gamesStorage: _ref.read(gamesLocalStorage),
+    );
+    final selectedGameId = orderedGames[safeIndex].gameId;
+    final resolvedIndex = resolvedGames.indexWhere(
+      (game) => game.gameId == selectedGameId,
+    );
+
+    return _ResolvedNavigation(
+      games: resolvedGames,
+      index: resolvedIndex >= 0 ? resolvedIndex : safeIndex,
+    );
   }
 
   void navigateToChessBoard({


### PR DESCRIPTION
## Summary
- Hydrates For You board navigation with the full tour game list before opening the chessboard selector, while preserving the tapped live game snapshot.
- Keeps Player Profile game navigation scoped to the player’s event section instead of the broader/global profile list, so the selector shows the relevant event games.

## Validation
- `git diff --check`
- `flutter analyze --no-fatal-infos lib/screens/tour_detail/games_tour/widgets/game_card_wrapper/game_card_wrapper_provider.dart lib/screens/player_profile/tabs/player_games_tab.dart`

## Notes
- `flutter test --no-pub --concurrency=1 -r expanded test/for_you_games_provider_test.dart` could not complete because the Flutter test compiler crashed before executing tests (`Null check operator used on a null value` in `flutter_tools/src/test/test_compiler.dart`).
- Manual QA needed on device: For You preview should still show four boards, but tapping a board should open the selector with all event games; Player Profile event sections should open selectors scoped to that player’s games in that event.
