### PR TITLE
Fix event placeholder boards

### DIFF
--- a/lib/screens/tour_detail/games_tour/providers/games_tour_grouped_provider.dart
+++ b/lib/screens/tour_detail/games_tour/providers/games_tour_grouped_provider.dart
@@ -8,6 +8,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_s
 import 'package:chessever2/screens/tour_detail/games_tour/providers/knockout_tournament_state_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/utils/knockout_match_detector.dart';
 import 'package:chessever2/screens/tour_detail/provider/tour_detail_screen_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class GroupedGamesData {
@@ -146,6 +147,9 @@ final gamesTourGroupedProvider = Provider.autoDispose<GroupedGamesData>((ref) {
   }
 
   bool addGameToRound(String roundId, GamesTourModel game) {
+    if (!isEventBoardGameVisible(game)) {
+      return false;
+    }
     ensureRoundEntry(roundId);
     if (seenGameIdsPerRound[roundId]!.add(game.gameId)) {
       gamesByRound[roundId]!.add(game);
@@ -184,7 +188,10 @@ final gamesTourGroupedProvider = Provider.autoDispose<GroupedGamesData>((ref) {
         final stageAsync = ref.read(gamesTourProvider(stageTourId));
         final rawStageGames = stageAsync.valueOrNull ?? [];
         stageTourGames[stageTourId] =
-            rawStageGames.map((g) => GamesTourModel.fromGame(g)).toList();
+            rawStageGames
+                .map((g) => GamesTourModel.fromGame(g))
+                .where(isEventBoardGameVisible)
+                .toList();
       }
 
       for (final round in rounds) {
@@ -274,4 +281,60 @@ bool _shouldIncludeGame(GameDisplayMode mode, GamesTourModel game) {
     case GameDisplayMode.all:
       return true;
   }
+}
+
+@visibleForTesting
+bool isEventBoardGameVisible(GamesTourModel game) {
+  if (!_hasResolvedPlayer(game.whitePlayer) ||
+      !_hasResolvedPlayer(game.blackPlayer)) {
+    return false;
+  }
+
+  if (_hasPlayedPosition(game)) {
+    return true;
+  }
+
+  // Do not turn unstarted pairings/placeholders into playable event boards.
+  // Round start times still live on the round models/schedule; empty rounds are
+  // removed from the Games dropdown by filteredRounds.
+  return false;
+}
+
+bool _hasResolvedPlayer(PlayerCard player) {
+  final normalized = player.name.trim().toLowerCase();
+  if (normalized.isEmpty) return false;
+  return normalized != '?' &&
+      normalized != '??' &&
+      normalized != 'tbd' &&
+      normalized != 'tba' &&
+      normalized != 'unknown';
+}
+
+bool _hasPlayedPosition(GamesTourModel game) {
+  if (game.lastMove?.trim().isNotEmpty == true) return true;
+  if (_pgnContainsMoves(game.pgn)) return true;
+  final fen = game.fen?.trim();
+  if (fen == null || fen.isEmpty) return false;
+  return !_isInitialFen(fen);
+}
+
+bool _pgnContainsMoves(String? pgn) {
+  final text = pgn?.trim();
+  if (text == null || text.isEmpty) return false;
+  final withoutHeaders =
+      text
+          .split('\n')
+          .where((line) => !line.trimLeft().startsWith('['))
+          .join(' ')
+          .trim();
+  return RegExp(r'\b\d+\s*\.').hasMatch(withoutHeaders) ||
+      RegExp(
+        r'\b[a-h][1-8][a-h][1-8][qrbn]?\b',
+        caseSensitive: false,
+      ).hasMatch(withoutHeaders);
+}
+
+bool _isInitialFen(String fen) {
+  final board = fen.split(RegExp(r'\s+')).first;
+  return board == 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
 }

--- a/test/event_placeholder_board_filter_test.dart
+++ b/test/event_placeholder_board_filter_test.dart
@@ -1,0 +1,93 @@
+import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/providers/games_tour_grouped_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('event board placeholder filtering', () {
+    test('hides unresolved starting-position placeholders', () {
+      final placeholder = _game(
+        id: 'future-placeholder',
+        whiteName: '?',
+        blackName: '?',
+        fen: _initialFen,
+      );
+
+      expect(isEventBoardGameVisible(placeholder), isFalse);
+    });
+
+    test(
+      'hides named unstarted pairings so future rounds are not board cards',
+      () {
+        final futurePairing = _game(
+          id: 'future-pairing',
+          whiteName: 'Player A',
+          blackName: 'Player B',
+          fen: _initialFen,
+        );
+
+        expect(isEventBoardGameVisible(futurePairing), isFalse);
+      },
+    );
+
+    test('keeps real games with resolved players and moves', () {
+      final liveGame = _game(
+        id: 'live-game',
+        whiteName: 'Player A',
+        blackName: 'Player B',
+        lastMove: 'e2e4',
+        fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1',
+      );
+
+      expect(isEventBoardGameVisible(liveGame), isTrue);
+    });
+
+    test('keeps PGN-only games even when last_move is missing', () {
+      final pgnGame = _game(
+        id: 'pgn-game',
+        whiteName: 'Player A',
+        blackName: 'Player B',
+        pgn: '[Event "Demo"]\n\n1. e4 e5 2. Nf3',
+      );
+
+      expect(isEventBoardGameVisible(pgnGame), isTrue);
+    });
+  });
+}
+
+const _initialFen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+GamesTourModel _game({
+  required String id,
+  required String whiteName,
+  required String blackName,
+  String? lastMove,
+  String? fen,
+  String? pgn,
+}) {
+  return GamesTourModel(
+    gameId: id,
+    whitePlayer: _player(whiteName),
+    blackPlayer: _player(blackName),
+    whiteTimeDisplay: '--:--',
+    blackTimeDisplay: '--:--',
+    whiteClockCentiseconds: 0,
+    blackClockCentiseconds: 0,
+    gameStatus: GameStatus.ongoing,
+    roundId: 'round-8',
+    tourId: 'tour-1',
+    lastMove: lastMove,
+    fen: fen,
+    pgn: pgn,
+  );
+}
+
+PlayerCard _player(String name) {
+  return PlayerCard(
+    name: name,
+    federation: 'USA',
+    title: '',
+    rating: 2500,
+    countryCode: 'USA',
+    team: null,
+  );
+}


### PR DESCRIPTION
## Summary
- Filters event Games grouping so unstarted placeholder/pairing rows do not render as playable board cards.
- Keeps round metadata/start times intact; rounds with no visible games fall out of the Games round dropdown through existing `filteredRounds` behavior.
- Applies the same visibility guard to multi-stage event grouping.

## Test plan
- `dart format --output=none --set-exit-if-changed lib/screens/tour_detail/games_tour/providers/games_tour_grouped_provider.dart test/event_placeholder_board_filter_test.dart`
- `flutter analyze lib/screens/tour_detail/games_tour/providers/games_tour_grouped_provider.dart test/event_placeholder_board_filter_test.dart`
- `flutter test test/event_placeholder_board_filter_test.dart`
- `git diff --check`

## Notes
- This is the mobile/client defensive guard for the event Games tab and round dropdown.
- It does not remove round/start-time metadata from the event schedule/about surface.
- Related but separate For You preview guard: #255.
