### PR TITLE
fix: keep phone scorecard ratings aligned

### DIFF
--- a/lib/screens/standings/widget/scoreboard_card_widget.dart
+++ b/lib/screens/standings/widget/scoreboard_card_widget.dart
@@ -74,7 +74,9 @@ class ScoreboardCardWidget extends ConsumerWidget {
           children: [
             Text(
               '${index + 1}.',
-              style: AppTypography.textMdBold.copyWith(color: context.colors.textPrimary),
+              style: AppTypography.textMdBold.copyWith(
+                color: context.colors.textPrimary,
+              ),
             ),
             SizedBox(width: 10.w),
             if (countryCode.trim().isNotEmpty) ...[
@@ -123,17 +125,21 @@ class ScoreboardCardWidget extends ConsumerWidget {
                     color: context.colors.textPrimary,
                   ),
                 ),
-                if (scoreChange != null && scoreChange != 0.0) ...[
-                  SizedBox(width: 4.w),
-                  Text(
-                    scoreChange! > 0
-                        ? '+${scoreChange!.toStringAsFixed(0)}'
-                        : scoreChange!.toStringAsFixed(0),
-                    style: AppTypography.textXsMedium.copyWith(
-                      color: scoreChange! > 0 ? kGreenColor : kRedColor,
-                    ),
-                  ),
-                ],
+                SizedBox(width: 4.w),
+                SizedBox(
+                  width: 30.w,
+                  child:
+                      scoreChange != null && scoreChange != 0.0
+                          ? Text(
+                            scoreChange! > 0
+                                ? '+${scoreChange!.toStringAsFixed(0)}'
+                                : scoreChange!.toStringAsFixed(0),
+                            style: AppTypography.textXsMedium.copyWith(
+                              color: scoreChange! > 0 ? kGreenColor : kRedColor,
+                            ),
+                          )
+                          : null,
+                ),
               ],
             ),
             SizedBox(width: 14.w),
@@ -148,7 +154,9 @@ class ScoreboardCardWidget extends ConsumerWidget {
                       isWhite!
                           ? null
                           : Border.all(
-                            color: context.colors.textPrimary.withValues(alpha: 0.35),
+                            color: context.colors.textPrimary.withValues(
+                              alpha: 0.35,
+                            ),
                             width: 1.1,
                           ),
                 ),
@@ -168,7 +176,9 @@ class ScoreboardCardWidget extends ConsumerWidget {
               Text(
                 matchScore!,
                 textAlign: TextAlign.start,
-                style: AppTypography.textMdBold.copyWith(color: context.colors.textPrimary),
+                style: AppTypography.textMdBold.copyWith(
+                  color: context.colors.textPrimary,
+                ),
               ),
           ],
         ),

--- a/test/scoreboard_card_rating_alignment_test.dart
+++ b/test/scoreboard_card_rating_alignment_test.dart
@@ -1,0 +1,64 @@
+import 'package:chessever2/screens/standings/widget/scoreboard_card_widget.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  testWidgets('keeps opponent ratings aligned when rating change is absent', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(320, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) {
+              ResponsiveHelper.init(context);
+              return Scaffold(
+                body: Column(
+                  children: [
+                    ScoreboardCardWidget(
+                      countryCode: '',
+                      name: 'Player With Change',
+                      score: 2500,
+                      scoreChange: -5,
+                      matchScore: '0',
+                      isWhite: true,
+                      index: 0,
+                      isFirst: true,
+                      isLast: false,
+                      onTap: () {},
+                    ),
+                    ScoreboardCardWidget(
+                      countryCode: '',
+                      name: 'Player Without Change',
+                      score: 2500,
+                      matchScore: '1',
+                      isWhite: false,
+                      index: 1,
+                      isFirst: false,
+                      isLast: true,
+                      onTap: () {},
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final ratingFinder = find.text('2500');
+    expect(ratingFinder, findsNWidgets(2));
+
+    final ratings = tester.widgetList<Text>(ratingFinder).toList();
+    final withChangeX = tester.getTopLeft(find.byWidget(ratings[0])).dx;
+    final withoutChangeX = tester.getTopLeft(find.byWidget(ratings[1])).dx;
+
+    expect(withoutChangeX, withChangeX);
+  });
+}


### PR DESCRIPTION
## Summary
- keep opponent ratings in a stable horizontal position when per-game rating change is unavailable
- reserve the existing rating-change area instead of letting each row shrink independently
- preserve rating-change colors and result-circle alignment

## Validation
- regression test reproduced the 26.5px shift before the fix and passes after it
- focused scorecard/rating tests: 22 passed
- focused Flutter analysis: no issues
- touched-file formatter check and `git diff --check`: passed
- actual 390px Flutter visual preview verified with positive, negative, and missing changes

## Scope
Phone scorecard row presentation only. No rating calculation, backend, data, website, or release behavior changes.
