### PR TITLE
Fix event search result matching and rotating examples

### DIFF
--- a/lib/screens/tour_detail/widgets/event_search_bar.dart
+++ b/lib/screens/tour_detail/widgets/event_search_bar.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:math' as math;
 
+import 'package:chessever2/providers/country_dropdown_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_screen_provider.dart';
 import 'package:chessever2/screens/tour_detail/player_tour/player_tour_screen_provider.dart';
+import 'package:chessever2/screens/tour_detail/widgets/event_search_placeholder.dart';
 import 'package:chessever2/theme/app_colors.dart';
-import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/simple_search_bar.dart';
 import 'package:flutter/material.dart';
@@ -22,6 +24,7 @@ class EventSearchBar extends ConsumerStatefulWidget {
 class _EventSearchBarState extends ConsumerState<EventSearchBar> {
   late final TextEditingController _controller;
   late final FocusNode _focusNode;
+  late final int _placeholderIndex;
   Timer? _debounce;
 
   @override
@@ -31,6 +34,7 @@ class _EventSearchBarState extends ConsumerState<EventSearchBar> {
       text: ref.read(standingsSearchQueryProvider),
     );
     _focusNode = FocusNode();
+    _placeholderIndex = math.Random().nextInt(eventSearchPlaceholderCount);
   }
 
   @override
@@ -78,6 +82,13 @@ class _EventSearchBarState extends ConsumerState<EventSearchBar> {
 
   @override
   Widget build(BuildContext context) {
+    final countryCode =
+        ref.watch(countryDropdownProvider).valueOrNull?.countryCode;
+    final hintText = eventSearchPlaceholderForIndex(
+      _placeholderIndex,
+      countryCode: countryCode,
+    );
+
     ref.listen<String>(standingsSearchQueryProvider, (_, next) {
       _syncControllerText(next);
     });
@@ -96,8 +107,7 @@ class _EventSearchBarState extends ConsumerState<EventSearchBar> {
         child: SimpleSearchBar(
           controller: _controller,
           focusNode: _focusNode,
-          hintText: 'Search',
-          // No rotating hints: keep the field static, no word-swap animation.
+          hintText: hintText,
           onChanged: _handleChanged,
           onCloseTap: _handleCleared,
           onOpenFilter: null,

--- a/lib/screens/tour_detail/widgets/event_search_placeholder.dart
+++ b/lib/screens/tour_detail/widgets/event_search_placeholder.dart
@@ -1,0 +1,25 @@
+import 'package:chessever2/utils/country_utils.dart';
+
+const int eventSearchPlaceholderCount = 7;
+
+String eventSearchPlaceholderForIndex(int index, {String? countryCode}) {
+  final normalizedCountry = _eventSearchCountryExample(countryCode);
+  final placeholders = <String>[
+    'Search',
+    'Search by player: Caruana',
+    'Search by opening: Ruy Lopez',
+    'Search by ECO: B90',
+    'Search by country: $normalizedCountry',
+    'Search by title: GM',
+    'Search by result: 1-0',
+  ];
+
+  return placeholders[index % placeholders.length];
+}
+
+String _eventSearchCountryExample(String? countryCode) {
+  final trimmed = countryCode?.trim().toUpperCase();
+  if (trimmed == null || trimmed.isEmpty) return 'AZE';
+  if (trimmed.length == 2) return CountryUtils.toFideCode(trimmed);
+  return trimmed;
+}

--- a/lib/widgets/search/gameSearch/enhanced_game_search.dart
+++ b/lib/widgets/search/gameSearch/enhanced_game_search.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:chessever2/repository/local_storage/tournament/games/games_local_storage.dart';
 import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/widgets/search/gameSearch/game_result_search.dart';
 
 class EnhancedGameSearchResult {
   final List<GameSearchResult> results;
@@ -89,6 +90,13 @@ extension GamesLocalStorageEnhancedSearch on GamesLocalStorage {
             hasMatch = true;
             matchedText = game.openingName!;
           }
+        }
+
+        // Check exact PGN result tokens. Keep this intentionally literal:
+        // no draw/white-won/black-won aliases, only standard PGN results.
+        if (!hasMatch && gameResultMatchesSearchQuery(game, normalizedQuery)) {
+          hasMatch = true;
+          matchedText = gameResultSearchText(game);
         }
 
         if (hasMatch) {

--- a/lib/widgets/search/gameSearch/game_result_search.dart
+++ b/lib/widgets/search/gameSearch/game_result_search.dart
@@ -1,0 +1,35 @@
+import 'package:chessever2/repository/supabase/game/games.dart';
+
+String gameResultSearchText(Games game) {
+  final status = game.status?.trim();
+  if (_isSupportedPgnResult(status)) return status!;
+
+  final pgn = game.pgn;
+  if (pgn == null || pgn.isEmpty) return '';
+
+  final match = RegExp(
+    r'\[Result\s+"([^"]+)"\]',
+    caseSensitive: false,
+  ).firstMatch(pgn);
+  final result = match?.group(1)?.trim();
+  return _isSupportedPgnResult(result) ? result! : '';
+}
+
+bool gameResultMatchesSearchQuery(Games game, String query) {
+  final normalizedQuery = query.toLowerCase().trim();
+  if (normalizedQuery.isEmpty) return false;
+
+  final resultText = gameResultSearchText(game).toLowerCase();
+  if (resultText.isEmpty) return false;
+
+  final queryTokens =
+      normalizedQuery.split(' ').where((token) => token.isNotEmpty).toList();
+  for (final token in queryTokens) {
+    if (!resultText.contains(token)) return false;
+  }
+  return true;
+}
+
+bool _isSupportedPgnResult(String? value) {
+  return value == '1-0' || value == '0-1' || value == '1/2-1/2';
+}

--- a/test/event_search_placeholder_and_result_search_test.dart
+++ b/test/event_search_placeholder_and_result_search_test.dart
@@ -1,0 +1,68 @@
+import 'package:chessever2/repository/supabase/game/games.dart';
+import 'package:chessever2/screens/tour_detail/widgets/event_search_placeholder.dart';
+import 'package:chessever2/widgets/search/gameSearch/game_result_search.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Games _game({String? status, String? pgn}) {
+  return Games(
+    id: 'game-1',
+    roundId: 'round-1',
+    roundSlug: 'round-1',
+    tourId: 'tour-1',
+    tourSlug: 'tour-1',
+    status: status,
+    pgn: pgn,
+  );
+}
+
+void main() {
+  group('event search placeholders', () {
+    test('covers plain search and supported example searches', () {
+      final placeholders = List.generate(
+        eventSearchPlaceholderCount,
+        (index) => eventSearchPlaceholderForIndex(index, countryCode: 'AZ'),
+      );
+
+      expect(placeholders, contains('Search'));
+      expect(placeholders, contains('Search by player: Caruana'));
+      expect(placeholders, contains('Search by opening: Ruy Lopez'));
+      expect(placeholders, contains('Search by ECO: B90'));
+      expect(placeholders, contains('Search by country: AZE'));
+      expect(placeholders, contains('Search by title: GM'));
+      expect(placeholders, contains('Search by result: 1-0'));
+    });
+
+    test('uses AZE fallback when the user country is not loaded yet', () {
+      expect(eventSearchPlaceholderForIndex(4), 'Search by country: AZE');
+    });
+  });
+
+  group('game result search', () {
+    test('matches exact standard result tokens from status', () {
+      expect(gameResultMatchesSearchQuery(_game(status: '1-0'), '1-0'), isTrue);
+      expect(gameResultMatchesSearchQuery(_game(status: '0-1'), '0-1'), isTrue);
+      expect(
+        gameResultMatchesSearchQuery(_game(status: '1/2-1/2'), '1/2-1/2'),
+        isTrue,
+      );
+    });
+
+    test('falls back to PGN Result tag when status is not a result', () {
+      final game = _game(
+        status: '*',
+        pgn: '[Event "Example"]\n[Result "0-1"]\n\n1. e4 c5 0-1',
+      );
+
+      expect(gameResultSearchText(game), '0-1');
+      expect(gameResultMatchesSearchQuery(game, '0-1'), isTrue);
+    });
+
+    test('does not match unsupported natural-language aliases', () {
+      final game = _game(status: '1/2-1/2');
+
+      expect(gameResultMatchesSearchQuery(game, 'draw'), isFalse);
+      expect(gameResultMatchesSearchQuery(game, 'white won'), isFalse);
+      expect(gameResultMatchesSearchQuery(game, 'black won'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Rotates the Event Games/Standings search placeholder once per screen open across supported examples: plain Search, player, opening, ECO, user/default country, title, and result.
- Uses the saved/default country and converts ISO-2 country codes to FIDE-style examples such as AZE/USA.
- Adds exact PGN result search matching for `1-0`, `0-1`, and `1/2-1/2` from `status` or the PGN `[Result "..."]` tag.

## Test plan
- `flutter test --no-pub --reporter expanded test/event_search_placeholder_and_result_search_test.dart`
- `flutter analyze --no-pub --no-fatal-warnings lib/screens/tour_detail/widgets/event_search_bar.dart lib/screens/tour_detail/widgets/event_search_placeholder.dart lib/widgets/search/gameSearch/enhanced_game_search.dart lib/widgets/search/gameSearch/game_result_search.dart test/event_search_placeholder_and_result_search_test.dart`
- `git diff --check`

## Notes
- No natural-language aliases were added for result search; this intentionally supports only exact PGN result tokens.
- Focused analyzer still reports pre-existing unused helper warnings in `enhanced_game_search.dart`; `--no-fatal-warnings` was used for touched-file validation.