### PR TITLE
fix: limit board player tap target to name

### DIFF
--- a/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
+++ b/lib/screens/chessboard/widgets/player_first_row_detail_widget.dart
@@ -428,354 +428,376 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
     // Clock padding - add small horizontal padding to prevent flickering and provide stability
     final clockPadding = playerView == PlayerView.gridView ? 4.w : 6.w;
 
-    return GestureDetector(
-      onTap: () async {
-        final standingsAsync = ref.read(playerTourScreenProvider);
+    Future<void> openPlayerScoreCard() async {
+      final standingsAsync = ref.read(playerTourScreenProvider);
 
-        // Create fallback player model from game data - always has fideId if available
-        final fallbackPlayer = PlayerStandingModel(
-          countryCode: effectivePlayerCard.countryCode,
-          title:
-              effectivePlayerCard.title.isNotEmpty
-                  ? effectivePlayerCard.title
-                  : null,
-          name: effectivePlayerCard.name,
-          score: effectivePlayerCard.rating,
-          scoreChange: 0,
-          matchScore: null,
+      // Create fallback player model from game data - always has fideId if available
+      final fallbackPlayer = PlayerStandingModel(
+        countryCode: effectivePlayerCard.countryCode,
+        title:
+            effectivePlayerCard.title.isNotEmpty
+                ? effectivePlayerCard.title
+                : null,
+        name: effectivePlayerCard.name,
+        score: effectivePlayerCard.rating,
+        scoreChange: 0,
+        matchScore: null,
+        fideId: effectivePlayerCard.fideId,
+        gamebasePlayerId: effectivePlayerCard.gamebasePlayerId,
+      );
+
+      // Try to find player in tournament standings, otherwise use fallback
+      var playerStanding =
+          standingsAsync.whenOrNull(
+            data:
+                (standings) => standings.firstWhere(
+                  (player) => player.name == effectivePlayerCard.name,
+                  orElse: () => fallbackPlayer,
+                ),
+          ) ??
+          fallbackPlayer;
+
+      // IMPORTANT: If standings player has null fideId but game data has it,
+      // use the fideId from game data (playerCard) - this is more reliable
+      // since games.players always has fideId from broadcast while tours.players
+      // may sometimes be missing it
+      if (playerStanding.fideId == null && effectivePlayerCard.fideId != null) {
+        playerStanding = playerStanding.copyWith(
           fideId: effectivePlayerCard.fideId,
+        );
+      }
+      if (playerStanding.gamebasePlayerId == null &&
+          effectivePlayerCard.gamebasePlayerId != null &&
+          effectivePlayerCard.gamebasePlayerId!.isNotEmpty) {
+        playerStanding = playerStanding.copyWith(
           gamebasePlayerId: effectivePlayerCard.gamebasePlayerId,
         );
+      }
 
-        // Try to find player in tournament standings, otherwise use fallback
-        var playerStanding =
-            standingsAsync.whenOrNull(
-              data:
-                  (standings) => standings.firstWhere(
-                    (player) => player.name == effectivePlayerCard.name,
-                    orElse: () => fallbackPlayer,
-                  ),
-            ) ??
-            fallbackPlayer;
-
-        // IMPORTANT: If standings player has null fideId but game data has it,
-        // use the fideId from game data (playerCard) - this is more reliable
-        // since games.players always has fideId from broadcast while tours.players
-        // may sometimes be missing it
-        if (playerStanding.fideId == null &&
-            effectivePlayerCard.fideId != null) {
-          playerStanding = playerStanding.copyWith(
-            fideId: effectivePlayerCard.fideId,
-          );
-        }
-        if (playerStanding.gamebasePlayerId == null &&
-            effectivePlayerCard.gamebasePlayerId != null &&
-            effectivePlayerCard.gamebasePlayerId!.isNotEmpty) {
-          playerStanding = playerStanding.copyWith(
-            gamebasePlayerId: effectivePlayerCard.gamebasePlayerId,
-          );
-        }
-
-        // Fill missing title/federation from chess_players by FIDE ID.
-        if (playerStanding.fideId != null &&
-            ((playerStanding.title?.trim().isEmpty ?? true) ||
-                playerStanding.countryCode.trim().isEmpty)) {
-          try {
-            final chessPlayer = await ref
-                .read(chessPlayerRepositoryProvider)
-                .getPlayerByFideId(playerStanding.fideId!);
-            if (chessPlayer != null) {
-              playerStanding = playerStanding.copyWith(
-                title:
-                    (playerStanding.title?.trim().isNotEmpty ?? false)
-                        ? playerStanding.title
-                        : chessPlayer.title,
-                countryCode:
-                    playerStanding.countryCode.trim().isNotEmpty
-                        ? playerStanding.countryCode
-                        : (chessPlayer.country ?? ''),
-                score:
-                    playerStanding.score > 0
-                        ? playerStanding.score
-                        : (chessPlayer.rating ?? playerStanding.score),
-              );
-            }
-          } catch (_) {
-            // Non-critical: score card can still render with existing values.
-          }
-        }
-
-        // TWIC/Gamebase route: resolve fideId from gamebasePlayerId if missing.
-        // The gamebase search API may not include fideId in preview data, but
-        // the player record has it. Resolve it so ScoreCardScreen can fetch
-        // ratings per time control and player photo.
-        if (playerStanding.fideId == null &&
-            playerStanding.gamebasePlayerId != null &&
-            playerStanding.gamebasePlayerId!.isNotEmpty) {
-          try {
-            final gamebaseRepo = ref.read(gamebaseRepositoryProvider);
-            final gamebasePlayer = await gamebaseRepo.getPlayerById(
-              playerStanding.gamebasePlayerId!,
+      // Fill missing title/federation from chess_players by FIDE ID.
+      if (playerStanding.fideId != null &&
+          ((playerStanding.title?.trim().isEmpty ?? true) ||
+              playerStanding.countryCode.trim().isEmpty)) {
+        try {
+          final chessPlayer = await ref
+              .read(chessPlayerRepositoryProvider)
+              .getPlayerByFideId(playerStanding.fideId!);
+          if (chessPlayer != null) {
+            playerStanding = playerStanding.copyWith(
+              title:
+                  (playerStanding.title?.trim().isNotEmpty ?? false)
+                      ? playerStanding.title
+                      : chessPlayer.title,
+              countryCode:
+                  playerStanding.countryCode.trim().isNotEmpty
+                      ? playerStanding.countryCode
+                      : (chessPlayer.country ?? ''),
+              score:
+                  playerStanding.score > 0
+                      ? playerStanding.score
+                      : (chessPlayer.rating ?? playerStanding.score),
             );
-            if (gamebasePlayer != null) {
-              final resolvedFideId = int.tryParse(gamebasePlayer.fideId);
-              final normalizedTitle = ChessTitleUtils.normalize(
-                gamebasePlayer.title,
-              );
-              final currentCountry = playerStanding.countryCode.trim();
-              final fallbackRating =
-                  gamebasePlayer.ratingClassical ??
-                  gamebasePlayer.highestRating ??
-                  0;
-
-              playerStanding = playerStanding.copyWith(
-                fideId:
-                    (resolvedFideId != null && resolvedFideId > 0)
-                        ? resolvedFideId
-                        : playerStanding.fideId,
-                title:
-                    (playerStanding.title?.trim().isNotEmpty ?? false)
-                        ? playerStanding.title
-                        : (normalizedTitle.isNotEmpty ? normalizedTitle : null),
-                countryCode:
-                    currentCountry.isNotEmpty
-                        ? currentCountry
-                        : gamebasePlayer.fed,
-                score:
-                    playerStanding.score > 0
-                        ? playerStanding.score
-                        : fallbackRating,
-              );
-            }
-          } catch (_) {
-            // Non-critical: score card will fall back to name-based lookup
           }
+        } catch (_) {
+          // Non-critical: score card can still render with existing values.
         }
+      }
 
-        if (!context.mounted) return;
+      // TWIC/Gamebase route: resolve fideId from gamebasePlayerId if missing.
+      // The gamebase search API may not include fideId in preview data, but
+      // the player record has it. Resolve it so ScoreCardScreen can fetch
+      // ratings per time control and player photo.
+      if (playerStanding.fideId == null &&
+          playerStanding.gamebasePlayerId != null &&
+          playerStanding.gamebasePlayerId!.isNotEmpty) {
+        try {
+          final gamebaseRepo = ref.read(gamebaseRepositoryProvider);
+          final gamebasePlayer = await gamebaseRepo.getPlayerById(
+            playerStanding.gamebasePlayerId!,
+          );
+          if (gamebasePlayer != null) {
+            final resolvedFideId = int.tryParse(gamebasePlayer.fideId);
+            final normalizedTitle = ChessTitleUtils.normalize(
+              gamebasePlayer.title,
+            );
+            final currentCountry = playerStanding.countryCode.trim();
+            final fallbackRating =
+                gamebasePlayer.ratingClassical ??
+                gamebasePlayer.highestRating ??
+                0;
 
-        ref.read(selectedPlayerProvider.notifier).state = playerStanding;
+            playerStanding = playerStanding.copyWith(
+              fideId:
+                  (resolvedFideId != null && resolvedFideId > 0)
+                      ? resolvedFideId
+                      : playerStanding.fideId,
+              title:
+                  (playerStanding.title?.trim().isNotEmpty ?? false)
+                      ? playerStanding.title
+                      : (normalizedTitle.isNotEmpty ? normalizedTitle : null),
+              countryCode:
+                  currentCountry.isNotEmpty
+                      ? currentCountry
+                      : gamebasePlayer.fed,
+              score:
+                  playerStanding.score > 0
+                      ? playerStanding.score
+                      : fallbackRating,
+            );
+          }
+        } catch (_) {
+          // Non-critical: score card will fall back to name-based lookup
+        }
+      }
 
-        // Get the current games context based on the chessboard view source
-        // This ensures ScoreCardScreen displays games from the correct source
-        final view = ref.read(chessboardViewFromProviderNew);
-        List<GamesTourModel>? gamesContext;
-        bool hasEventContext = false;
+      if (!context.mounted) return;
 
-        switch (view) {
-          case ChessboardView.favScorecard:
-          case ChessboardView.playerProfile:
-            // For favorites/player profile, show ALL player games (no event context)
-            // Clear tournament context to avoid ScoreCardScreen using stale tournament data
+      ref.read(selectedPlayerProvider.notifier).state = playerStanding;
+
+      // Get the current games context based on the chessboard view source
+      // This ensures ScoreCardScreen displays games from the correct source
+      final view = ref.read(chessboardViewFromProviderNew);
+      List<GamesTourModel>? gamesContext;
+      bool hasEventContext = false;
+
+      switch (view) {
+        case ChessboardView.favScorecard:
+        case ChessboardView.playerProfile:
+          // For favorites/player profile, show ALL player games (no event context)
+          // Clear tournament context to avoid ScoreCardScreen using stale tournament data
+          ref.read(selectedBroadcastModelProvider.notifier).state = null;
+          gamesContext =
+              null; // Let ScoreCardScreen fetch via playerGamesProvider
+          hasEventContext = false;
+          break;
+        case ChessboardView.tour:
+          if (playerProfileDataSource == PlayerProfileDataSource.twic) {
+            // TWIC route: no broadcast model, use board screen's game list
+            // filtered to the current event for score card context.
             ref.read(selectedBroadcastModelProvider.notifier).state = null;
+            final allBoardGames = ref.read(chessBoardAllGamesProvider);
+            final currentEvent = effectiveGameModel.tourId;
+            if (currentEvent.isNotEmpty && allBoardGames.isNotEmpty) {
+              gamesContext =
+                  allBoardGames.where((g) => g.tourId == currentEvent).toList();
+            }
             gamesContext =
-                null; // Let ScoreCardScreen fetch via playerGamesProvider
+                (gamesContext != null && gamesContext.isNotEmpty)
+                    ? gamesContext
+                    : [gamesTourModel];
+            hasEventContext = true;
+          } else {
+            // For tournament view, selectedBroadcastModelProvider will be set
+            // ScoreCardScreen will use gamesTourScreenProvider directly
+            gamesContext = null;
+            hasEventContext = true; // Tournament context
+          }
+          break;
+        case ChessboardView.countryman:
+          // For countrymen view, filter games by the current game's tournament
+          // This ensures ScoreCardScreen shows only games from that specific event
+          ref.read(selectedBroadcastModelProvider.notifier).state = null;
+          final allCountrymanGames =
+              ref
+                  .read(countrymanGamesTourScreenProvider)
+                  .valueOrNull
+                  ?.gamesTourModels ??
+              [];
+          final currentTourIdCountryman = effectiveGameModel.tourId;
+          if (currentTourIdCountryman.isNotEmpty) {
+            gamesContext =
+                allCountrymanGames
+                    .where((g) => g.tourId == currentTourIdCountryman)
+                    .toList();
+            hasEventContext = true; // Filtered to specific event
+          } else {
+            gamesContext = allCountrymanGames;
+            hasEventContext = false; // No specific event
+          }
+          break;
+        case ChessboardView.forYou:
+          // For "For You" view, use current game's tourId so ScoreCardScreen
+          // can fetch all event games. Don't rely on convertedForYouGamesProvider
+          // since it may not contain the current game (ChessBoardScreenNew receives
+          // resolved full event games from gameCardWrapperProvider).
+          ref.read(selectedBroadcastModelProvider.notifier).state = null;
+          if (effectiveGameModel.tourId.isNotEmpty) {
+            // Pass current game - ScoreCardScreen will fetch all event games via tourId
+            gamesContext = [effectiveGameModel];
+            hasEventContext = true;
+          } else {
+            // No tourId - can't determine event context
+            gamesContext = null;
             hasEventContext = false;
-            break;
-          case ChessboardView.tour:
-            if (playerProfileDataSource == PlayerProfileDataSource.twic) {
-              // TWIC route: no broadcast model, use board screen's game list
-              // filtered to the current event for score card context.
-              ref.read(selectedBroadcastModelProvider.notifier).state = null;
-              final allBoardGames = ref.read(chessBoardAllGamesProvider);
-              final currentEvent = effectiveGameModel.tourId;
-              if (currentEvent.isNotEmpty && allBoardGames.isNotEmpty) {
-                gamesContext =
-                    allBoardGames
-                        .where((g) => g.tourId == currentEvent)
-                        .toList();
-              }
-              gamesContext =
-                  (gamesContext != null && gamesContext.isNotEmpty)
-                      ? gamesContext
-                      : [gamesTourModel];
-              hasEventContext = true;
-            } else {
-              // For tournament view, selectedBroadcastModelProvider will be set
-              // ScoreCardScreen will use gamesTourScreenProvider directly
-              gamesContext = null;
-              hasEventContext = true; // Tournament context
-            }
-            break;
-          case ChessboardView.countryman:
-            // For countrymen view, filter games by the current game's tournament
-            // This ensures ScoreCardScreen shows only games from that specific event
-            ref.read(selectedBroadcastModelProvider.notifier).state = null;
-            final allCountrymanGames =
-                ref
-                    .read(countrymanGamesTourScreenProvider)
-                    .valueOrNull
-                    ?.gamesTourModels ??
-                [];
-            final currentTourIdCountryman = effectiveGameModel.tourId;
-            if (currentTourIdCountryman.isNotEmpty) {
-              gamesContext =
-                  allCountrymanGames
-                      .where((g) => g.tourId == currentTourIdCountryman)
-                      .toList();
-              hasEventContext = true; // Filtered to specific event
-            } else {
-              gamesContext = allCountrymanGames;
-              hasEventContext = false; // No specific event
-            }
-            break;
-          case ChessboardView.forYou:
-            // For "For You" view, use current game's tourId so ScoreCardScreen
-            // can fetch all event games. Don't rely on convertedForYouGamesProvider
-            // since it may not contain the current game (ChessBoardScreenNew receives
-            // resolved full event games from gameCardWrapperProvider).
-            ref.read(selectedBroadcastModelProvider.notifier).state = null;
-            if (effectiveGameModel.tourId.isNotEmpty) {
-              // Pass current game - ScoreCardScreen will fetch all event games via tourId
-              gamesContext = [effectiveGameModel];
-              hasEventContext = true;
-            } else {
-              // No tourId - can't determine event context
-              gamesContext = null;
-              hasEventContext = false;
-            }
-            break;
-        }
+          }
+          break;
+      }
 
-        // Fallback: ensure event context is set when we have a valid tourId
-        // This handles cases where:
-        // - view might not match expected case
-        // - gamesContext filter returned empty (e.g., For You only has few games from event)
-        if ((gamesContext == null || gamesContext.isEmpty) &&
-            effectiveGameModel.tourId.isNotEmpty) {
-          gamesContext = [effectiveGameModel];
-          hasEventContext = true;
-        }
+      // Fallback: ensure event context is set when we have a valid tourId
+      // This handles cases where:
+      // - view might not match expected case
+      // - gamesContext filter returned empty (e.g., For You only has few games from event)
+      if ((gamesContext == null || gamesContext.isEmpty) &&
+          effectiveGameModel.tourId.isNotEmpty) {
+        gamesContext = [effectiveGameModel];
+        hasEventContext = true;
+      }
 
-        // Set the games context and event context flag for ScoreCardScreen
-        ref.read(scoreCardGamesContextProvider.notifier).state = gamesContext;
-        ref.read(scoreCardHasEventContextProvider.notifier).state =
-            hasEventContext;
-        ref.read(scoreCardPlayerProfileDataSourceProvider.notifier).state =
-            playerProfileDataSource;
+      // Set the games context and event context flag for ScoreCardScreen
+      ref.read(scoreCardGamesContextProvider.notifier).state = gamesContext;
+      ref.read(scoreCardHasEventContextProvider.notifier).state =
+          hasEventContext;
+      ref.read(scoreCardPlayerProfileDataSourceProvider.notifier).state =
+          playerProfileDataSource;
 
-        if (!context.mounted) return;
-        Navigator.pushNamed(context, '/scorecard_screen');
-      },
-      child: SizedBox(
-        height: playerView == PlayerView.gridView ? 20.h : null,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            SizedBox(width: boardMargin),
-            // Game result score - centered in eval bar width
+      if (!context.mounted) return;
+      Navigator.pushNamed(context, '/scorecard_screen');
+    }
+
+    return SizedBox(
+      height: playerView == PlayerView.gridView ? 20.h : null,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          SizedBox(width: boardMargin),
+          // Game result score - centered in eval bar width
+          SizedBox(
+            width: engineGaugeWidth,
+            child:
+                effectiveGameModel.gameStatus.isFinished && revealSpoilers
+                    ? Center(
+                      child: Builder(
+                        builder: (context) {
+                          final status = effectiveGameModel.gameStatus;
+                          final isDraw = status == GameStatus.draw;
+                          final isWin =
+                              (status == GameStatus.whiteWins &&
+                                  isWhitePlayer) ||
+                              (status == GameStatus.blackWins &&
+                                  !isWhitePlayer);
+                          final label =
+                              boardResultLabelForSide(
+                                effectiveGameModel,
+                                isWhite: isWhitePlayer,
+                              ) ??
+                              '';
+                          final resultColor =
+                              isWin
+                                  ? kPrimaryColor
+                                  : isDraw
+                                  ? context.colors.textPrimaryMuted
+                                  : context.colors.danger;
+                          final scoreFontSize =
+                              playerView == PlayerView.listView
+                                  ? 12.f
+                                  : playerView == PlayerView.gridView
+                                  ? 13.f
+                                  : 15.f;
+                          return Text(
+                            label,
+                            style: TextStyle(
+                              fontSize: scoreFontSize,
+                              fontWeight: FontWeight.w500,
+                              color: resultColor,
+                              height: 1.0,
+                              letterSpacing: -0.2,
+                            ),
+                            strutStyle: const StrutStyle(
+                              forceStrutHeight: true,
+                              height: 1.0,
+                              leading: 0,
+                            ),
+                            textAlign: TextAlign.center,
+                          );
+                        },
+                      ),
+                    )
+                    : null,
+          ),
+          if (effectiveGameModel.gameStatus.isFinished && revealSpoilers)
             SizedBox(
-              width: engineGaugeWidth,
-              child:
-                  effectiveGameModel.gameStatus.isFinished && revealSpoilers
-                      ? Center(
-                        child: Builder(
-                          builder: (context) {
-                            final status = effectiveGameModel.gameStatus;
-                            final isDraw = status == GameStatus.draw;
-                            final isWin =
-                                (status == GameStatus.whiteWins &&
-                                    isWhitePlayer) ||
-                                (status == GameStatus.blackWins &&
-                                    !isWhitePlayer);
-                            final label =
-                                boardResultLabelForSide(
-                                  effectiveGameModel,
-                                  isWhite: isWhitePlayer,
-                                ) ??
-                                '';
-                            final resultColor =
-                                isWin
-                                    ? kPrimaryColor
-                                    : isDraw
-                                    ? context.colors.textPrimaryMuted
-                                    : context.colors.danger;
-                            final scoreFontSize =
-                                playerView == PlayerView.listView
-                                    ? 12.f
-                                    : playerView == PlayerView.gridView
-                                    ? 13.f
-                                    : 15.f;
-                            return Text(
-                              label,
-                              style: TextStyle(
-                                fontSize: scoreFontSize,
-                                fontWeight: FontWeight.w500,
-                                color: resultColor,
-                                height: 1.0,
-                                letterSpacing: -0.2,
-                              ),
-                              strutStyle: const StrutStyle(
-                                forceStrutHeight: true,
-                                height: 1.0,
-                                leading: 0,
-                              ),
-                              textAlign: TextAlign.center,
-                            );
-                          },
-                        ),
-                      )
-                      : null,
+              width:
+                  playerView == PlayerView.gridView
+                      ? 4.w
+                      : playerView == PlayerView.listView
+                      ? 5.w
+                      : 6.w,
             ),
-            if (effectiveGameModel.gameStatus.isFinished && revealSpoilers)
-              SizedBox(
-                width:
-                    playerView == PlayerView.gridView
-                        ? 4.w
-                        : playerView == PlayerView.listView
-                        ? 5.w
-                        : 6.w,
-              ),
-            if (showFlag) ...[
-              FederationFlag(
-                federation: federationForFlag,
-                height: flagHeight,
-                width: flagWidth,
-                borderRadius: BorderRadius.circular(2.br),
-              ),
-              SizedBox(width: elementSpacing),
-            ],
-            Expanded(
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  // Reserve space for edit icon if present
-                  final editIconSpace = onEditName != null ? 4.w + 14.ic : 0.0;
-                  final availableWidth = constraints.maxWidth - editIconSpace;
+          if (showFlag) ...[
+            FederationFlag(
+              federation: federationForFlag,
+              height: flagHeight,
+              width: flagWidth,
+              borderRadius: BorderRadius.circular(2.br),
+            ),
+            SizedBox(width: elementSpacing),
+          ],
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                // Reserve space for edit icon if present
+                final editIconSpace = onEditName != null ? 4.w + 14.ic : 0.0;
+                final availableWidth = constraints.maxWidth - editIconSpace;
 
-                  // Parse name parts - format is "Surname, Given Names"
-                  final fullName = effectivePlayerCard.name;
-                  final nameParts =
-                      fullName.split(',').map((e) => e.trim()).toList();
-                  final surname =
-                      nameParts.isNotEmpty
-                          ? nameParts[0]
-                          : ''; // Part before comma
-                  final firstName =
-                      nameParts.length > 1
-                          ? nameParts[1]
-                          : ''; // Part after comma
+                // Parse name parts - format is "Surname, Given Names"
+                final fullName = effectivePlayerCard.name;
+                final nameParts =
+                    fullName.split(',').map((e) => e.trim()).toList();
+                final surname =
+                    nameParts.isNotEmpty
+                        ? nameParts[0]
+                        : ''; // Part before comma
+                final firstName =
+                    nameParts.length > 1
+                        ? nameParts[1]
+                        : ''; // Part after comma
 
-                  // Build static parts
-                  final rating =
-                      effectivePlayerCard.rating > 0
-                          ? ' ${effectivePlayerCard.rating}'
-                          : '';
+                // Build static parts
+                final rating =
+                    effectivePlayerCard.rating > 0
+                        ? ' ${effectivePlayerCard.rating}'
+                        : '';
 
-                  // Create text painter to measure text width
-                  final textPainter = TextPainter(
-                    textDirection: TextDirection.ltr,
-                    maxLines: 1,
+                // Create text painter to measure text width
+                final textPainter = TextPainter(
+                  textDirection: TextDirection.ltr,
+                  maxLines: 1,
+                );
+
+                // Smart truncation: ALWAYS prioritize showing full surname
+                // Only abbreviate/truncate other parts, never reduce surname to initials
+                String displaySurname = surname;
+                String displayFirstName =
+                    firstName.isNotEmpty ? ', $firstName' : '';
+
+                if (surname.isNotEmpty) {
+                  // Strategy 1: Try full surname + full first name
+                  textPainter.text = TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '${effectivePlayerCard.title} ',
+                        style: rankStyle,
+                      ),
+                      TextSpan(text: surname, style: nameStyle),
+                      if (firstName.isNotEmpty)
+                        TextSpan(text: ', $firstName', style: nameStyle),
+                      TextSpan(text: rating, style: ratingStyle),
+                    ],
                   );
+                  textPainter.layout();
 
-                  // Smart truncation: ALWAYS prioritize showing full surname
-                  // Only abbreviate/truncate other parts, never reduce surname to initials
-                  String displaySurname = surname;
-                  String displayFirstName =
-                      firstName.isNotEmpty ? ', $firstName' : '';
+                  // If doesn't fit, start trimming (but keep full surname!)
+                  if (textPainter.width > availableWidth &&
+                      firstName.isNotEmpty) {
+                    // Strategy 2: Keep full surname + abbreviate first name
+                    final firstNameParts = firstName.split(' ');
+                    final abbreviatedFirst = firstNameParts
+                        .where((part) => part.isNotEmpty)
+                        .map((part) => '${part[0]}.')
+                        .join(' ');
+                    displayFirstName = ', $abbreviatedFirst';
 
-                  if (surname.isNotEmpty) {
-                    // Strategy 1: Try full surname + full first name
                     textPainter.text = TextSpan(
                       children: [
                         TextSpan(
@@ -783,23 +805,15 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
                           style: rankStyle,
                         ),
                         TextSpan(text: surname, style: nameStyle),
-                        if (firstName.isNotEmpty)
-                          TextSpan(text: ', $firstName', style: nameStyle),
+                        TextSpan(text: displayFirstName, style: nameStyle),
                         TextSpan(text: rating, style: ratingStyle),
                       ],
                     );
                     textPainter.layout();
 
-                    // If doesn't fit, start trimming (but keep full surname!)
-                    if (textPainter.width > availableWidth &&
-                        firstName.isNotEmpty) {
-                      // Strategy 2: Keep full surname + abbreviate first name
-                      final firstNameParts = firstName.split(' ');
-                      final abbreviatedFirst = firstNameParts
-                          .where((part) => part.isNotEmpty)
-                          .map((part) => '${part[0]}.')
-                          .join(' ');
-                      displayFirstName = ', $abbreviatedFirst';
+                    // Strategy 3: If still doesn't fit, drop first name entirely
+                    if (textPainter.width > availableWidth) {
+                      displayFirstName = '';
 
                       textPainter.text = TextSpan(
                         children: [
@@ -808,62 +822,57 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
                             style: rankStyle,
                           ),
                           TextSpan(text: surname, style: nameStyle),
-                          TextSpan(text: displayFirstName, style: nameStyle),
                           TextSpan(text: rating, style: ratingStyle),
                         ],
                       );
                       textPainter.layout();
 
-                      // Strategy 3: If still doesn't fit, drop first name entirely
-                      if (textPainter.width > availableWidth) {
-                        displayFirstName = '';
-
-                        textPainter.text = TextSpan(
-                          children: [
-                            TextSpan(
-                              text: '${effectivePlayerCard.title} ',
-                              style: rankStyle,
-                            ),
-                            TextSpan(text: surname, style: nameStyle),
-                            TextSpan(text: rating, style: ratingStyle),
-                          ],
-                        );
-                        textPainter.layout();
-
-                        // Strategy 4: If STILL doesn't fit, let ellipsis truncate surname
-                        // This is the last resort - RichText will handle the truncation
-                        // We keep displaySurname as the full surname, RichText will add "..."
-                      }
+                      // Strategy 4: If STILL doesn't fit, let ellipsis truncate surname
+                      // This is the last resort - RichText will handle the truncation
+                      // We keep displaySurname as the full surname, RichText will add "..."
                     }
                   }
+                }
 
-                  final nameWidget = RichText(
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
-                    softWrap: false,
-                    textAlign: TextAlign.left,
-                    text: TextSpan(
-                      style: nameStyle, // Add base style for inheritance
-                      children: [
-                        // Always render title (with trailing space) like old code
-                        TextSpan(
-                          text: '${effectivePlayerCard.title} ',
-                          style: rankStyle,
-                        ),
-                        if (displaySurname.isNotEmpty)
-                          TextSpan(text: displaySurname, style: nameStyle),
-                        if (displayFirstName.isNotEmpty)
-                          TextSpan(text: displayFirstName, style: nameStyle),
-                        TextSpan(text: rating, style: ratingStyle),
-                      ],
-                    ),
-                  );
+                final nameWidget = RichText(
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                  softWrap: false,
+                  textAlign: TextAlign.left,
+                  text: TextSpan(
+                    style: nameStyle, // Add base style for inheritance
+                    children: [
+                      // Always render title (with trailing space) like old code
+                      TextSpan(
+                        text: '${effectivePlayerCard.title} ',
+                        style: rankStyle,
+                      ),
+                      if (displaySurname.isNotEmpty)
+                        TextSpan(text: displaySurname, style: nameStyle),
+                      if (displayFirstName.isNotEmpty)
+                        TextSpan(text: displayFirstName, style: nameStyle),
+                      TextSpan(text: rating, style: ratingStyle),
+                    ],
+                  ),
+                );
 
-                  if (onEditName != null) {
-                    return Row(
+                final maxNameTapWidth =
+                    availableWidth < 0 ? 0.0 : availableWidth;
+                final nameTapWidth =
+                    textPainter.width.clamp(0.0, maxNameTapWidth).toDouble();
+                final tappableName = GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: openPlayerScoreCard,
+                  child: SizedBox(width: nameTapWidth, child: nameWidget),
+                );
+
+                if (onEditName != null) {
+                  return Align(
+                    alignment: Alignment.centerLeft,
+                    child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Flexible(child: nameWidget),
+                        Flexible(child: tappableName),
                         SizedBox(width: 4.w),
                         GestureDetector(
                           onTap:
@@ -879,60 +888,63 @@ class PlayerFirstRowDetailWidget extends HookConsumerWidget {
                           ),
                         ),
                       ],
-                    );
-                  }
+                    ),
+                  );
+                }
 
-                  return nameWidget;
-                },
-              ),
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: tappableName,
+                );
+              },
             ),
-            if (isPinned) ...[
-              SvgPicture.asset(
-                SvgAsset.pin,
-                colorFilter: ColorFilter.mode(kpinColor, BlendMode.srcIn),
-                height: playerView == PlayerView.gridView ? 12.h : 12.h,
-                width: playerView == PlayerView.gridView ? 12.w : 12.w,
+          ),
+          if (isPinned) ...[
+            SvgPicture.asset(
+              SvgAsset.pin,
+              colorFilter: ColorFilter.mode(kpinColor, BlendMode.srcIn),
+              height: playerView == PlayerView.gridView ? 12.h : 12.h,
+              width: playerView == PlayerView.gridView ? 12.w : 12.w,
+            ),
+            SizedBox(width: playerView == PlayerView.gridView ? 3.w : 4.w),
+          ],
+          // Always show clock/time on the right - simplified structure to prevent overflow
+          if (showClock && hasClockData)
+            Container(
+              padding: EdgeInsets.symmetric(
+                horizontal: clockPadding,
+                vertical: 1.sp,
               ),
-              SizedBox(width: playerView == PlayerView.gridView ? 3.w : 4.w),
-            ],
-            // Always show clock/time on the right - simplified structure to prevent overflow
-            if (showClock && hasClockData)
-              Container(
-                padding: EdgeInsets.symmetric(
-                  horizontal: clockPadding,
-                  vertical: 1.sp,
+              decoration: BoxDecoration(
+                color:
+                    visibleIsCurrentPlayer
+                        ? kPrimaryColor.withValues(alpha: 0.12)
+                        : Colors.transparent,
+                borderRadius: BorderRadius.circular(
+                  playerView == PlayerView.gridView ? 3.br : 4.br,
                 ),
-                decoration: BoxDecoration(
+                // Border always occupies space (transparent when inactive) so
+                // the row's height never changes as the active player flips
+                // during move navigation — otherwise the board shifts.
+                border: Border.all(
                   color:
                       visibleIsCurrentPlayer
-                          ? kPrimaryColor.withValues(alpha: 0.12)
+                          ? kPrimaryColor.withValues(alpha: 0.4)
                           : Colors.transparent,
-                  borderRadius: BorderRadius.circular(
-                    playerView == PlayerView.gridView ? 3.br : 4.br,
-                  ),
-                  // Border always occupies space (transparent when inactive) so
-                  // the row's height never changes as the active player flips
-                  // during move navigation — otherwise the board shifts.
-                  border: Border.all(
-                    color:
-                        visibleIsCurrentPlayer
-                            ? kPrimaryColor.withValues(alpha: 0.4)
-                            : Colors.transparent,
-                    width: 0.7,
-                  ),
-                ),
-                child: _PlayerClock(
-                  isWhitePlayer: isWhitePlayer,
-                  gamesTourModel: effectiveGameModel,
-                  chessBoardState: chessBoardState,
-                  isCurrentPlayer: visibleIsCurrentPlayer,
-                  timeStyle: timeStyle,
-                  moveTime: moveTime,
+                  width: 0.7,
                 ),
               ),
-            SizedBox(width: endPadding),
-          ],
-        ),
+              child: _PlayerClock(
+                isWhitePlayer: isWhitePlayer,
+                gamesTourModel: effectiveGameModel,
+                chessBoardState: chessBoardState,
+                isCurrentPlayer: visibleIsCurrentPlayer,
+                timeStyle: timeStyle,
+                moveTime: moveTime,
+              ),
+            ),
+          SizedBox(width: endPadding),
+        ],
       ),
     );
   }

--- a/test/player_name_tap_target_test.dart
+++ b/test/player_name_tap_target_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('board player row scorecard tap is limited to rendered player name', () {
+    final source =
+        File(
+          'lib/screens/chessboard/widgets/player_first_row_detail_widget.dart',
+        ).readAsStringSync();
+
+    expect(source, contains('Future<void> openPlayerScoreCard() async'));
+    expect(source, contains('final tappableName = GestureDetector('));
+    expect(source, contains('onTap: openPlayerScoreCard'));
+    expect(
+      source,
+      contains('child: SizedBox(width: nameTapWidth, child: nameWidget)'),
+    );
+    expect(
+      source,
+      contains(
+        'return SizedBox(\n      height: playerView == PlayerView.gridView ? 20.h : null',
+      ),
+    );
+    expect(
+      source,
+      isNot(contains('return GestureDetector(\n      onTap: () async {')),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Limits the chessboard player-row scorecard/profile navigation tap target to the rendered player name text.
- Keeps clock, empty row space, board-adjacent padding, and edit icon behavior from triggering accidental player navigation.
- Adds a focused regression test guarding against restoring the old row-wide tap handler.

## Test Plan
- `git diff --check`
- `dart format --output=none lib/screens/chessboard/widgets/player_first_row_detail_widget.dart test/player_name_tap_target_test.dart`
- `flutter analyze lib/screens/chessboard/widgets/player_first_row_detail_widget.dart test/player_name_tap_target_test.dart`
- `flutter test test/player_name_tap_target_test.dart`

## Notes
- Phone/mobile UX fix for accidental taps around the board player bars.
- Review owner: Berkay/mobile frontend.
