### PR TITLE
fix: hide engine arrows on checkmate boards

### DIFF
--- a/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
+++ b/lib/screens/chessboard/provider/chess_board_screen_provider_new.dart
@@ -16,6 +16,7 @@ import 'package:chessever2/screens/chessboard/analysis/chess_game_navigator_stat
 import 'package:chessever2/screens/chessboard/provider/current_eval_provider.dart';
 import 'package:chessever2/screens/chessboard/provider/game_pgn_stream_provider.dart';
 import 'package:chessever2/screens/chessboard/provider/stockfish_singleton.dart';
+import 'package:chessever2/screens/chessboard/utils/engine_arrow_visibility.dart';
 import 'package:chessever2/screens/chessboard/view_model/chess_board_state_new.dart';
 import 'package:chessever2/screens/chessboard/notation/notation_tree.dart';
 import 'package:chessever2/screens/chessboard/widgets/nag_display.dart';
@@ -6567,9 +6568,19 @@ class ChessBoardScreenNotifierNew
       final Position positionForArrows =
           currentSnapshot.isThreatsMode ? positionForAnalysis : position;
 
+      // Do not paint engine recommendation arrows once the displayed position is
+      // checkmate. A mate board has no legal next move, so best-move/threat
+      // arrows look like actionable engine advice after the game is over.
+      final shouldSuppressEngineArrows = shouldSuppressEngineArrowsForPosition(
+        positionForArrows,
+      );
+
       // CRITICAL: Use multi-variant arrows if variant selected, otherwise use best move
       final ISet<Shape> shapes;
-      if (currentSnapshot.selectedVariantIndex != null && pvLines.isNotEmpty) {
+      if (shouldSuppressEngineArrows) {
+        shapes = const ISet<Shape>.empty();
+      } else if (currentSnapshot.selectedVariantIndex != null &&
+          pvLines.isNotEmpty) {
         shapes = _getAllVariantArrowShapes(
           pvLines,
           currentSnapshot.selectedVariantIndex!,
@@ -6792,6 +6803,10 @@ class ChessBoardScreenNotifierNew
         // (and not inside an analysis variation). Applies to completed games too
         // so PiP shows the exact viewed move instead of jumping to the latest.
         isAtLiveTail: isAtMainlineTail,
+        shapes:
+            shouldSuppressEngineArrowsForPosition(position)
+                ? const ISet<Shape>.empty()
+                : current.shapes,
       );
 
       var progressedState = _setVariantProgress(
@@ -6868,6 +6883,10 @@ class ChessBoardScreenNotifierNew
   }
 
   ISet<Shape> getBestMoveShape(Position pos, CloudEval? cloudEval) {
+    if (shouldSuppressEngineArrowsForPosition(pos)) {
+      return const ISet.empty();
+    }
+
     if (cloudEval?.pvs.isNotEmpty ?? false) {
       final arrowShapes = <Shape>[];
 

--- a/lib/screens/chessboard/utils/engine_arrow_visibility.dart
+++ b/lib/screens/chessboard/utils/engine_arrow_visibility.dart
@@ -1,0 +1,7 @@
+import 'package:dartchess/dartchess.dart';
+
+/// Engine arrows represent playable recommendations, so they should be hidden
+/// once the displayed board position is a final checkmate.
+bool shouldSuppressEngineArrowsForPosition(Position position) {
+  return position.isCheckmate;
+}

--- a/test/engine_arrow_visibility_test.dart
+++ b/test/engine_arrow_visibility_test.dart
@@ -1,0 +1,26 @@
+import 'package:chessever2/screens/chessboard/utils/engine_arrow_visibility.dart';
+import 'package:dartchess/dartchess.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldSuppressEngineArrowsForPosition', () {
+    test('returns true for final checkmate positions', () {
+      const mateFen =
+          'rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3';
+      final matePosition = Chess.fromSetup(Setup.parseFen(mateFen));
+
+      expect(matePosition.isCheckmate, isTrue);
+      expect(shouldSuppressEngineArrowsForPosition(matePosition), isTrue);
+    });
+
+    test('returns false for playable checked positions', () {
+      const checkedFen =
+          'rnb1kbnr/pppp1ppp/8/4p3/7q/5P2/PPPPP1PP/RNBQKBNR w KQkq - 1 3';
+      final checkedPosition = Chess.fromSetup(Setup.parseFen(checkedFen));
+
+      expect(checkedPosition.isCheck, isTrue);
+      expect(checkedPosition.isCheckmate, isFalse);
+      expect(shouldSuppressEngineArrowsForPosition(checkedPosition), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Hide engine/PV recommendation arrows when the displayed board position is checkmate.
- Clear stale arrow overlays when navigator sync lands on a mate position.
- Add a focused visibility helper and regression test covering mate vs playable-check positions.

## Test Plan
- `flutter test --no-pub test/engine_arrow_visibility_test.dart` — passed.
- `flutter analyze --no-fatal-infos lib/screens/chessboard/provider/chess_board_screen_provider_new.dart lib/screens/chessboard/utils/engine_arrow_visibility.dart test/engine_arrow_visibility_test.dart` — passed, no issues found.
- `git diff --check` — passed.

## Queue / overlap note
- Phone queue is heavy: 31 open PRs, 24 dirty/conflicting, 28 with `devberkay` requested.
- This branch is fresh on `origin/dev` (`0 behind / 1 ahead`) and narrow, but it touches `chess_board_screen_provider_new.dart`, which is also touched by older open PRs #241, #240, #221, #220, #219, #218, and #209.
- Please review/merge carefully against current `dev`; this fix is intentionally small and defensive.
