### PR TITLE
fix(pip): background audio + native SFX; Android share image; live-round pin veto

### DIFF
--- a/android/app/src/main/kotlin/com/chessEver/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/chessEver/app/MainActivity.kt
@@ -12,6 +12,8 @@ import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.media.AudioAttributes
+import android.media.SoundPool
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -54,6 +56,12 @@ class MainActivity : FlutterActivity() {
   private var lastReportedPipMode = false
   private var pipLayoutListener: View.OnLayoutChangeListener? = null
   private var lastSoundedMove: String? = null
+  // PiP move SFX are played natively: once the activity is in PiP, Flutter reports
+  // `paused` and AudioPlayerService hibernates the SoLoud engine 300ms later, so
+  // bouncing the request back into Dart never made a sound.
+  private var sfxPool: SoundPool? = null
+  private var moveSfxId = 0
+  private var captureSfxId = 0
 
   override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
     super.configureFlutterEngine(flutterEngine)
@@ -68,6 +76,7 @@ class MainActivity : FlutterActivity() {
           } else {
             pipPayload = args.toMutableMap()
             lastSoundedMove = args["lastMoveUci"] as? String
+            preloadPipSfx()
             pipOverlay?.payload = pipPayload
             pipOverlay?.invalidate()
             if (isCurrentlyInPip()) {
@@ -85,6 +94,7 @@ class MainActivity : FlutterActivity() {
           } else {
             mergePayload(args)
             lastSoundedMove = args["lastMoveUci"] as? String
+            preloadPipSfx()
             pipOverlay?.payload = pipPayload
             pipOverlay?.invalidate()
             if (isCurrentlyInPip()) {
@@ -142,6 +152,8 @@ class MainActivity : FlutterActivity() {
     stopClockTicker()
     stopNativePolling()
     removePipOverlay()
+    sfxPool?.release()
+    sfxPool = null
     pipChannel?.setMethodCallHandler(null)
     super.onDestroy()
   }
@@ -404,7 +416,14 @@ class MainActivity : FlutterActivity() {
     val previousFen = payload["fen"] as? String
 
     if (row.has("fen") && !row.isNull("fen")) {
-      row.optString("fen").takeIf { it.isNotBlank() }?.let { payload["fen"] = it }
+      row.optString("fen").takeIf { it.isNotBlank() }?.let {
+        payload["fen"] = it
+        // The polled row is now the freshest thing we have, so the side-to-move it
+        // carries beats the hint Flutter sent at PiP entry. Leaving that hint in
+        // place would pin the ticking clock to the wrong player for the rest of
+        // the PiP session.
+        payload.remove("clockTurnIsWhite")
+      }
     }
     if (row.has("last_move") && !row.isNull("last_move")) {
       row.optString("last_move").takeIf { it.isNotBlank() }?.let {
@@ -443,16 +462,42 @@ class MainActivity : FlutterActivity() {
         newMove != lastSoundedMove) {
       lastSoundedMove = newMove
       val captured = fenPieceCount(payload["fen"] as? String) < fenPieceCount(previousFen)
-      requestDartSfx(if (captured) "takeover" else "move")
+      playPipSfx(captured)
     }
   }
 
-  private fun requestDartSfx(type: String) {
-    try {
-      pipChannel?.invokeMethod("playSfx", mapOf("type" to type))
+  // Build the pool while still foreground so SoundPool.load (async) has finished
+  // long before the first live move lands in PiP — a sample that is still loading
+  // is dropped silently.
+  private fun preloadPipSfx() {
+    if (sfxPool != null) return
+    val attributes = AudioAttributes.Builder()
+      .setUsage(AudioAttributes.USAGE_GAME)
+      .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+      .build()
+    val pool = SoundPool.Builder().setMaxStreams(2).setAudioAttributes(attributes).build()
+    moveSfxId = loadSfx(pool, "flutter_assets/assets/sfx/piece_move.wav")
+    captureSfxId = loadSfx(pool, "flutter_assets/assets/sfx/piece_takeover.wav")
+    sfxPool = pool
+  }
+
+  private fun loadSfx(pool: SoundPool, path: String): Int {
+    return try {
+      // openFd (not open) because SoundPool needs an offset/length into the APK.
+      // .wav is in aapt2's no-compress list, so the entry is stored uncompressed.
+      assets.openFd(path).use { pool.load(it, 1) }
     } catch (e: Exception) {
-      Log.w("ChessPiP", "Failed to request Dart SFX", e)
+      Log.w("ChessPiP", "Failed to load PiP SFX $path", e)
+      0
     }
+  }
+
+  private fun playPipSfx(captured: Boolean) {
+    val pool = sfxPool ?: return
+    val soundId = if (captured) captureSfxId else moveSfxId
+    if (soundId == 0) return
+    // No audio focus request: a move blip should not duck the user's music.
+    pool.play(soundId, 1f, 1f, 1, 0, 1f)
   }
 
   private fun fenPieceCount(fen: String?): Int {
@@ -669,7 +714,7 @@ private class ChessPipOverlayView(context: Context) : View(context) {
     if (clock.isNotBlank()) {
       val clockRect = RectF(x + width - clockW, y, x + width, y + height)
       Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.rgb(32, 169, 210) }.also {
-        if (isOngoing(data) && isWhiteToMove(data) == isWhite) canvas.drawRect(clockRect, it)
+        if (isOngoing(data) && clockSideIsWhite(data) == isWhite) canvas.drawRect(clockRect, it)
       }
       val cp = Paint(textPaint).apply {
         color = Color.WHITE
@@ -729,7 +774,7 @@ private class ChessPipOverlayView(context: Context) : View(context) {
   private fun displayClock(data: Map<String, Any?>, isWhite: Boolean): String {
     val prefix = if (isWhite) "white" else "black"
     val fallback = data["${prefix}Clock"] as? String ?: ""
-    if (!isOngoing(data) || data["followLive"] == false || isWhiteToMove(data) != isWhite) return fallback
+    if (!isOngoing(data) || data["followLive"] == false || clockSideIsWhite(data) != isWhite) return fallback
 
     val baseSeconds = intValue(data["${prefix}ClockSeconds"]) ?: return fallback
     val lastMoveMillis = instantMillis(data["lastMoveTime"] as? String) ?: return fallback
@@ -740,6 +785,16 @@ private class ChessPipOverlayView(context: Context) : View(context) {
   private fun isOngoing(data: Map<String, Any?>): Boolean {
     val status = (data["status"] as? String ?: "").trim().lowercase()
     return status.isEmpty() || status == "ongoing" || status == "*"
+  }
+
+  // Which side's clock is running. Flutter sends `clockTurnIsWhite` taken from the
+  // same model it builds the clock values from; the board FEN can legitimately sit
+  // a move behind that model, and deriving the ticking side from it would run the
+  // wrong player's clock. Falls back to the FEN once the native poll takes over as
+  // the source of truth (mergeLiveRow drops the key when it lands a fresh FEN).
+  private fun clockSideIsWhite(data: Map<String, Any?>): Boolean {
+    (data["clockTurnIsWhite"] as? Boolean)?.let { return it }
+    return isWhiteToMove(data)
   }
 
   private fun isWhiteToMove(data: Map<String, Any?>): Boolean {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -358,7 +358,7 @@ SPEC CHECKSUMS:
   firebase_core: 995454a784ff288be5689b796deb9e9fa3601818
   FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
   FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
-  Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   flutter_screenshot_detect: 1617896225a428f4aef698050c8900460566e1ff
   flutter_soloud: d9969a9777b511239e85da6e108e05b429207baf

--- a/ios/Runner/ChessPipController.swift
+++ b/ios/Runner/ChessPipController.swift
@@ -26,9 +26,18 @@ final class ChessPipController: NSObject {
   private var moveSoundPlayer: AVAudioPlayer?
   private var captureSoundPlayer: AVAudioPlayer?
   private var lastSoundedMove: String?
+  // Whether our last `setActive(true)` actually succeeded. `AVAudioSession.category`
+  // only reflects the last `setCategory`, so it cannot be used to detect a session
+  // that is category .playback but deactivated — that state plays no audio.
+  private var isSessionActive = false
+  // True once a PiP-eligible board is on its way to (or already in) PiP. While set,
+  // the session must be non-mixable: iOS refuses background playback for a mixable
+  // session that holds no playback assertion.
+  private var wantsExclusivePlayback = false
 
   private override init() {
     super.init()
+    observeAudioSessionAndLifecycle()
   }
 
   func configure(binaryMessenger: FlutterBinaryMessenger) {
@@ -104,12 +113,18 @@ final class ChessPipController: NSObject {
   private func prepareIfNeeded() {
     guard #available(iOS 15.0, *) else { return }
     guard AVPictureInPictureController.isPictureInPictureSupported() else { return }
-    if pipController != nil { return }
 
-    // Audio session must be active and use a category that supports PiP
-    // BEFORE the controller is created and while we are still foreground.
+    // Audio session must be active and use a category that supports PiP BEFORE the
+    // controller is created and while we are still foreground. This deliberately
+    // sits ABOVE the `pipController != nil` early return: the controller is created
+    // once and never torn down, but `clear()` hands the session back to .ambient on
+    // every resume — so the 2nd and later PiP entries would otherwise background
+    // with a category PiP cannot start from. Same for the sound players: a single
+    // failed load must not be permanent.
     configureAudioSession()
     preloadSounds()
+
+    if pipController != nil { return }
 
     let layer = AVSampleBufferDisplayLayer()
     layer.videoGravity = .resizeAspect
@@ -176,7 +191,7 @@ final class ChessPipController: NSObject {
 
   private func enterIfEligible() -> Bool {
     guard payload?["eligible"] as? Bool == true else { return false }
-    configureAudioSession()
+    armExclusivePlayback()
     prepareIfNeeded()
     enqueueFrame()
     startRenderLoop()
@@ -212,40 +227,151 @@ final class ChessPipController: NSObject {
   }
 
   private func configureAudioSession() {
+    activateAudioSession(exclusive: wantsExclusivePlayback)
+  }
+
+  /// Put the shared session into .playback and activate it.
+  ///
+  /// `exclusive` decides whether we keep `.mixWithOthers`. This is the crux of
+  /// background PiP audio: a mixable .playback session lands in CoreMedia's
+  /// "mixable playback" privilege class, and a backgrounded app that is only awake
+  /// because PiP is on screen holds no assertion for that class. iOS then denies
+  /// playback outright (`CMSUtility_IsAllowedToStartPlaying: ... does not have
+  /// assertions to start mixable playback`, surfaced as
+  /// AVAudioSession.ErrorCode.cannotStartPlaying) — `AVAudioPlayer.play()` just
+  /// returns false and nothing is heard. So while PiP is armed we must take a
+  /// non-mixable session, which interrupts whatever else is playing; the rest of
+  /// the time we stay mixable so browsing a board never stops the user's music.
+  private func activateAudioSession(exclusive: Bool) {
+    let session = AVAudioSession.sharedInstance()
+    let options: AVAudioSession.CategoryOptions = exclusive ? [] : [.mixWithOthers]
     do {
-      let session = AVAudioSession.sharedInstance()
-      try session.setCategory(.playback, mode: .moviePlayback, options: [.mixWithOthers])
+      if session.category != .playback || session.categoryOptions != options {
+        try session.setCategory(.playback, mode: .moviePlayback, options: options)
+      }
       try session.setActive(true)
+      isSessionActive = true
     } catch {
-      print("[PiP] Failed to configure audio session: \(error)")
+      isSessionActive = false
+      print("[PiP] Failed to activate audio session (exclusive=\(exclusive)): \(error)")
     }
   }
 
-  // Re-assert .playback if something (e.g. flutter_soloud lazily initializing on
-  // the first move sound) reset the category to .ambient. PiP requires .playback
-  // to be the active category at the moment the app backgrounds.
+  /// Re-assert the session PiP needs. Called every render tick while PiP is
+  /// visible, so a denied activation (contended route, an interruption that ended
+  /// while we were backgrounded) self-heals on the next tick instead of leaving
+  /// PiP permanently silent.
   private func ensurePlaybackAudioSession() {
     let session = AVAudioSession.sharedInstance()
-    guard session.category != .playback else { return }
-    do {
-      try session.setCategory(.playback, mode: .moviePlayback, options: [.mixWithOthers])
-      try session.setActive(true)
-    } catch {
-      print("[PiP] Failed to re-assert playback audio session: \(error)")
-    }
+    let categoryWrong =
+      session.category != .playback || session.categoryOptions.contains(.mixWithOthers)
+    guard categoryWrong || !isSessionActive else { return }
+    activateAudioSession(exclusive: true)
   }
 
   private func restoreAmbientAudioSession() {
     // Runs on resume (via clear()) when no game is PiP-eligible. setCategory can
     // block when the route is contended right after foregrounding, so hand the
     // session back OFF the main thread to keep the resume frame responsive.
-    DispatchQueue.global(qos: .userInitiated).async {
+    handBackSession(to: .ambient, mode: .default)
+  }
+
+  /// PiP is about to take over (app resigning active with a game armed, or AVKit
+  /// telling us PiP is starting). Grab the non-mixable session while we still have
+  /// the foreground assertion that makes the request succeed — asking for it after
+  /// the app has backgrounded is the request iOS denies.
+  private func armExclusivePlayback() {
+    guard payload?["eligible"] as? Bool == true else { return }
+    wantsExclusivePlayback = true
+    activateAudioSession(exclusive: true)
+  }
+
+  /// No PiP in play: give the user's audio back. A board is still open, so stay on
+  /// .playback (that is the category PiP must start from) but go mixable again.
+  private func relinquishExclusivePlayback() {
+    guard wantsExclusivePlayback else { return }
+    handBackSession(to: .playback, mode: .moviePlayback)
+  }
+
+  /// Drop exclusivity and settle on `category`. The `setActive(false,
+  /// .notifyOthersOnDeactivation)` is the important part: without it the music or
+  /// podcast we interrupted to take the exclusive session never resumes, and the
+  /// user is left in silence after PiP closes.
+  private func handBackSession(
+    to category: AVAudioSession.Category,
+    mode: AVAudioSession.Mode
+  ) {
+    let wasExclusive = wantsExclusivePlayback
+    wantsExclusivePlayback = false
+    isSessionActive = false
+    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+      let session = AVAudioSession.sharedInstance()
       do {
-        try AVAudioSession.sharedInstance().setCategory(.ambient, mode: .default, options: [.mixWithOthers])
+        if wasExclusive {
+          try session.setActive(false, options: [.notifyOthersOnDeactivation])
+        }
+        try session.setCategory(category, mode: mode, options: [.mixWithOthers])
+        try session.setActive(true)
+        DispatchQueue.main.async { self?.isSessionActive = true }
       } catch {
-        print("[PiP] Failed to restore ambient audio session: \(error)")
+        print("[PiP] Failed to hand back audio session (\(category.rawValue)): \(error)")
       }
     }
+  }
+
+  private func observeAudioSessionAndLifecycle() {
+    let center = NotificationCenter.default
+    // An interruption (call, alarm, Siri, another app taking the route) deactivates
+    // our session but leaves the category untouched, so nothing else would notice.
+    center.addObserver(
+      self,
+      selector: #selector(handleAudioSessionInterruption(_:)),
+      name: AVAudioSession.interruptionNotification,
+      object: nil
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleAppWillResignActive),
+      name: UIApplication.willResignActiveNotification,
+      object: nil
+    )
+    center.addObserver(
+      self,
+      selector: #selector(handleAppDidBecomeActive),
+      name: UIApplication.didBecomeActiveNotification,
+      object: nil
+    )
+  }
+
+  @objc private func handleAudioSessionInterruption(_ notification: Notification) {
+    guard
+      let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+      let type = AVAudioSession.InterruptionType(rawValue: raw)
+    else { return }
+    switch type {
+    case .began:
+      isSessionActive = false
+    case .ended:
+      guard wantsExclusivePlayback else { return }
+      activateAudioSession(exclusive: true)
+    @unknown default:
+      break
+    }
+  }
+
+  @objc private func handleAppWillResignActive() {
+    // Last moment we are still foreground. If a PiP-eligible board is armed, take
+    // the exclusive session now — requesting it after the app has backgrounded is
+    // exactly the request iOS denies.
+    armExclusivePlayback()
+  }
+
+  @objc private func handleAppDidBecomeActive() {
+    // Came back without PiP ever starting (notification centre, control centre, a
+    // banner). Give the user's audio back rather than sitting on an exclusive
+    // session we never used.
+    guard pipController?.isPictureInPictureActive != true else { return }
+    relinquishExclusivePlayback()
   }
 
   private func preloadSounds() {
@@ -294,6 +420,9 @@ final class ChessPipController: NSObject {
     newFen: String?
   ) {
     guard pipController?.isPictureInPictureActive == true else { return }
+    // Dart owns the user's sound preference; honour it here too, otherwise a user
+    // who muted the board still gets move SFX out of the PiP window.
+    guard (payload?["soundEnabled"] as? Bool) != false else { return }
     guard
       let newMove,
       !newMove.isEmpty,
@@ -303,9 +432,22 @@ final class ChessPipController: NSObject {
     lastSoundedMove = newMove
 
     let captured = Self.pieceCount(newFen) < Self.pieceCount(previousFen)
-    let player = (captured ? captureSoundPlayer : moveSoundPlayer) ?? moveSoundPlayer
-    player?.currentTime = 0
-    player?.play()
+    guard let player = (captured ? captureSoundPlayer : moveSoundPlayer) ?? moveSoundPlayer
+    else {
+      // Load failed on first prepare; prepareIfNeeded() retries it from now on.
+      print("[PiP] move SFX skipped: no player loaded")
+      return
+    }
+    player.currentTime = 0
+    guard !player.play() else { return }
+    // play() returning false in the background almost always means the session lost
+    // its playback assertion. Re-take it and retry once.
+    print("[PiP] move SFX denied — re-activating session and retrying")
+    activateAudioSession(exclusive: true)
+    player.currentTime = 0
+    if !player.play() {
+      print("[PiP] move SFX retry failed (category=\(AVAudioSession.sharedInstance().category.rawValue), options=\(AVAudioSession.sharedInstance().categoryOptions.rawValue))")
+    }
   }
 
   private static func pieceCount(_ fen: String?) -> Int {
@@ -556,6 +698,11 @@ final class ChessPipController: NSObject {
 
     if let fen = row["fen"] as? String, !fen.isEmpty {
       payload["fen"] = fen
+      // The polled row is now the freshest thing we have, so the side-to-move it
+      // carries beats the hint Flutter sent at PiP entry. Leaving that hint in
+      // place would pin the ticking clock to the wrong player for the rest of the
+      // PiP session.
+      payload.removeValue(forKey: "clockTurnIsWhite")
     }
     if let lastMove = row["last_move"] as? String, !lastMove.isEmpty {
       payload["lastMoveUci"] = lastMove
@@ -600,6 +747,13 @@ final class ChessPipController: NSObject {
 }
 
 extension ChessPipController: AVPictureInPictureControllerDelegate {
+  func pictureInPictureControllerWillStartPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    // Backstop for the willResignActive path (PiP can also be started manually).
+    armExclusivePlayback()
+  }
+
   func pictureInPictureControllerDidStartPictureInPicture(
     _ pictureInPictureController: AVPictureInPictureController
   ) {
@@ -612,7 +766,20 @@ extension ChessPipController: AVPictureInPictureControllerDelegate {
     _ pictureInPictureController: AVPictureInPictureController
   ) {
     stopNativePolling()
-    stopRenderLoop()
+    if payload == nil {
+      stopRenderLoop()
+    } else {
+      // Do NOT stop the render loop while a game is still armed.
+      // `isPictureInPicturePossible` is false whenever the sample-buffer layer is
+      // idle, so tearing the loop down here is what made the SECOND PiP entry fail:
+      // Flutter's payload signature is unchanged after a short PiP session, so no
+      // `setActiveGame` arrives to restart it, and the layer stays dark forever.
+      // The foreground tick only re-enqueues a cached frame, so keeping it is cheap.
+      startRenderLoop()
+    }
+    // PiP is gone, so the exclusive session has no reason to keep the user's music
+    // interrupted. `clear()` may follow on resume and take it further to .ambient.
+    relinquishExclusivePlayback()
     channel?.invokeMethod("onPipModeChanged", arguments: ["isInPip": false])
   }
 
@@ -777,7 +944,7 @@ private enum ChessPipRenderer {
     let clockW = clock.isEmpty ? 0 : rect.height * 1.9
     if !clock.isEmpty {
       let clockRect = CGRect(x: rect.maxX - clockW, y: rect.minY, width: clockW, height: rect.height)
-      if isOngoing(payload: payload) && isWhiteToMove(payload: payload) == isWhite {
+      if isOngoing(payload: payload) && clockSideIsWhite(payload: payload) == isWhite {
         UIColor(red: 0.13, green: 0.66, blue: 0.82, alpha: 1).setFill()
         UIRectFill(clockRect)
       }
@@ -800,7 +967,7 @@ private enum ChessPipRenderer {
     guard
       isOngoing(payload: payload),
       (payload["followLive"] as? Bool) != false,
-      isWhiteToMove(payload: payload) == isWhite,
+      clockSideIsWhite(payload: payload) == isWhite,
       let baseSeconds = intValue(payload["\(prefix)ClockSeconds"]),
       let lastMoveTime = dateValue(payload["lastMoveTime"] as? String)
     else {
@@ -814,6 +981,16 @@ private enum ChessPipRenderer {
   private static func isOngoing(payload: [String: Any]) -> Bool {
     let status = (payload["status"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     return status.isEmpty || status == "ongoing" || status == "*"
+  }
+
+  /// Which side's clock is running. Flutter sends `clockTurnIsWhite` taken from the
+  /// same model it builds the clock values from; the board FEN can legitimately sit
+  /// a move behind that model, and deriving the ticking side from it would run the
+  /// wrong player's clock. Falls back to the FEN once the native poll takes over as
+  /// the source of truth (`mergeLiveRow` drops the key when it lands a fresh FEN).
+  private static func clockSideIsWhite(payload: [String: Any]) -> Bool {
+    if let explicit = payload["clockTurnIsWhite"] as? Bool { return explicit }
+    return isWhiteToMove(payload: payload)
   }
 
   private static func isWhiteToMove(payload: [String: Any]) -> Bool {

--- a/lib/providers/pip_mode_provider.dart
+++ b/lib/providers/pip_mode_provider.dart
@@ -21,3 +21,10 @@ extension PipModeInfo on PipMode {
     return PipMode.values[index];
   }
 }
+
+// A PiP board-size setting used to live here. It was removed: neither platform
+// lets an app choose the PiP window's size (iOS derives it from the aspect
+// ratio in SpringBoard, Android's PictureInPictureParams has no size setter),
+// and users already pinch-resize the window themselves. The unused
+// `user_engine_settings.pip_board_size` column is left in place — it is
+// NOT NULL DEFAULT 1, so writes that omit it are fine.

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -61,6 +61,7 @@ import 'package:chessever2/utils/logger/logger.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/string_utils.dart';
 import 'package:chessever2/utils/user_error_message.dart';
+import 'package:chessever2/screens/tour_detail/games_tour/widgets/game_card_wrapper/live_game_card_provider.dart';
 import 'package:chessground/chessground.dart';
 import 'package:collection/collection.dart';
 import 'package:dartchess/dartchess.dart';
@@ -1554,7 +1555,13 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     if (!mounted) return;
     if (_isRouteCovered) return;
     _scheduleAndroidPipBoardRecovery();
-    unawaited(_syncCurrentPipState());
+    // Force: leaving PiP tears down the native polling and re-arms the audio
+    // session, and the payload signature is usually IDENTICAL to the one we sent
+    // on the way in (the foreground signature ignores clock/eval churn, and a
+    // short PiP session often ends with no new move). Without force this
+    // short-circuits, no `setActiveGame` reaches native, and the next PiP attempt
+    // finds a stale native side — which is why PiP would not start a second time.
+    unawaited(_syncCurrentPipState(force: true));
   }
 
   void _scheduleAndroidPipBoardRecovery() {
@@ -1582,7 +1589,7 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     notifier.state = notifier.state + 1;
   }
 
-  Future<void> _syncCurrentPipState() async {
+  Future<void> _syncCurrentPipState({bool force = false}) async {
     if (!mounted || widget.games.isEmpty) return;
     if (_isRouteCovered) return;
     final safeIndex = _currentPageIndex.clamp(0, widget.games.length - 1);
@@ -1593,10 +1600,13 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       await _syncPipGameSnapshot(game);
       return;
     }
-    await _syncPipState(state);
+    await _syncPipState(state, force: force);
   }
 
-  Future<void> _syncPipState(ChessBoardStateNew state) async {
+  Future<void> _syncPipState(
+    ChessBoardStateNew state, {
+    bool force = false,
+  }) async {
     if (_isRouteCovered) return;
     if (!_isPipEligible(state.game)) {
       // PiP off / ineligible: clear the native side ONCE, then no-op on every
@@ -1618,7 +1628,11 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     // position/game/settings changes and immediately before entering PiP.
     final isInPip = PipService.instance.isInPip;
     final sig = _pipPayloadSignature(payload, isInPip: isInPip);
-    if (sig == _lastPipSig) return;
+    // `force` is used on the way into PiP: the foreground signature deliberately
+    // ignores clock/eval churn, so without it the native side would hand PiP a
+    // clock+eval snapshot from whenever a *whitelisted* field last changed and
+    // then visibly snap to the truth on the first background poll.
+    if (!force && sig == _lastPipSig) return;
     _lastPipSig = sig;
     if (isInPip) {
       await PipService.instance.updatePosition(payload);
@@ -1637,6 +1651,11 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       payload['eligible'],
       payload['followLive'],
       payload['gameId'],
+      payload['isBoardFlipped'],
+      // The shared clock model can advance a move before the board's own state
+      // does, so this flips independently of `fen` — it has to be its own trigger
+      // or the native side keeps ticking the previous player's clock.
+      payload['clockTurnIsWhite'],
       payload['fen'],
       payload['lastMoveUci'],
       payload['lastMove'],
@@ -1705,6 +1724,7 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     // of where the user scrolled. `isAtLiveTail` is the reliable signal (set in
     // _syncAnalysisFromNavigator from the navigator's mainline-tail check).
     final followLive = state?.isAtLiveTail ?? true;
+    final clockGame = _pipClockGame(game);
     final eventName =
         game.tourSlug != null && game.tourSlug!.isNotEmpty
             ? StringUtils.slugToTitle(game.tourSlug!)
@@ -1718,14 +1738,25 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       'eligible': true,
       'followLive': followLive,
       'gameId': game.gameId,
+      // PiP renders the board itself, so it needs the same orientation the user
+      // is looking at — otherwise flipping in-app makes the floating board
+      // appear to jump to the mirrored position.
+      'isBoardFlipped':
+          state?.isBoardFlipped ?? ref.read(activeBoardFlippedProvider),
       'fen': fen,
       'lastMoveUci': lastMoveUci,
       'lastMove': game.lastMove ?? '',
       'lastMoveSan': lastMoveSan,
       'soundEnabled': boardSettings?.soundEnabled == true,
       'status': game.gameStatus.name,
-      if (game.lastMoveTime != null)
-        'lastMoveTime': game.lastMoveTime!.toUtc().toIso8601String(),
+      if (clockGame.lastMoveTime != null)
+        'lastMoveTime': clockGame.lastMoveTime!.toUtc().toIso8601String(),
+      // Which side's clock is ticking, taken from the same model the clocks come
+      // from. Native would otherwise derive it from the payload FEN, which is the
+      // *board's* position — and the board can legitimately sit a move behind the
+      // clock model, which would tick the wrong player's clock in PiP.
+      if (clockGame.activePlayer != null)
+        'clockTurnIsWhite': clockGame.activePlayer == Side.white,
       if (evaluation != null) 'evalCp': (evaluation * 100).round(),
       if (state?.mate != null) 'mate': state!.mate,
       'whiteName': game.whitePlayer.name,
@@ -1742,25 +1773,49 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
           game.blackPlayer.countryCode.isNotEmpty
               ? game.blackPlayer.countryCode
               : game.blackPlayer.federation,
-      if (game.whiteClockSeconds != null)
-        'whiteClockSeconds': game.whiteClockSeconds,
-      if (game.blackClockSeconds != null)
-        'blackClockSeconds': game.blackClockSeconds,
+      if (clockGame.whiteClockSeconds != null)
+        'whiteClockSeconds': clockGame.whiteClockSeconds,
+      if (clockGame.blackClockSeconds != null)
+        'blackClockSeconds': clockGame.blackClockSeconds,
       'whiteClock': _formatPipClock(
-        game.whiteClockSeconds,
-        game.whiteClockCentiseconds,
-        game.whiteTimeDisplay,
+        clockGame.whiteClockSeconds,
+        clockGame.whiteClockCentiseconds,
+        clockGame.whiteTimeDisplay,
       ),
       'blackClock': _formatPipClock(
-        game.blackClockSeconds,
-        game.blackClockCentiseconds,
-        game.blackTimeDisplay,
+        clockGame.blackClockSeconds,
+        clockGame.blackClockCentiseconds,
+        clockGame.blackTimeDisplay,
       ),
       if (eventName != null) 'eventName': eventName,
       if (roundName != null) 'roundName': roundName,
       'boardThemeIndex': boardSettings?.boardThemeIndex ?? 9,
       'pieceStyleIndex': boardSettings?.pieceStyleIndex ?? 0,
     };
+  }
+
+  /// The game model the PiP clocks must be built from.
+  ///
+  /// The on-screen clock does NOT render from `state.game` — it renders from
+  /// `baseGameProvider(gameId)` (via `watchLiveGameClock`), which is fed by this
+  /// screen's game stream AND by the still-mounted list cards' batched realtime
+  /// stream. `state.game` only ever sees the first of those, so it can trail by a
+  /// move. Handing PiP that trailing model gave it a stale clock base *and* a
+  /// stale `lastMoveTime` anchor, so PiP over-counted elapsed time and opened
+  /// showing less time than the board did — then snapped up when the native poll
+  /// (which fires immediately on PiP start) replaced it with the truth. That snap
+  /// is the "clocks changed the moment I entered PiP" bug.
+  ///
+  /// Only prefer the shared model when it is genuinely fresher, so a stale or
+  /// half-populated entry can never drag the clocks backwards.
+  GamesTourModel _pipClockGame(GamesTourModel game) {
+    final shared = ref.read(baseGameProvider(game.gameId));
+    if (shared == null) return game;
+    final sharedTime = shared.lastMoveTime;
+    final gameTime = game.lastMoveTime;
+    if (sharedTime == null) return game;
+    if (gameTime == null) return shared;
+    return sharedTime.isBefore(gameTime) ? game : shared;
   }
 
   String _formatPipClock(int? seconds, int centiseconds, String fallback) {
@@ -1880,10 +1935,14 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
       debugPrint('Error refreshing Stockfish on resume: $e');
     }
 
+    // Force for the same reason as the PiP-exit path: coming back from background
+    // (with or without PiP) must re-arm the native side, and the signature is
+    // frequently unchanged so a non-forced sync would send nothing at all.
     unawaited(
       _syncPipState(
         ref.read(chessBoardScreenProviderNew(params)).valueOrNull ??
             ChessBoardStateNew(game: currentGame),
+        force: true,
       ),
     );
   }
@@ -1908,7 +1967,9 @@ class _ChessBoardScreenState extends ConsumerState<ChessBoardScreenNew>
     final params = _createParams(currentGame, safeIndex);
     final state = ref.read(chessBoardScreenProviderNew(params)).valueOrNull;
     if (state != null) {
-      await _syncPipState(state);
+      // Force: PiP is about to take over rendering, so it needs the live clock,
+      // eval and orientation as they are right now, not the last signature hit.
+      await _syncPipState(state, force: true);
     } else {
       await _syncPipGameSnapshot(currentGame);
     }

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -20,6 +20,7 @@ import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/pgn_clock_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/utils/share_card.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
 import 'package:chessever2/widgets/federation_flag.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -374,15 +375,12 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
         },
       ),
     );
-    // Android: X (Twitter) drops EXTRA_STREAM when EXTRA_TEXT is present, so
-    // the shared image never reaches its composer. Omit the text there — the
-    // overlay's link bar still exposes the URL for copying.
-    final shareText =
-        (!kIsWeb && io.Platform.isAndroid) ? null : _effectiveShareUrl;
-    return Share.shareXFiles(
+    // Text is dropped on Android inside the helper (X eats EXTRA_STREAM when
+    // EXTRA_TEXT is set); the overlay's link bar still exposes the URL.
+    return shareFilesWithText(
       files,
       subject: _shareSubject,
-      text: shareText,
+      text: _effectiveShareUrl,
       sharePositionOrigin: const Rect.fromLTWH(0, 0, 1, 1),
     );
   }

--- a/lib/screens/player_profile/player_profile_screen.dart
+++ b/lib/screens/player_profile/player_profile_screen.dart
@@ -553,7 +553,7 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
         context,
         imageBytes: imageBytes,
         onShareImage: () async {
-          await Share.shareXFiles(
+          await shareFilesWithText(
             [XFile(file.path, mimeType: 'image/png')],
             text: shareUrl,
             subject: effectiveName,

--- a/lib/screens/standings/score_card_screen.dart
+++ b/lib/screens/standings/score_card_screen.dart
@@ -1329,7 +1329,7 @@ class _ScoreCardPage extends ConsumerWidget {
         context,
         imageBytes: imageBytes,
         onShareImage: () async {
-          await Share.shareXFiles(
+          await shareFilesWithText(
             [XFile(file.path, mimeType: 'image/png')],
             text: playerShareUrl,
             subject: subject,

--- a/lib/screens/tour_detail/games_tour/providers/round_ordering.dart
+++ b/lib/screens/tour_detail/games_tour/providers/round_ordering.dart
@@ -187,6 +187,16 @@ GamesAppBarModel? pickUpcomingRoundForPromotion(
       isRoundFullyPlayed?.call(model) ??
       model.roundStatus == RoundStatus.completed;
 
+  // A live round always owns the top slot. Check this before (and independently
+  // of) the fully-played gate below, which is not a reliable live signal: a
+  // blitz round can have every currently loaded game report `isFinished`
+  // between pairings, and a live round with no games loaded yet is filtered out
+  // of `startedRounds` by `include` entirely. Both would otherwise let an
+  // upcoming round bubble above a round that is still being played.
+  if (models.any((model) => model.roundStatus == RoundStatus.live)) {
+    return null;
+  }
+
   final startedRounds = models.where(
     (model) =>
         include(model) && _isStartedRound(model, effectiveNow, resolveDate),

--- a/lib/screens/tour_detail/team_tour/team_score_card_screen.dart
+++ b/lib/screens/tour_detail/team_tour/team_score_card_screen.dart
@@ -467,7 +467,7 @@ Future<void> _shareTeamScorecard({
       context,
       imageBytes: imageBytes,
       onShareImage: () async {
-        await Share.shareXFiles(
+        await shareFilesWithText(
           [XFile(file.path, mimeType: 'image/png')],
           text: shareUrl,
           subject: subject,

--- a/lib/screens/tour_detail/widgets/tournament_menu_button.dart
+++ b/lib/screens/tour_detail/widgets/tournament_menu_button.dart
@@ -593,7 +593,7 @@ class TournamentMenuButton extends ConsumerWidget {
         context,
         imageBytes: imageBytes,
         onShareImage: () async {
-          await Share.shareXFiles(
+          await shareFilesWithText(
             [XFile(file.path, mimeType: 'image/png')],
             text: shareUrl,
             subject: subject,
@@ -676,7 +676,7 @@ class TournamentMenuButton extends ConsumerWidget {
         context,
         imageBytes: imageBytes,
         onShareImage: () async {
-          await Share.shareXFiles(
+          await shareFilesWithText(
             [XFile(file.path, mimeType: 'image/png')],
             text: shareUrl,
             subject: subject,
@@ -774,7 +774,7 @@ class TournamentMenuButton extends ConsumerWidget {
         context,
         imageBytes: imageBytes,
         onShareImage: () async {
-          await Share.shareXFiles(
+          await shareFilesWithText(
             [XFile(file.path, mimeType: 'image/png')],
             text: shareUrl,
             subject: subject,

--- a/lib/utils/share_card.dart
+++ b/lib/utils/share_card.dart
@@ -1,11 +1,13 @@
-import 'dart:typed_data';
+import 'dart:io' as io;
 import 'dart:ui' as ui;
 
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:share_plus/share_plus.dart';
 
 /// Renders [child] to PNG bytes by briefly mounting it off-screen in a real
 /// [Overlay] wrapped in a [RepaintBoundary], pumping a few frames so async
@@ -109,6 +111,31 @@ Future<Uint8List?> captureBoundaryPng(
   } finally {
     image.dispose();
   }
+}
+
+/// Shares [files] through the native sheet, dropping [text] on Android.
+///
+/// X (Twitter) on Android ignores `EXTRA_STREAM` whenever `EXTRA_TEXT` is also
+/// set, so an image-plus-URL share arrives in its composer as text only and the
+/// card is silently lost. Every share here pairs the image with a "Share Link"
+/// action (and the board overlay's link bar), so the URL stays reachable
+/// without riding along on the file share. iOS and web keep the text — they
+/// attach both correctly.
+///
+/// Use this instead of calling [Share.shareXFiles] with a `text:` directly.
+Future<void> shareFilesWithText(
+  List<XFile> files, {
+  String? text,
+  String? subject,
+  Rect? sharePositionOrigin,
+}) {
+  final isAndroid = !kIsWeb && io.Platform.isAndroid;
+  return Share.shareXFiles(
+    files,
+    text: isAndroid ? null : text,
+    subject: subject,
+    sharePositionOrigin: sharePositionOrigin,
+  );
 }
 
 /// Shows the captured share image in a preview bottom sheet with up to two

--- a/lib/utils/share_standings.dart
+++ b/lib/utils/share_standings.dart
@@ -90,7 +90,7 @@ Future<void> shareTournamentStandings(
       context,
       imageBytes: imageBytes,
       onShareImage: () async {
-        await Share.shareXFiles(
+        await shareFilesWithText(
           [XFile(file.path, mimeType: 'image/png')],
           text: shareUrl,
           subject: subject,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -824,10 +824,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -944,10 +944,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -960,10 +960,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1709,10 +1709,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   type_plus:
     dependency: transitive
     description:
@@ -1845,10 +1845,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "1d774bbdf6b72a0b12122fc1560c9c2d2a67db5a4a4cc2bd8a5c990ab20e3188"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.2.0"
   version:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 32.7.0+3222
+version: 32.7.5+3227
 
 environment:
   sdk: ^3.7.2

--- a/test/tour_detail_round_ordering_test.dart
+++ b/test/tour_detail_round_ordering_test.dart
@@ -196,6 +196,85 @@ void main() {
       },
     );
 
+    test(
+      'does not promote over a live round whose loaded boards all report finished',
+      () {
+        // 59th Biel International Masters, blitz category: round 5 was live
+        // while every board we had loaded for it already reported a result, so
+        // the fully-played gate opened and round 6 bubbled above the live round.
+        final now = DateTime(2026, 3, 30, 16);
+        final rounds = [
+          _round(
+            id: 'r4',
+            name: 'Round 4',
+            startsAt: now.subtract(const Duration(hours: 3)),
+            status: RoundStatus.completed,
+          ),
+          _round(
+            id: 'r5',
+            name: 'Round 5',
+            startsAt: now.subtract(const Duration(minutes: 25)),
+            status: RoundStatus.live,
+          ),
+          _round(
+            id: 'r6',
+            name: 'Round 6',
+            startsAt: now.add(const Duration(minutes: 35)),
+            status: RoundStatus.upcoming,
+          ),
+          _round(
+            id: 'r7',
+            name: 'Round 7',
+            startsAt: now.add(const Duration(minutes: 95)),
+            status: RoundStatus.upcoming,
+          ),
+        ];
+
+        final sorted = sortRoundsForDisplay(
+          rounds,
+          resolveDate: (round) => round.startsAt,
+          isRoundFullyPlayed: (_) => true,
+          now: now,
+        );
+
+        expect(_ids(sorted), ['r5', 'r4', 'r6', 'r7']);
+      },
+    );
+
+    test('does not promote over a live round that has no games loaded yet', () {
+      final now = DateTime(2026, 3, 30, 16);
+      final rounds = [
+        _round(
+          id: 'r4',
+          name: 'Round 4',
+          startsAt: now.subtract(const Duration(hours: 3)),
+          status: RoundStatus.completed,
+        ),
+        _round(
+          id: 'r5',
+          name: 'Round 5',
+          startsAt: now.subtract(const Duration(minutes: 5)),
+          status: RoundStatus.live,
+        ),
+        _round(
+          id: 'r6',
+          name: 'Round 6',
+          startsAt: now.add(const Duration(minutes: 35)),
+          status: RoundStatus.upcoming,
+        ),
+      ];
+
+      final sorted = sortRoundsForDisplay(
+        rounds,
+        resolveDate: (round) => round.startsAt,
+        hasGames: (round) => round.id != 'r5',
+        isRoundFullyPlayed: (round) => round.id == 'r4',
+        now: now,
+      );
+
+      expect(_ids(sorted), ['r5', 'r4', 'r6']);
+    });
+
     test('promotes the next round at exactly two hours', () {
       final now = DateTime(2026, 3, 30, 16);
       final rounds = [


### PR DESCRIPTION
## Summary

Small bugfix branch rebased cleanly onto `5d529738` (`fix(share): drop Android share text…`, version `32.7.0`). It deliberately does **not** include later `stable` features (miniatures library, explorer sum-row/focus, team-event heuristics, for-you countdown, standings played-count).

Previously this PR was opened off the tip of `stable` (`58d4d05b`) by mistake and pulled those features into the branch history. The branch was rewritten from scratch so the PR only carries the intended fixes.

### 1. iOS PiP background audio
- Non-mixable `.playback` `AVAudioSession` while PiP is active (mixable playback is refused once the app is backgrounded).
- Re-entry path restores / re-activates the correct category so audio keeps working when returning to PiP.

### 2. Android PiP move SFX
- Flutter audio is silenced under Android PiP; move sounds now play via a native `SoundPool` in `MainActivity`.
- Stale clock-hint guard so a late SFX does not fire after the move moment has passed.

### 3. Android share image on X (extension of `5d529738`)
- Base commit already fixed the board share overlay.
- This PR extends the same rule (omit `EXTRA_TEXT` on Android file shares) to the remaining call sites: `share_card`, `share_standings`, scorecards, profile, tournament menu.

### 4. Live-round pin veto (Biel blitz)
Round display strategy (unchanged intent, fixed gate) in `round_ordering.dart`:

1. **Promoted slot** — at most one upcoming round pinned top-most.
2. **Started rounds** — live / ongoing / completed, descending by start time.
3. **Future rounds** — ascending at the bottom.

Promotion (`pickUpcomingRoundForPromotion`) now requires:

- **No** `RoundStatus.live` round present (explicit veto — this was the hole).
- Every started round fully played.
- Candidate is the earliest upcoming round starting in `[now, now + 2h]`.

Without the live veto, a blitz round that is still `live` but whose loaded boards all report finished (or a live round with zero games loaded yet) would let the next future round pin above it. Two regression tests cover both holes.

## Out of scope / deliberately not here
- PiP window **size** setting — not implementable (iOS SpringBoard sizes from aspect ratio only; Android `PictureInPictureParams` has no size API). Users pinch-resize; both platforms persist that.
- Miniatures / explorer / teams / for-you / standings changes that landed on `stable` after `5d529738`.

## Test plan
- [ ] Build `32.7.5+3227` from this branch.
- [ ] Enter PiP on a live game — background audio continues (iOS).
- [ ] Android PiP — move SFX audible.
- [ ] Android share to X from board / standings / profile — image attaches (not text-only).
- [ ] Multi-round blitz mid-round: live round stays top-most; next future round does **not** pin above it while live.
- [ ] After live ends, next round `<2h` away: exactly one future round may pin top; remaining futures stay ascending at bottom.
- [ ] `flutter test test/tour_detail_round_ordering_test.dart` → 32/32.

## Validation (this rewrite)
- `flutter analyze` on touched Dart paths: clean.
- `tour_detail_round_ordering_test.dart`: 32/32 pass.
- Ancestry: parent of tip is `5d529738`; miniatures (`55c53736`) and explorer (`58d4d05b`) commits are **not** on this branch.