### PR TITLE
Fix stale classical rating on player profiles

### DIFF
--- a/lib/screens/player_profile/provider/player_profile_provider.dart
+++ b/lib/screens/player_profile/provider/player_profile_provider.dart
@@ -12,6 +12,7 @@ import 'package:dio/dio.dart';
 import 'package:chessever2/screens/group_event/model/tour_event_card_model.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/player_profile/player_profile_data_source.dart';
+import 'package:chessever2/screens/player_profile/utils/player_rating_source.dart';
 import 'package:chessever2/screens/player_profile/utils/twic_event_identity.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/utils/chess_title_utils.dart';
@@ -1697,7 +1698,10 @@ final playerProfileDataKeyProvider = FutureProvider.family
                   (supabasePlayer?.country?.trim().isNotEmpty ?? false)
                       ? supabasePlayer!.country
                       : player.fed,
-              classicalRating: player.ratingClassical ?? supabasePlayer?.rating,
+              classicalRating: preferCanonicalFideRating(
+                canonicalRating: supabasePlayer?.rating,
+                gamebaseRating: player.ratingClassical,
+              ),
               rapidRating: player.ratingRapid,
               blitzRating: player.ratingBlitz,
             );

--- a/lib/screens/player_profile/utils/player_rating_source.dart
+++ b/lib/screens/player_profile/utils/player_rating_source.dart
@@ -1,0 +1,8 @@
+/// Prefer the canonical FIDE/Supabase rating over Gamebase metadata.
+///
+/// Gamebase remains the fallback while its staged player row is unavailable or
+/// waiting for the canonical rating synchronization to complete.
+int? preferCanonicalFideRating({
+  required int? canonicalRating,
+  required int? gamebaseRating,
+}) => canonicalRating ?? gamebaseRating;

--- a/test/screens/player_profile/player_rating_source_test.dart
+++ b/test/screens/player_profile/player_rating_source_test.dart
@@ -1,0 +1,20 @@
+import 'package:chessever2/screens/player_profile/utils/player_rating_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('preferCanonicalFideRating', () {
+    test('uses the canonical FIDE rating when Gamebase is stale', () {
+      expect(
+        preferCanonicalFideRating(canonicalRating: 2538, gamebaseRating: 2522),
+        2538,
+      );
+    });
+
+    test('falls back to Gamebase when canonical FIDE data is unavailable', () {
+      expect(
+        preferCanonicalFideRating(canonicalRating: null, gamebaseRating: 2522),
+        2522,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- prefer the canonical FIDE/Supabase classical rating on player profiles
- retain Gamebase as the fallback when canonical player data is unavailable
- add focused regression coverage for stale Gamebase metadata

## Reproduction
For FIDE ID `13402390`, the canonical `chess_players` row is Classical `2538`, while the profile previously displayed stale Gamebase `2522` because the fallback order was reversed.

## Companion backend PR
- Chessever/gamebase#64 updates existing Gamebase player rows during staging imports
- This phone change is defensive and does not depend on a new backend field
- Canonical backend propagation should merge first where practical, but this guard is independently safe

## Validation
- `flutter test test/screens/player_profile/player_rating_source_test.dart`
- `flutter analyze --no-pub lib/screens/player_profile/provider/player_profile_provider.dart lib/screens/player_profile/utils/player_rating_source.dart test/screens/player_profile/player_rating_source_test.dart`
- `git diff --check`

## Risk
Low. Only classical-rating source precedence changes; Gamebase remains the fallback.
