### PR TITLE
fix: update player share image copy

### DIFF
--- a/lib/screens/standings/widgets/player_event_share_image_card.dart
+++ b/lib/screens/standings/widgets/player_event_share_image_card.dart
@@ -91,6 +91,9 @@ class PlayerEventShareImageCard extends StatelessWidget {
   static const _textLo = Color(0xFF868C97); // ≥4.5:1 on the dark surfaces
 
   static const _padH = 22.0;
+  static const footerSlogan = 'Follow Chess Better';
+
+  static String formatHeaderRating(int rating) => rating.toString();
 
   @override
   Widget build(BuildContext context) {
@@ -290,7 +293,7 @@ class PlayerEventShareImageCard extends StatelessWidget {
                   ],
                   if (standardRating != null)
                     Text(
-                      '$standardRating FIDE',
+                      formatHeaderRating(standardRating!),
                       style: AppTypography.textSmMedium.copyWith(
                         color: _textMid,
                         fontSize: 13,
@@ -464,7 +467,7 @@ class PlayerEventShareImageCard extends StatelessWidget {
               ),
               const SizedBox(height: 1),
               Text(
-                'Follow live chess',
+                PlayerEventShareImageCard.footerSlogan,
                 style: AppTypography.textXxsMedium.copyWith(
                   color: _textLo,
                   fontSize: 11,

--- a/test/screens/standings/player_event_share_image_card_test.dart
+++ b/test/screens/standings/player_event_share_image_card_test.dart
@@ -15,4 +15,14 @@ void main() {
       expect(PlayerEventShareImageCard.formatShareScore(0, 7), '0/7');
     });
   });
+  group('share image copy', () {
+    test('uses clean player rating and brand slogan copy', () {
+      expect(PlayerEventShareImageCard.formatHeaderRating(2529), '2529');
+      expect(
+        PlayerEventShareImageCard.formatHeaderRating(2529),
+        isNot(contains('FIDE')),
+      );
+      expect(PlayerEventShareImageCard.footerSlogan, 'Follow Chess Better');
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Removes the `FIDE` suffix from the player rating shown in the player-event share image header.
- Changes the share image footer slogan to `Follow Chess Better`.
- Adds focused coverage for the share-image copy helpers.

## Validation
- `dart format lib/screens/standings/widgets/player_event_share_image_card.dart test/screens/standings/player_event_share_image_card_test.dart`
- `git diff --check`
- `flutter analyze --no-pub lib/screens/standings/widgets/player_event_share_image_card.dart test/screens/standings/player_event_share_image_card_test.dart`
- `flutter test --no-pub test/screens/standings/player_event_share_image_card_test.dart`

## Handoff
Phone/mobile UI polish. Please route review to Berkay.
