### PR TITLE
Expand long notation variations by default

### DIFF
--- a/lib/screens/chessboard/notation/notation_token_builder.dart
+++ b/lib/screens/chessboard/notation/notation_token_builder.dart
@@ -136,7 +136,6 @@ bool shouldCollapseByDefault(
   int autoCollapseMoveThreshold = 12,
 }) {
   if (variation.depth >= autoCollapseDepth) return true;
-  if (variation.moves.length >= autoCollapseMoveThreshold) return true;
   return false;
 }
 

--- a/test/notation_token_builder_test.dart
+++ b/test/notation_token_builder_test.dart
@@ -67,6 +67,33 @@ List<NotationDisplayToken> _buildTokens(
 // ---------------------------------------------------------------------------
 
 void main() {
+  group('variation collapse defaults', () {
+    test('keeps long top-level variation lines expanded', () {
+      final move = _treeFromSans(['e4']).mainline.first;
+      final variation = NotationVariationNode(
+        id: 'long-top-level',
+        parentPointer: const [0],
+        variationIndex: 0,
+        depth: 1,
+        moves: List<NotationMoveNode>.filled(34, move),
+      );
+
+      expect(shouldCollapseByDefault(variation), isFalse);
+    });
+
+    test('still collapses deeply nested variation lines', () {
+      final variation = NotationVariationNode(
+        id: 'deep-variation',
+        parentPointer: const [0, 0, 0],
+        variationIndex: 0,
+        depth: 3,
+        moves: const [],
+      );
+
+      expect(shouldCollapseByDefault(variation), isTrue);
+    });
+  });
+
   group('resolveAnnotationPresentation', () {
     test('evaluative types resolve to inlineSymbol', () {
       const evaluativeTypes = [


### PR DESCRIPTION
## Summary
- keep long first- and second-level notation variation lines expanded when a game opens
- retain automatic collapsing for deeply nested variations (depth 3+)
- preserve manual collapse/expand behavior

## Why
Long analysis lines were automatically collapsed solely because they exceeded 12 moves, leaving analysis-heavy games with a `34 moves` placeholder instead of visible notation.

## Validation
- `flutter test --no-pub test/notation_token_builder_test.dart --plain-name 'variation collapse defaults'` — **2 passed**
- `flutter analyze --no-pub lib/screens/chessboard/notation/notation_token_builder.dart test/notation_token_builder_test.dart` — **No issues found**
- `git diff --check` — passed
- Full `test/notation_token_builder_test.dart` still has the same two pre-existing failures on clean `origin/dev` (`evaluative annotation with comment...` and `variation moves do not receive Lichess annotation tokens`); this PR introduces no additional failures.

## Scope / risk
Focused two-file change. No backend, database, release, or production mutation. Deeply nested lines remain auto-collapsed to protect readability; users can still manually collapse any visible line.

## Queue note
Created from current `origin/dev` with `0 behind / 1 ahead`. The live phone queue is saturated (13 open dev PRs; 13 blocked/unknown/unstable by current metadata; 12 already request `devberkay`), but no open PR touches the two files in this PR. This branch is clean and isolated.
