### PR TITLE
Fix For You upcoming preview guards

### DIFF
--- a/lib/providers/for_you_games_provider.dart
+++ b/lib/providers/for_you_games_provider.dart
@@ -47,6 +47,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 const int kGamesPerEvent = 4;
 const int _kPageSize = 20;
 const Duration _kForYouStaleThreshold = Duration(minutes: 5);
+const Duration _kForYouUpcomingPreviewWindow = Duration(hours: 2);
+const Duration _kForYouStartingPreviewGrace = Duration(minutes: 30);
 
 @visibleForTesting
 List<GroupBroadcast> mergeMissingFavoriteCurrentBroadcasts({
@@ -210,19 +212,17 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
       final appliedFilters = ref.read(forYouAppliedFilterProvider);
 
       // Parse filters
-      final formatFilters =
-          appliedFilters.formatsAndStates
-              .where(
-                (f) => ['blitz', 'rapid', 'standard'].contains(f.toLowerCase()),
-              )
-              .map((f) => f.toLowerCase())
-              .toList();
+      final formatFilters = appliedFilters.formatsAndStates
+          .where(
+            (f) => ['blitz', 'rapid', 'standard'].contains(f.toLowerCase()),
+          )
+          .map((f) => f.toLowerCase())
+          .toList();
 
-      final statusFilters =
-          appliedFilters.formatsAndStates
-              .where((f) => ['live', 'completed'].contains(f.toLowerCase()))
-              .map((f) => f.toLowerCase())
-              .toSet();
+      final statusFilters = appliedFilters.formatsAndStates
+          .where((f) => ['live', 'completed'].contains(f.toLowerCase()))
+          .map((f) => f.toLowerCase())
+          .toSet();
 
       final minElo = appliedFilters.minElo;
       final maxElo = appliedFilters.maxElo;
@@ -253,10 +253,9 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
       final liveIds = await _getLiveIdsSnapshot();
 
       // Convert to models
-      final models =
-          filteredBroadcasts
-              .map((b) => GroupEventCardModel.fromGroupBroadcast(b, liveIds))
-              .toList();
+      final models = filteredBroadcasts
+          .map((b) => GroupEventCardModel.fromGroupBroadcast(b, liveIds))
+          .toList();
 
       await _prefetchTopGames(models, replace: isInitial);
 
@@ -276,8 +275,9 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
         _maybeFinalizePendingFavoritePlayerOrder();
       } else {
         final existingIds = state.events.map((event) => event.id).toSet();
-        final newModels =
-            models.where((event) => !existingIds.contains(event.id)).toList();
+        final newModels = models
+            .where((event) => !existingIds.contains(event.id))
+            .toList();
         final sortedNewModels = _sortPageOnceForSession(newModels);
         state = state.copyWith(
           events: [...state.events, ...sortedNewModels],
@@ -408,13 +408,9 @@ class ForYouNotifier extends StateNotifier<ForYouState> {
         ),
     };
 
-    notifier.state =
-        replace
-            ? snapshots
-            : <String, ForYouEventGamesSnapshot>{
-              ...notifier.state,
-              ...snapshots,
-            };
+    notifier.state = replace
+        ? snapshots
+        : <String, ForYouEventGamesSnapshot>{...notifier.state, ...snapshots};
   }
 
   Future<void> _refreshVisibleFavoritePlayerCounts({
@@ -703,8 +699,9 @@ class _ForYouPinActionController implements ForYouPinAction {
     required String tourId,
   }) async {
     final storage = _ref.read(forYouPinStorageProvider);
-    final snapshot =
-        _ref.read(forYouEventSnapshotProvider(eventId)).valueOrNull;
+    final snapshot = _ref
+        .read(forYouEventSnapshotProvider(eventId))
+        .valueOrNull;
     final mode = resolvePinToggleMode(
       isManualPinned:
           snapshot?.manualPinnedIds.contains(gameId) ??
@@ -734,8 +731,11 @@ class _ForYouPinActionController implements ForYouPinAction {
     }
 
     final selectedBroadcast = _ref.read(selectedBroadcastModelProvider);
-    final selectedTourId =
-        _ref.read(tourDetailScreenProvider).valueOrNull?.aboutTourModel.id;
+    final selectedTourId = _ref
+        .read(tourDetailScreenProvider)
+        .valueOrNull
+        ?.aboutTourModel
+        .id;
 
     if (selectedBroadcast?.id == eventId &&
         selectedTourId != null &&
@@ -754,33 +754,37 @@ class _ForYouPinActionController implements ForYouPinAction {
 // then lets the UI render only the first 4 visible games.
 // ============================================================================
 
-final eventGamesProvider = StateNotifierProvider.autoDispose.family<
-  _ForYouEventGamesController,
-  AsyncValue<ForYouEventGamesSnapshot>,
-  String
->((ref, eventId) {
-  final controller = _ForYouEventGamesController(ref: ref, eventId: eventId);
+final eventGamesProvider = StateNotifierProvider.autoDispose
+    .family<
+      _ForYouEventGamesController,
+      AsyncValue<ForYouEventGamesSnapshot>,
+      String
+    >((ref, eventId) {
+      final controller = _ForYouEventGamesController(
+        ref: ref,
+        eventId: eventId,
+      );
 
-  ref.onCancel(controller.handleCancel);
-  ref.onResume(controller.handleResume);
+      ref.onCancel(controller.handleCancel);
+      ref.onResume(controller.handleResume);
 
-  // Per-event listeners only. Global signals (favorites version, country
-  // dropdown, auto-pin prefs, current user, live tour id, live rounds id) are
-  // funneled through `forYouEventsRefreshProvider` by `ForYouNotifier` — that
-  // collapses N×6 family listens into 6 single listens + N event listens, a
-  // ~6× reduction at typical list sizes.
-  ref.listen(eventPinRefreshProvider(eventId), (_, __) {
-    controller.requestRefresh();
-  });
-  ref.listen(forYouEventsRefreshProvider, (_, __) {
-    controller.requestRefresh();
-  });
-  ref.listen(currentSelectedTourIdForEventProvider(eventId), (_, __) {
-    controller.requestRefresh();
-  });
+      // Per-event listeners only. Global signals (favorites version, country
+      // dropdown, auto-pin prefs, current user, live tour id, live rounds id) are
+      // funneled through `forYouEventsRefreshProvider` by `ForYouNotifier` — that
+      // collapses N×6 family listens into 6 single listens + N event listens, a
+      // ~6× reduction at typical list sizes.
+      ref.listen(eventPinRefreshProvider(eventId), (_, __) {
+        controller.requestRefresh();
+      });
+      ref.listen(forYouEventsRefreshProvider, (_, __) {
+        controller.requestRefresh();
+      });
+      ref.listen(currentSelectedTourIdForEventProvider(eventId), (_, __) {
+        controller.requestRefresh();
+      });
 
-  return controller;
-});
+      return controller;
+    });
 
 class _ForYouEventGamesController
     extends StateNotifier<AsyncValue<ForYouEventGamesSnapshot>> {
@@ -961,27 +965,25 @@ Future<ForYouEventGamesSnapshot> _computeForYouEventGamesSnapshot({
     games: selectedTourGames,
   );
 
-  final gamesForAutoPin =
-      isKnockout
-          ? gamesByTourId.values
-              .expand((games) => games)
-              .map((game) {
-                try {
-                  return GamesTourModel.fromGame(game);
-                } catch (_) {
-                  return null;
-                }
-              })
-              .whereType<GamesTourModel>()
-              .toList()
-          : sortGamesForGamesTab(games: selectedTourGames, pinnedIds: const []);
+  final gamesForAutoPin = isKnockout
+      ? gamesByTourId.values
+            .expand((games) => games)
+            .map((game) {
+              try {
+                return GamesTourModel.fromGame(game);
+              } catch (_) {
+                return null;
+              }
+            })
+            .whereType<GamesTourModel>()
+            .toList()
+      : sortGamesForGamesTab(games: selectedTourGames, pinnedIds: const []);
 
   final pinState = await _loadPinnedStateForEvent(
     ref: ref,
-    relatedTourIds:
-        isKnockout
-            ? eventTours.map((tour) => tour.id).toList(growable: false)
-            : [selectedTour.id],
+    relatedTourIds: isKnockout
+        ? eventTours.map((tour) => tour.id).toList(growable: false)
+        : [selectedTour.id],
     autoPinTourId: selectedTour.id,
     allRelevantGames: gamesForAutoPin,
   );
@@ -1140,6 +1142,48 @@ ForYouEventGamesSnapshot _emptyForYouEventGamesSnapshot(String eventId) {
   );
 }
 
+@visibleForTesting
+bool isForYouPreviewGameAllowed(Games game, {DateTime? now}) {
+  if (!_hasResolvedForYouPlayers(game)) return false;
+  if (_hasStartedOrFinished(game)) return true;
+
+  final roundStartsAt = game.roundStartsAt;
+  if (roundStartsAt == null) return false;
+
+  final referenceNow = now ?? DateTime.now().toUtc();
+  final startsAtUtc = roundStartsAt.toUtc();
+  final earliestAllowed = referenceNow.subtract(_kForYouStartingPreviewGrace);
+  final latestAllowed = referenceNow.add(_kForYouUpcomingPreviewWindow);
+
+  return !startsAtUtc.isBefore(earliestAllowed) &&
+      !startsAtUtc.isAfter(latestAllowed);
+}
+
+bool _hasResolvedForYouPlayers(Games game) {
+  final players = game.players;
+  if (players == null || players.length < 2) return false;
+  return _isResolvedForYouPlayerName(players[0].name) &&
+      _isResolvedForYouPlayerName(players[1].name);
+}
+
+bool _isResolvedForYouPlayerName(String name) {
+  final normalized = name.trim().toLowerCase();
+  if (normalized.isEmpty) return false;
+  return normalized != '?' &&
+      normalized != '??' &&
+      normalized != 'unknown' &&
+      normalized != 'tbd' &&
+      normalized != 'tba';
+}
+
+bool _hasStartedOrFinished(Games game) {
+  if (game.lastMove?.trim().isNotEmpty == true) return true;
+  if (game.lastMoveTime != null) return true;
+
+  final status = game.status?.trim();
+  return status != null && status.isNotEmpty && status != '*';
+}
+
 ForYouEventGamesSnapshot _buildForYouTopGamesSnapshot({
   required String eventId,
   required List<Games> games,
@@ -1147,7 +1191,8 @@ ForYouEventGamesSnapshot _buildForYouTopGamesSnapshot({
   if (games.isEmpty) return _emptyForYouEventGamesSnapshot(eventId);
 
   final visibleGames = <GamesTourModel>[];
-  for (final game in games.take(kGamesPerEvent)) {
+  for (final game
+      in games.where(isForYouPreviewGameAllowed).take(kGamesPerEvent)) {
     try {
       visibleGames.add(GamesTourModel.fromGame(game));
     } catch (error) {
@@ -1174,10 +1219,9 @@ List<TourModel> _buildEventTourModels(
 
   for (final tour in tours) {
     if (tour.dates.isEmpty) {
-      final status =
-          liveTourIds.contains(tour.id)
-              ? RoundStatus.live
-              : RoundStatus.completed;
+      final status = liveTourIds.contains(tour.id)
+          ? RoundStatus.live
+          : RoundStatus.completed;
       models.add(TourModel(tour: tour, roundStatus: status));
       continue;
     }
@@ -1443,20 +1487,19 @@ Future<List<String>> _loadAutoPins({
 
   if (prefs.countrymenAutoPinEnabled) {
     if (countryCode != null && countryCode.isNotEmpty) {
-      final countryGames =
-          allRelevantGames
-              .where((game) {
-                return CountryCodeMatcher.matches(
-                      game.whitePlayer.countryCode,
-                      countryCode,
-                    ) ||
-                    CountryCodeMatcher.matches(
-                      game.blackPlayer.countryCode,
-                      countryCode,
-                    );
-              })
-              .map((game) => game.gameId)
-              .toList();
+      final countryGames = allRelevantGames
+          .where((game) {
+            return CountryCodeMatcher.matches(
+                  game.whitePlayer.countryCode,
+                  countryCode,
+                ) ||
+                CountryCodeMatcher.matches(
+                  game.blackPlayer.countryCode,
+                  countryCode,
+                );
+          })
+          .map((game) => game.gameId)
+          .toList();
 
       if (countryGames.length < allRelevantGames.length) {
         pinnedIds.addAll(countryGames);
@@ -1510,19 +1553,19 @@ bool shouldLoadDeferredActivityTourId({
     return false;
   }
 
-  final selectableModels =
-      hasStartedTours
-          ? tourModels
-              .where((model) => model.roundStatus != RoundStatus.upcoming)
-              .toList()
-          : List<TourModel>.from(tourModels);
+  final selectableModels = hasStartedTours
+      ? tourModels
+            .where((model) => model.roundStatus != RoundStatus.upcoming)
+            .toList()
+      : List<TourModel>.from(tourModels);
 
   if (selectableModels.isEmpty) {
     return true;
   }
 
-  final toursWithDates =
-      selectableModels.where((model) => model.tour.dates.isNotEmpty).toList();
+  final toursWithDates = selectableModels
+      .where((model) => model.tour.dates.isNotEmpty)
+      .toList();
 
   if (toursWithDates.isNotEmpty) {
     final firstStart = toursWithDates.first.tour.dates.first;
@@ -1576,74 +1619,72 @@ Future<String?> _resolveAutoPinCountryCode(Ref ref) async {
 /// The card widgets consume their own live row data, but this wrapper keeps the
 /// section subscribed to the same rendered live rows and refreshes the snapshot
 /// as soon as a displayed game finishes.
-final forYouEventGamesWithAutoRefreshProvider = Provider.autoDispose.family<
-  AsyncValue<ForYouEventGamesSnapshot>,
-  String
->((ref, eventId) {
-  final snapshotAsync = ref.watch(eventGamesProvider(eventId));
+final forYouEventGamesWithAutoRefreshProvider = Provider.autoDispose
+    .family<AsyncValue<ForYouEventGamesSnapshot>, String>((ref, eventId) {
+      final snapshotAsync = ref.watch(eventGamesProvider(eventId));
 
-  return snapshotAsync.when(
-    data: (snapshot) {
-      final liveGames =
-          snapshot.visibleGames
+      return snapshotAsync.when(
+        data: (snapshot) {
+          final liveGames = snapshot.visibleGames
               .take(kGamesPerEvent)
               .where((game) => game.gameStatus == GameStatus.ongoing)
               .toList();
 
-      if (liveGames.isNotEmpty) {
-        final shouldWatchLiveFinishes =
-            ref.watch(shouldStreamProvider) &&
-            !ref.watch(liveGameCardsPausedProvider);
-        if (!shouldWatchLiveFinishes) {
-          return AsyncValue.data(snapshot);
-        }
-
-        final displayedGames = snapshot.visibleGames.take(kGamesPerEvent);
-        final watchedGameIds = liveGames
-            .map((game) => game.gameId)
-            .toList(growable: false);
-        final updatesAsync = ref.watch(
-          gameUpdatesBatchStreamProvider(
-            LiveGamesBatchKey(
-              scopeId: 'for_you:$eventId:${snapshot.tourId}',
-              gameIds: displayedGames.map((game) => game.gameId),
-            ),
-          ).select(
-            (async) => async.whenData(
-              (updates) => _LiveGameStatusProjection.fromUpdates(
-                watchedGameIds,
-                updates,
-              ),
-            ),
-          ),
-        );
-
-        updatesAsync.whenData((updates) {
-          for (final status in updates.statuses) {
-            if (status.status != null && _isFinishedStatus(status.status!)) {
-              Future.microtask(() {
-                try {
-                  ref
-                      .read(eventGamesProvider(eventId).notifier)
-                      .requestRefreshForFinishedGame(
-                        gameId: status.gameId,
-                        status: status.status!,
-                      );
-                } on StateError {
-                  // The section can be disposed while a stream event is queued.
-                }
-              });
+          if (liveGames.isNotEmpty) {
+            final shouldWatchLiveFinishes =
+                ref.watch(shouldStreamProvider) &&
+                !ref.watch(liveGameCardsPausedProvider);
+            if (!shouldWatchLiveFinishes) {
+              return AsyncValue.data(snapshot);
             }
-          }
-        });
-      }
 
-      return AsyncValue.data(snapshot);
-    },
-    loading: () => const AsyncValue.loading(),
-    error: (e, st) => AsyncValue.error(e, st),
-  );
-});
+            final displayedGames = snapshot.visibleGames.take(kGamesPerEvent);
+            final watchedGameIds = liveGames
+                .map((game) => game.gameId)
+                .toList(growable: false);
+            final updatesAsync = ref.watch(
+              gameUpdatesBatchStreamProvider(
+                LiveGamesBatchKey(
+                  scopeId: 'for_you:$eventId:${snapshot.tourId}',
+                  gameIds: displayedGames.map((game) => game.gameId),
+                ),
+              ).select(
+                (async) => async.whenData(
+                  (updates) => _LiveGameStatusProjection.fromUpdates(
+                    watchedGameIds,
+                    updates,
+                  ),
+                ),
+              ),
+            );
+
+            updatesAsync.whenData((updates) {
+              for (final status in updates.statuses) {
+                if (status.status != null &&
+                    _isFinishedStatus(status.status!)) {
+                  Future.microtask(() {
+                    try {
+                      ref
+                          .read(eventGamesProvider(eventId).notifier)
+                          .requestRefreshForFinishedGame(
+                            gameId: status.gameId,
+                            status: status.status!,
+                          );
+                    } on StateError {
+                      // The section can be disposed while a stream event is queued.
+                    }
+                  });
+                }
+              }
+            });
+          }
+
+          return AsyncValue.data(snapshot);
+        },
+        loading: () => const AsyncValue.loading(),
+        error: (e, st) => AsyncValue.error(e, st),
+      );
+    });
 
 @immutable
 class _LiveGameStatusProjection {

--- a/lib/repository/supabase/game/games.dart
+++ b/lib/repository/supabase/game/games.dart
@@ -18,6 +18,7 @@ class Games {
   final int? boardNr;
   final DateTime? lastMoveTime;
   final DateTime? gameDay;
+  final DateTime? roundStartsAt;
   final int? lastClockWhite;
   final int? lastClockBlack;
   final DateTime? dateStart;
@@ -45,6 +46,7 @@ class Games {
     this.boardNr,
     this.lastMoveTime,
     this.gameDay,
+    this.roundStartsAt,
     this.lastClockWhite,
     this.lastClockBlack,
     this.dateStart,
@@ -72,6 +74,7 @@ class Games {
     int? boardNr,
     DateTime? lastMoveTime,
     DateTime? gameDay,
+    DateTime? roundStartsAt,
     int? lastClockWhite,
     int? lastClockBlack,
     DateTime? dateStart,
@@ -98,6 +101,7 @@ class Games {
       boardNr: boardNr ?? this.boardNr,
       lastMoveTime: lastMoveTime ?? this.lastMoveTime,
       gameDay: gameDay ?? this.gameDay,
+      roundStartsAt: roundStartsAt ?? this.roundStartsAt,
       lastClockWhite: lastClockWhite ?? this.lastClockWhite,
       lastClockBlack: lastClockBlack ?? this.lastClockBlack,
       dateStart: dateStart ?? this.dateStart,
@@ -115,8 +119,9 @@ class Games {
       int? avgElo;
       final tours = json['tours'];
       if (tours is Map<String, dynamic>) {
-        avgElo =
-            tours['avg_elo'] != null ? (tours['avg_elo'] as num).toInt() : null;
+        avgElo = tours['avg_elo'] != null
+            ? (tours['avg_elo'] as num).toInt()
+            : null;
         final groupBroadcasts = tours['group_broadcasts'];
         if (groupBroadcasts is Map<String, dynamic>) {
           timeControl = groupBroadcasts['time_control'] as String?;
@@ -124,8 +129,9 @@ class Games {
       }
       // Also check direct fields (for backwards compatibility)
       timeControl ??= json['time_control'] as String?;
-      avgElo ??=
-          json['avg_elo'] != null ? (json['avg_elo'] as num).toInt() : null;
+      avgElo ??= json['avg_elo'] != null
+          ? (json['avg_elo'] as num).toInt()
+          : null;
 
       return Games(
         id: json['id'] as String,
@@ -135,49 +141,44 @@ class Games {
         tourSlug: json['tour_slug'] as String,
         name: json['name'] as String?,
         fen: json['fen'] as String?,
-        players:
-            json['players'] != null
-                ? (json['players'] as List)
-                    .map(
-                      (player) =>
-                          Player.fromJson(player as Map<String, dynamic>),
-                    )
-                    .toList()
-                : null,
+        players: json['players'] != null
+            ? (json['players'] as List)
+                  .map(
+                    (player) => Player.fromJson(player as Map<String, dynamic>),
+                  )
+                  .toList()
+            : null,
         lastMove: json['last_move'] as String?,
-        thinkTime:
-            json['think_time'] != null
-                ? (json['think_time'] as num).toInt()
-                : null,
+        thinkTime: json['think_time'] != null
+            ? (json['think_time'] as num).toInt()
+            : null,
         status: json['status'] as String?,
         pgn: json['pgn'] as String?,
-        search:
-            json['search'] != null
-                ? (json['search'] as List).map((e) => e as String).toList()
-                : null,
+        search: json['search'] != null
+            ? (json['search'] as List).map((e) => e as String).toList()
+            : null,
         lichessId: json['lichess_id'] as String?,
-        boardNr:
-            json['board_nr'] != null ? (json['board_nr'] as num).toInt() : null,
-        lastMoveTime:
-            json['last_move_time'] != null
-                ? DateTime.parse(json['last_move_time'] as String)
-                : null,
-        gameDay:
-            json['game_day'] != null
-                ? DateTime.parse(json['game_day'] as String)
-                : null,
-        lastClockWhite:
-            json['last_clock_white'] != null
-                ? (json['last_clock_white'] as num).toInt()
-                : null,
-        lastClockBlack:
-            json['last_clock_black'] != null
-                ? (json['last_clock_black'] as num).toInt()
-                : null,
-        dateStart:
-            json['date_start'] != null
-                ? DateTime.parse(json['date_start'] as String)
-                : null,
+        boardNr: json['board_nr'] != null
+            ? (json['board_nr'] as num).toInt()
+            : null,
+        lastMoveTime: json['last_move_time'] != null
+            ? DateTime.parse(json['last_move_time'] as String)
+            : null,
+        gameDay: json['game_day'] != null
+            ? DateTime.parse(json['game_day'] as String)
+            : null,
+        roundStartsAt: json['round_starts_at'] != null
+            ? DateTime.parse(json['round_starts_at'] as String)
+            : null,
+        lastClockWhite: json['last_clock_white'] != null
+            ? (json['last_clock_white'] as num).toInt()
+            : null,
+        lastClockBlack: json['last_clock_black'] != null
+            ? (json['last_clock_black'] as num).toInt()
+            : null,
+        dateStart: json['date_start'] != null
+            ? DateTime.parse(json['date_start'] as String)
+            : null,
         eco: json['eco'] as String?,
         openingName: json['opening_name'] as String?,
         timeControl: timeControl,
@@ -209,6 +210,8 @@ class Games {
         'last_move_time': lastMoveTime!.toIso8601String(),
       if (gameDay != null)
         'game_day': gameDay!.toIso8601String().split('T').first,
+      if (roundStartsAt != null)
+        'round_starts_at': roundStartsAt!.toIso8601String(),
       if (lastClockWhite != null) 'last_clock_white': lastClockWhite,
       if (lastClockBlack != null) 'last_clock_black': lastClockBlack,
       if (dateStart != null)
@@ -396,14 +399,12 @@ class SearchPlayer {
       id: json['id']?.toString() ?? '',
       name: json['name']?.toString() ?? '',
       title: json['title']?.toString(),
-      rating:
-          json['rating'] != null
-              ? int.tryParse(json['rating'].toString())
-              : null,
-      fideId:
-          json['fideId'] != null
-              ? int.tryParse(json['fideId'].toString())
-              : null,
+      rating: json['rating'] != null
+          ? int.tryParse(json['rating'].toString())
+          : null,
+      fideId: json['fideId'] != null
+          ? int.tryParse(json['fideId'].toString())
+          : null,
       fed: json['fed']?.toString(),
       tournamentId: tournamentId,
       tournamentName: tournamentName,

--- a/test/for_you_games_provider_test.dart
+++ b/test/for_you_games_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:chessever2/providers/event_pin_refresh_provider.dart';
 import 'package:chessever2/providers/for_you_games_provider.dart';
 import 'package:chessever2/providers/for_you_games_logic.dart';
+import 'package:chessever2/repository/supabase/game/games.dart';
 import 'package:chessever2/repository/supabase/group_broadcast/group_broadcast.dart';
 import 'package:chessever2/repository/supabase/round/round.dart';
 import 'package:chessever2/repository/supabase/round/round_repository.dart';
@@ -81,7 +82,6 @@ class _FakeForYouPinStorage implements ForYouPinStorage {
   }
 }
 
-
 PlayerCard _player(String name) {
   return PlayerCard(
     name: name,
@@ -118,8 +118,11 @@ ForYouEventGamesSnapshot _snapshot(
   List<String> unpinnedOverrideIds = const <String>[],
   bool hasGames = true,
 }) {
-  final games = visibleGames ??
-      (hasGames ? [_game('mock-game', tourId: tourId)] : const <GamesTourModel>[]);
+  final games =
+      visibleGames ??
+      (hasGames
+          ? [_game('mock-game', tourId: tourId)]
+          : const <GamesTourModel>[]);
   return ForYouEventGamesSnapshot(
     eventId: eventId,
     tourId: tourId,
@@ -183,6 +186,49 @@ GroupBroadcast _broadcast(String id) {
   );
 }
 
+Games _topGame({
+  String id = 'game-1',
+  String whiteName = 'White Player',
+  String blackName = 'Black Player',
+  String? lastMove,
+  DateTime? lastMoveTime,
+  DateTime? roundStartsAt,
+  String status = '*',
+}) {
+  return Games(
+    id: id,
+    roundId: 'round-1',
+    roundSlug: 'round-1',
+    tourId: 'tour-1',
+    tourSlug: 'tour-1',
+    fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+    players: [
+      Player(
+        name: whiteName,
+        title: 'GM',
+        rating: 2700,
+        fideId: 1,
+        fed: 'USA',
+        clock: 0,
+        team: '',
+      ),
+      Player(
+        name: blackName,
+        title: 'GM',
+        rating: 2700,
+        fideId: 2,
+        fed: 'USA',
+        clock: 0,
+        team: '',
+      ),
+    ],
+    lastMove: lastMove,
+    lastMoveTime: lastMoveTime,
+    roundStartsAt: roundStartsAt,
+    status: status,
+  );
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final triggerPinRefreshProvider = Provider.family<void Function(), String?>((
@@ -190,6 +236,43 @@ void main() {
     eventId,
   ) {
     return () => bumpEventPinRefreshSignal(ref, eventId);
+  });
+
+  group('isForYouPreviewGameAllowed', () {
+    final now = DateTime.utc(2026, 6, 30, 12);
+
+    test('rejects unresolved placeholder players even near round start', () {
+      final game = _topGame(
+        whiteName: '?',
+        blackName: 'Named Player',
+        roundStartsAt: now.add(const Duration(minutes: 30)),
+      );
+
+      expect(isForYouPreviewGameAllowed(game, now: now), isFalse);
+    });
+
+    test('allows named upcoming pairings inside the two-hour window', () {
+      final game = _topGame(roundStartsAt: now.add(const Duration(hours: 2)));
+
+      expect(isForYouPreviewGameAllowed(game, now: now), isTrue);
+    });
+
+    test('rejects named unstarted pairings too early for For You previews', () {
+      final game = _topGame(
+        roundStartsAt: now.add(const Duration(hours: 2, minutes: 1)),
+      );
+
+      expect(isForYouPreviewGameAllowed(game, now: now), isFalse);
+    });
+
+    test('allows named games that already have moves', () {
+      final game = _topGame(
+        lastMove: 'e2e4',
+        roundStartsAt: now.add(const Duration(hours: 8)),
+      );
+
+      expect(isForYouPreviewGameAllowed(game, now: now), isTrue);
+    });
   });
 
   group('mergeMissingFavoriteCurrentBroadcasts', () {
@@ -271,9 +354,8 @@ void main() {
 
         expect(values, [null]);
 
-        container
-            .read(selectedBroadcastModelProvider.notifier)
-            .state = _broadcast('event-x');
+        container.read(selectedBroadcastModelProvider.notifier).state =
+            _broadcast('event-x');
 
         expect(subscription.read(), isNull);
         expect(values, [null]);
@@ -306,9 +388,8 @@ void main() {
 
       expect(values, [null]);
 
-      container
-          .read(selectedBroadcastModelProvider.notifier)
-          .state = _broadcast('event-x');
+      container.read(selectedBroadcastModelProvider.notifier).state =
+          _broadcast('event-x');
 
       expect(subscription.read(), 'tour-a');
       expect(values, [null, 'tour-a']);
@@ -318,9 +399,8 @@ void main() {
       expect(subscription.read(), 'tour-b');
       expect(values, [null, 'tour-a', 'tour-b']);
 
-      container
-          .read(selectedBroadcastModelProvider.notifier)
-          .state = _broadcast('event-y');
+      container.read(selectedBroadcastModelProvider.notifier).state =
+          _broadcast('event-y');
 
       expect(subscription.read(), isNull);
       expect(values, [null, 'tour-a', 'tour-b', null]);


### PR DESCRIPTION
## Summary
- Parse `round_starts_at` from the backend top-games RPC payload.
- Add a mobile-side defensive guard before rendering For You previews: reject placeholder players, allow named unstarted pairings only inside the 2-hour start window, and allow games that already have move/status activity.
- Add provider tests for placeholder, soon-upcoming, too-early upcoming, and started-game cases.

## Tests
- `flutter test test/for_you_games_provider_test.dart`
- `flutter analyze lib/providers/for_you_games_provider.dart lib/repository/supabase/game/games.dart test/for_you_games_provider_test.dart`
- `git diff --check`

## Backend companion
- Backend/RPC migration PR: https://github.com/Chessever/chessever-data-hub/pull/36
- This frontend PR intentionally does not apply/own the SQL migration anymore.
