### PR TITLE
fix: prevent Group Event lifecycle crashes

### DIFF
--- a/lib/screens/group_event/group_event_screen.dart
+++ b/lib/screens/group_event/group_event_screen.dart
@@ -47,6 +47,22 @@ final selectedGroupCategoryProvider = StateProvider<GroupEventCategory>(
   (ref) => GroupEventCategory.forYou,
 );
 
+/// Prevents queued group-event work from running after this screen is torn
+/// down. The callback itself only receives objects captured while [ref] and
+/// the enclosing [ProviderScope] are valid.
+@visibleForTesting
+class GroupEventPostFrameActions {
+  bool _isActive = true;
+
+  void schedule(VoidCallback action) {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (_isActive) action();
+    });
+  }
+
+  void dispose() => _isActive = false;
+}
+
 class GroupEventScreen extends HookConsumerWidget {
   const GroupEventScreen({super.key});
 
@@ -55,6 +71,8 @@ class GroupEventScreen extends HookConsumerWidget {
     final searchController = useTextEditingController();
     final searchTabDebounce = useRef<Timer?>(null);
     useEffect(() => () => searchTabDebounce.value?.cancel(), const []);
+    final postFrameActions = useMemoized(GroupEventPostFrameActions.new);
+    useEffect(() => postFrameActions.dispose, [postFrameActions]);
     final selectedTourEvent = ref.watch(selectedGroupCategoryProvider);
     final searchQuery = ref.watch(searchTabQueryProvider);
     final hasActiveSearch = searchQuery.trim().isNotEmpty;
@@ -139,22 +157,34 @@ class GroupEventScreen extends HookConsumerWidget {
       // Only clear when switching between non-search tabs
       if (next == GroupEventCategory.search) return;
 
-      SchedulerBinding.instance.addPostFrameCallback((_) {
+      final searchQueryController =
+          previous == GroupEventCategory.search
+              ? ref.read(searchQueryProvider.notifier)
+              : null;
+      final searchTabQueryController =
+          previous == GroupEventCategory.search
+              ? ref.read(searchTabQueryProvider.notifier)
+              : null;
+      final forYouEventsController =
+          next == GroupEventCategory.forYou
+              ? ref.read(forYouEventsProvider.notifier)
+              : null;
+      final container = ProviderScope.containerOf(context, listen: false);
+
+      postFrameActions.schedule(() {
         if (context.mounted) {
           // Only clear search-related state if we're leaving the search tab
           if (previous == GroupEventCategory.search) {
-            ref.read(searchQueryProvider.notifier).state = '';
-            ref.read(searchTabQueryProvider.notifier).state = '';
+            searchQueryController!.state = '';
+            searchTabQueryController!.state = '';
             searchController.clear();
           }
           if (next == GroupEventCategory.forYou) {
-            unawaited(
-              ref.read(forYouEventsProvider.notifier).refreshForVisibility(),
-            );
+            unawaited(forYouEventsController!.refreshForVisibility());
           }
           FocusScope.of(context).unfocus();
           // ignore: unused_result
-          ref.refresh(groupEventScreenProvider);
+          container.refresh(groupEventScreenProvider);
         }
       });
     });

--- a/lib/screens/group_event/widget/for_you_games_widget.dart
+++ b/lib/screens/group_event/widget/for_you_games_widget.dart
@@ -79,6 +79,7 @@ class ForYouGamesWidget extends ConsumerStatefulWidget {
 
 class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
     with WidgetsBindingObserver, RouteAware, AutomaticKeepAliveClientMixin {
+  late final StateController<bool> _surfaceVisibilityController;
   bool _routeSubscribed = false;
   bool _routeIsCurrent = true;
   bool _appIsResumed = true;
@@ -87,6 +88,9 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
   @override
   void initState() {
     super.initState();
+    _surfaceVisibilityController = ref.read(
+      forYouSurfaceVisibleProvider.notifier,
+    );
     WidgetsBinding.instance.addObserver(this);
     widget.scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -112,7 +116,7 @@ class _ForYouGamesWidgetState extends ConsumerState<ForYouGamesWidget>
   @override
   void dispose() {
     _isDisposing = true;
-    ref.read(forYouSurfaceVisibleProvider.notifier).state = false;
+    _surfaceVisibilityController.state = false;
     widget.scrollController.removeListener(_onScroll);
     if (_routeSubscribed) {
       pageRouteObserver.unsubscribe(this);

--- a/test/group_event_lifecycle_test.dart
+++ b/test/group_event_lifecycle_test.dart
@@ -1,0 +1,69 @@
+import 'package:chessever2/providers/for_you_games_provider.dart';
+import 'package:chessever2/screens/group_event/group_event_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final _triggerProvider = StateProvider<bool>((ref) => false);
+
+class _DeferredRefReader extends ConsumerStatefulWidget {
+  const _DeferredRefReader();
+
+  @override
+  ConsumerState<_DeferredRefReader> createState() => _DeferredRefReaderState();
+}
+
+class _DeferredRefReaderState extends ConsumerState<_DeferredRefReader> {
+  final _actions = GroupEventPostFrameActions();
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(_triggerProvider, (_, __) {
+      _actions.schedule(() => ref.read(_triggerProvider));
+    });
+    return const SizedBox.shrink();
+  }
+
+  @override
+  void dispose() {
+    _actions.dispose();
+    super.dispose();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('pending group event post-frame work is cancelled on teardown', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const _DeferredRefReader(),
+      ),
+    );
+
+    container.read(_triggerProvider.notifier).state = true;
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    expect(tester.takeException(), isNull);
+  });
+
+  test('captured For You visibility controller supports teardown cleanup', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final visibilityController = container.read(
+      forYouSurfaceVisibleProvider.notifier,
+    );
+    visibilityController.state = true;
+
+    // Mirrors ForYouGamesWidget.dispose: cleanup uses the controller captured
+    // while the consumer ref was valid, not a disposed widget ref.
+    visibilityController.state = false;
+
+    expect(container.read(forYouSurfaceVisibleProvider), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- capture the For You visibility controller while the consumer ref is valid, then use it during widget teardown
- cancel deferred Group Event post-frame actions when the screen is disposed
- capture provider controllers/container before scheduling so the callback never reads a disposed widget ref
- add focused regression coverage for ProviderScope/widget removal before a queued frame and dispose-time visibility cleanup

## Production context
P0 lifecycle hotfix for fatal Riverpod teardown clusters in release `com.chessEver.app@28.9.1+2891`:
- CHESSEVER-1QV: disposed `ref` in `ForYouGamesWidget.dispose`
- CHESSEVER-1QW / CHESSEVER-1QX: deferred Group Event callback after ProviderScope teardown

The normal phone review-request pause threshold is exceeded, but this is an explicitly approved production-fatal exception. The branch starts from current `origin/dev`, is lifecycle-only, and no matching or overlapping open PR was found.

## Validation
- `dart format lib/screens/group_event/group_event_screen.dart lib/screens/group_event/widget/for_you_games_widget.dart test/group_event_lifecycle_test.dart`
- `flutter analyze --no-pub lib/screens/group_event/group_event_screen.dart lib/screens/group_event/widget/for_you_games_widget.dart test/group_event_lifecycle_test.dart`
- `flutter test --no-pub test/group_event_lifecycle_test.dart`
- `git diff --check`

All focused checks passed locally.

## Risk
Low and narrowly scoped to teardown/deferred-refresh lifecycle handling. No data, navigation, release, or feed-selection behavior is changed.

## Review
Please verify rapid For You tab changes and route/provider-tree teardown. Do not merge without mobile owner review.
