### PR TITLE
fix: share full game GIFs

### DIFF
--- a/lib/screens/chessboard/widgets/gif_export_worker.dart
+++ b/lib/screens/chessboard/widgets/gif_export_worker.dart
@@ -34,9 +34,9 @@ class GifExportProfile {
   });
 }
 
-/// Move prefix selected for a shared GIF.
+/// Full move list selected for a shared GIF.
 class GifExportWindow {
-  /// SAN moves to replay from [captureStartFen] up to the selected end move.
+  /// SAN moves to replay from [captureStartFen] through the final game position.
   final List<String> movesToAnimate;
 
   /// Offset into the original game move list. Kept for clock lookup.
@@ -52,26 +52,20 @@ class GifExportWindow {
   });
 }
 
-/// Selects the move prefix used for GIF generation.
+/// Selects the full game used for GIF generation.
 ///
-/// [currentMoveIndex] is the user-selected end position. The GIF always starts
-/// from the game's beginning position and replays the prefix up to that move.
+/// [currentMoveIndex] is intentionally ignored: Share GIF always replays the
+/// entire game from the beginning position to avoid ambiguity with the board's
+/// currently selected move. Use static image sharing for the current position.
 GifExportWindow? computeGifExportWindow({
   required List<String> moveSans,
   required int currentMoveIndex,
   String? startingFen,
 }) {
-  if (moveSans.isEmpty || currentMoveIndex < 0) return null;
-
-  final endIndex =
-      currentMoveIndex < moveSans.length
-          ? currentMoveIndex
-          : moveSans.length - 1;
+  if (moveSans.isEmpty) return null;
 
   return GifExportWindow(
-    movesToAnimate: List<String>.unmodifiable(
-      moveSans.sublist(0, endIndex + 1),
-    ),
+    movesToAnimate: List<String>.unmodifiable(moveSans),
     globalMoveOffset: 0,
     captureStartFen: startingFen,
   );
@@ -137,9 +131,9 @@ class GifWorkerError extends GifWorkerResponse {
 /// Builds an export profile for the given game length.
 ///
 /// [moveCount] is the number of moves to animate. [currentMoveIndex] should be
-/// `moveCount - 1`, because [computeGifExportWindow] already trims the source
-/// moves to the user-selected end position. Every selected move is captured so
-/// the GIF reaches the exact current board position without dropping plies.
+/// `moveCount - 1` for normal Share GIF exports, because
+/// [computeGifExportWindow] now returns the full game. Every move is captured
+/// so the GIF reaches the final board position without dropping plies.
 GifExportProfile planGifExport({
   required int moveCount,
   required int currentMoveIndex,

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -401,9 +401,8 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
   /// Computes the export window for GIF generation.
   ///
-  /// The current board position is the selected end position. GIFs always start
-  /// from the game's beginning position and replay up to that selected end.
-  /// Returns `null` if no moves are available to animate.
+  /// Share GIF always uses the full game, independent of the currently selected
+  /// board move. Returns `null` if no moves are available to animate.
   GifExportWindow? _computeExportWindow() {
     return computeGifExportWindow(
       moveSans: widget.moveSans,

--- a/test/gif_export_worker_test.dart
+++ b/test/gif_export_worker_test.dart
@@ -8,7 +8,7 @@ import 'package:image/image.dart' as img;
 
 void main() {
   group('computeGifExportWindow', () {
-    test('uses the selected move only as the GIF end position', () {
+    test('uses the full game even when an earlier move is selected', () {
       final moves = List.generate(20, (i) => 'move$i');
 
       final window = computeGifExportWindow(
@@ -18,17 +18,17 @@ void main() {
       );
 
       expect(window, isNotNull);
-      expect(window!.movesToAnimate, moves.take(6).toList());
+      expect(window!.movesToAnimate, moves);
       expect(window.globalMoveOffset, 0);
       expect(window.captureStartFen, 'custom start');
     });
 
-    test('keeps the full selected prefix for long games', () {
+    test('keeps the full game for long games', () {
       final moves = List.generate(80, (i) => 'move$i');
 
       final window = computeGifExportWindow(
         moveSans: moves,
-        currentMoveIndex: 79,
+        currentMoveIndex: 5,
       );
 
       expect(window, isNotNull);
@@ -37,13 +37,14 @@ void main() {
       expect(window.movesToAnimate.last, 'move79');
     });
 
-    test('returns null when the selected end is the initial position', () {
+    test('still shares the full game from the initial selected position', () {
       final window = computeGifExportWindow(
         moveSans: const ['e4', 'e5'],
         currentMoveIndex: -1,
       );
 
-      expect(window, isNull);
+      expect(window, isNotNull);
+      expect(window!.movesToAnimate, ['e4', 'e5']);
     });
   });
 


### PR DESCRIPTION
## Summary
- Makes `Share GIF` replay the whole game instead of stopping at the currently selected board move.
- Keeps `Share Image` as the current-position/share-card path.
- Updates GIF export tests so selected move `-1` or an earlier move still exports the full move list.

## Test Plan
- `dart format lib/screens/chessboard/widgets/gif_export_worker.dart lib/screens/chessboard/widgets/share_game_card_overlay.dart test/gif_export_worker_test.dart`
- `git diff --check`
- `flutter test test/gif_export_worker_test.dart`
- `flutter analyze --no-fatal-infos lib/screens/chessboard/widgets/gif_export_worker.dart lib/screens/chessboard/widgets/share_game_card_overlay.dart test/gif_export_worker_test.dart`

## Handoff
- Phone/mobile frontend change for Berkay review.
- Screenshot context: game share sheet `Share Image / Share GIF / Copy PGN`; expected GIF should always animate the whole game to avoid current-move ambiguity.
