### PR TITLE
fix: render FIDE federation flags

### DIFF
--- a/lib/widgets/backfilled_federation_flag.dart
+++ b/lib/widgets/backfilled_federation_flag.dart
@@ -7,9 +7,11 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 /// `chess_players` table when the supplied federation is missing.
 ///
 /// Imported PGNs frequently carry `[WhiteFideId]`/`[BlackFideId]` but omit
-/// `[WhiteFed]`/`[BlackFed]`, which would otherwise leave the card showing the
-/// generic FIDE logo. When [fideId] is present we look up the player's
-/// country and render the real flag once it loads.
+/// `[WhiteFed]`/`[BlackFed]`, which would otherwise leave the card without a
+/// flag. When [fideId] is present we look up the player's country and render the
+/// real flag once it loads. Explicit `FID`/`FIDE` federations are preserved so
+/// official FIDE-event rows show the FIDE flag instead of being backfilled to a
+/// country or hidden.
 class BackfilledFederationFlag extends ConsumerWidget {
   const BackfilledFederationFlag({
     super.key,
@@ -29,9 +31,7 @@ class BackfilledFederationFlag extends ConsumerWidget {
   bool _needsBackfill(String value) {
     if (value.isEmpty) return true;
     final upper = value.toUpperCase();
-    // Lichess returns the literal "FIDE" for sanctioned RU/BY players; treat
-    // it as missing so we backfill from chess_players.country.
-    return upper == 'FID' || upper == 'FIDE' || upper == '?';
+    return upper == '?';
   }
 
   @override

--- a/lib/widgets/federation_flag.dart
+++ b/lib/widgets/federation_flag.dart
@@ -1,4 +1,5 @@
 import 'package:chessever2/utils/country_utils.dart';
+import 'package:chessever2/utils/png_asset.dart';
 import 'package:country_picker/country_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_country_flags/flutter_country_flags.dart' as fcf;
@@ -29,7 +30,7 @@ class FederationFlag extends StatelessWidget {
 
   /// Federation values from the Gamebase API that mean "no real federation
   /// resolved" — TWIC fills this in for historical / unrated / unknown players.
-  /// Treat them as an unknown placeholder, not as a FIDE-stateless tag.
+  /// Treat them as unknown placeholders, not as federation flags.
   static const Set<String> _unknownSentinels = {
     'unknown',
     'none',
@@ -55,10 +56,10 @@ class FederationFlag extends StatelessWidget {
       return _noFlag();
     }
 
-    // FID/FIDE is not a real country flag. If no better player-profile
-    // backfill is available upstream, show no flag rather than a generic logo.
+    // FID/FIDE is an explicit FIDE federation flag used for some official
+    // FIDE-event players. Render it rather than leaving an empty flag slot.
     if (normalized == 'FID' || normalized == 'FIDE') {
-      return _noFlag();
+      return _fideFlag(context);
     }
 
     // Handle UK subdivisions (England, Scotland, Wales) with their own flags.
@@ -114,6 +115,19 @@ class FederationFlag extends StatelessWidget {
         country: country,
         width: width,
         height: height,
+      ),
+    );
+  }
+
+  Widget _fideFlag(BuildContext context) {
+    final radius = borderRadius ?? BorderRadius.circular(3);
+    return ClipRRect(
+      borderRadius: radius,
+      child: Image.asset(
+        PngAsset.fideLogo,
+        width: width,
+        height: height,
+        fit: BoxFit.cover,
       ),
     );
   }

--- a/test/federation_flag_test.dart
+++ b/test/federation_flag_test.dart
@@ -20,15 +20,17 @@ void main() {
     expect(find.byType(fcf.FlutterCountryFlags), findsOneWidget);
   });
 
+  testWidgets('renders FIDE flag for explicit FIDE federation', (tester) async {
+    await pumpFlag(tester, 'FIDE');
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.byType(fcf.FlutterCountryFlags), findsNothing);
+  });
+
   testWidgets('renders no placeholder for missing or sentinel federation', (
     tester,
   ) async {
     await pumpFlag(tester, '');
-    expect(find.byType(Icon), findsNothing);
-    expect(find.byType(Image), findsNothing);
-    expect(find.byType(fcf.FlutterCountryFlags), findsNothing);
-
-    await pumpFlag(tester, 'FIDE');
     expect(find.byType(Icon), findsNothing);
     expect(find.byType(Image), findsNothing);
     expect(find.byType(fcf.FlutterCountryFlags), findsNothing);


### PR DESCRIPTION
## Summary
- Renders the FIDE logo when player federation is explicitly `FID` / `FIDE`.
- Keeps real country flags and unknown/missing federation behavior unchanged.
- Preserves explicit FIDE federation values in `BackfilledFederationFlag` so sanctioned/FIDE-event players are not hidden or backfilled to a different country.

## Test plan
- `dart format --output=none --set-exit-if-changed lib/widgets/federation_flag.dart lib/widgets/backfilled_federation_flag.dart test/federation_flag_test.dart`
- `flutter test test/federation_flag_test.dart`
- `flutter analyze --no-fatal-infos lib/widgets/federation_flag.dart lib/widgets/backfilled_federation_flag.dart test/federation_flag_test.dart`
- `git diff --check`

## QA
Open a FIDE event Games list with players whose federation is `FID` / `FIDE`. Those rows should show the FIDE flag instead of an empty flag space, while genuinely missing/unknown federation values still render no flag placeholder.
