### PR TITLE
fix(phone): keep explorer board fixed during game pull-up

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -6771,6 +6771,52 @@ class _CollapsingExplorerPvSlot extends StatelessWidget {
   }
 }
 
+/// Pins the complete phone board while the lower analysis surface scrolls and
+/// expands. Pulling inline games up can cover engine chrome, never the board.
+class CompactBoardPinnedAnalysisLayout extends StatelessWidget {
+  const CompactBoardPinnedAnalysisLayout({
+    super.key,
+    required this.boardChildren,
+    required this.analysis,
+    required this.expandedOverChrome,
+    this.collapsingChrome,
+  });
+
+  final List<Widget> boardChildren;
+  final Widget? collapsingChrome;
+  final Widget analysis;
+  final bool expandedOverChrome;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        KeyedSubtree(
+          key: const ValueKey('compact_board_fixed'),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: boardChildren,
+          ),
+        ),
+        if (collapsingChrome != null) collapsingChrome!,
+        AnimatedContainer(
+          duration: _kExplorerGamesExpandDuration,
+          curve: _kExplorerGamesExpandCurve,
+          height: expandedOverChrome ? 0 : 12.h,
+        ),
+        Expanded(
+          child: KeyedSubtree(
+            key: const ValueKey('compact_analysis_panel'),
+            child: analysis,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _AnalysisGameBody extends ConsumerWidget {
   final int index;
   final int currentPageIndex;
@@ -6872,7 +6918,7 @@ class _AnalysisGameBody extends ConsumerWidget {
           };
         }
 
-        final headerChildren = <Widget>[
+        final boardHeaderChildren = <Widget>[
           _PlayerWidget(
             game: game,
             isFlipped: state.isBoardFlipped,
@@ -6905,6 +6951,9 @@ class _AnalysisGameBody extends ConsumerWidget {
                     ? editNameCallback(!state.isBoardFlipped)
                     : null,
           ),
+        ];
+        final headerChildren = <Widget>[
+          ...boardHeaderChildren,
           ...pvSection,
         ];
 
@@ -7007,29 +7056,13 @@ class _AnalysisGameBody extends ConsumerWidget {
         }
 
         if (useCompactLayout) {
-          // When games expand over PV, give the panel most of the viewport
-          // so cards stay readable under a still-visible bottom nav.
-          // Height eases with the PV collapse so the panel doesn't jump.
-          final movesPanelHeight =
-              expandGamesOverPv
-                  ? math.max(320.h, availableHeight * 0.72)
-                  : math.max(220.h, availableHeight * 0.55);
-          return SingleChildScrollView(
-            padding: EdgeInsets.only(bottom: 12.h),
-            physics: const ClampingScrollPhysics(),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                ...headerChildren,
-                SizedBox(height: 12.h),
-                AnimatedContainer(
-                  duration: _kExplorerGamesExpandDuration,
-                  curve: _kExplorerGamesExpandCurve,
-                  height: movesPanelHeight,
-                  child: buildAnalysisView(),
-                ),
-              ],
-            ),
+          // Keep the full board fixed. Explorer/notation owns vertical scroll;
+          // pinned games expand into PV and stop below the lower player row.
+          return CompactBoardPinnedAnalysisLayout(
+            boardChildren: boardHeaderChildren,
+            collapsingChrome: collapsingPv,
+            expandedOverChrome: expandGamesOverPv,
+            analysis: buildAnalysisView(),
           );
         }
 

--- a/lib/screens/gamebase/widgets/explorer_game_card.dart
+++ b/lib/screens/gamebase/widgets/explorer_game_card.dart
@@ -1,3 +1,4 @@
+import 'package:chessever2/providers/board_settings_provider_new.dart';
 import 'package:chessever2/repository/gamebase/gamebase_repository.dart';
 import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/chessboard/widgets/chess_board_from_fen_new.dart';
@@ -10,6 +11,7 @@ import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_mode
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/audio_player_service.dart';
 import 'package:chessever2/utils/broadcast_custom_scoring.dart';
 import 'package:chessever2/utils/chess_title_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -159,17 +161,6 @@ class _ExplorerGamesSectionState extends ConsumerState<ExplorerGamesSection> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Padding(
-          padding: EdgeInsets.fromLTRB(12.sp, 10.sp, 12.sp, 6.sp),
-          child: Text(
-            'Games',
-            style: TextStyle(
-              color: context.colors.textSecondary,
-              fontSize: 11.f,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ),
         gamesAsync.when(
           loading: () => const _ExplorerGamesStatusRow.loading(),
           error: (_, __) => const _ExplorerGamesStatusRow(
@@ -314,6 +305,28 @@ String resolveExplorerCardOpenInitialFen({
   return anchorFen;
 }
 
+/// SAN to sonify when a focused explorer card changes its displayed ply.
+/// Forward/jump plays the reached move; backward plays the move being undone.
+@visibleForTesting
+String? resolveExplorerFocusSoundSan(
+  ExplorerGameFocus? previous,
+  ExplorerGameFocus? next,
+) {
+  if (next == null) return null;
+  final sameGame = previous?.gameId == next.gameId;
+  if (sameGame && previous!.ply == next.ply) return null;
+
+  final soundPly =
+      sameGame && next.ply < previous!.ply ? previous.ply : next.ply;
+  if (soundPly < 0 || soundPly >= next.sans.length) return null;
+  return next.sans[soundPly];
+}
+
+/// Human-readable event for the center slot. `tourId` may be an opaque UUID.
+@visibleForTesting
+String explorerGameEventLabel(GamesTourModel game) =>
+    sanitizeGamebaseEventLabel(game.tourSlug);
+
 /// One game remaining in the explored position: mini board on the left, player
 /// metadata on the right, and the game's continuation from this position as a
 /// horizontally scrollable SAN chip strip at the bottom.
@@ -334,6 +347,7 @@ class ExplorerGameCard extends ConsumerStatefulWidget {
     required this.line,
     required this.allGames,
     required this.index,
+    this.playMoveSound,
   });
 
   final GamesTourModel game;
@@ -341,6 +355,9 @@ class ExplorerGameCard extends ConsumerStatefulWidget {
   final ContinuationLine line;
   final List<GamesTourModel> allGames;
   final int index;
+
+  /// Test seam for the native audio plugin. Production uses AudioPlayerService.
+  final ValueChanged<String>? playMoveSound;
 
   @override
   ConsumerState<ExplorerGameCard> createState() => _ExplorerGameCardState();
@@ -459,21 +476,7 @@ class _ExplorerGameCardState extends ConsumerState<ExplorerGameCard> {
     });
   }
 
-  String _formatDate(DateTime? date) {
-    if (date == null) return '';
-    return '${date.day.toString().padLeft(2, '0')}/'
-        '${date.month.toString().padLeft(2, '0')}/${date.year}';
-  }
-
-  /// Concise meta only: ECO code · date (no event / opening name).
-  String get _metaLine {
-    final parts = <String>[
-      if ((widget.game.eco ?? '').trim().isNotEmpty) widget.game.eco!.trim(),
-      if (_formatDate(widget.game.lastMoveTime).isNotEmpty)
-        _formatDate(widget.game.lastMoveTime),
-    ];
-    return parts.join(' · ');
-  }
+  String get _eventLine => explorerGameEventLabel(widget.game);
 
   Move? _uciToMove(String? uci) {
     final raw = (uci ?? '').trim().toLowerCase();
@@ -489,6 +492,24 @@ class _ExplorerGameCardState extends ConsumerState<ExplorerGameCard> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<ExplorerGameFocus?>(explorerFocusedGameProvider, (
+      previous,
+      next,
+    ) {
+      if (next?.gameId != widget.game.gameId) return;
+      final san = resolveExplorerFocusSoundSan(previous, next);
+      if (san == null) return;
+      final soundEnabled =
+          ref.read(boardSettingsProviderNew).valueOrNull?.soundEnabled == true;
+      if (!soundEnabled) return;
+      final playMoveSound = widget.playMoveSound;
+      if (playMoveSound != null) {
+        playMoveSound(san);
+      } else {
+        AudioPlayerService.instance.playSfxForSan(san);
+      }
+    });
+
     final focus = ref.watch(
       explorerFocusedGameProvider.select(
         (f) => (f != null && f.gameId == widget.game.gameId) ? f : null,
@@ -642,10 +663,10 @@ class _ExplorerGameCardState extends ConsumerState<ExplorerGameCard> {
                                     padding: EdgeInsets.symmetric(
                                       horizontal: 2.w,
                                     ),
-                                    child: _metaLine.isEmpty
+                                    child: _eventLine.isEmpty
                                         ? const SizedBox.shrink()
                                         : _FadingOverflowText(
-                                          text: _metaLine,
+                                          text: _eventLine,
                                           textAlign: TextAlign.center,
                                           style: AppTypography.textXsRegular
                                               .copyWith(color: metaColor),

--- a/lib/screens/gamebase/widgets/move_statistics_panel.dart
+++ b/lib/screens/gamebase/widgets/move_statistics_panel.dart
@@ -378,8 +378,9 @@ class MoveStatisticsPanel extends HookConsumerWidget {
       sort.value = ExplorerMoveSort.cycle(sort.value, field);
     }
 
-    // Sticky header crossfade: Move columns ↔ Games columns when the inline
-    // games section scrolls up under the header.
+    // Collapse the move-column header once inline game cards reach the top.
+    // The cards are self-explanatory; keeping another "Games" row wastes the
+    // exact vertical space this quick-check mode is meant to recover.
     final scrollController = useScrollController();
     final gamesSectionKey = useMemoized(
       () => GlobalKey(debugLabel: 'explorer_inline_games_section'),
@@ -571,13 +572,17 @@ class MoveStatisticsPanel extends HookConsumerWidget {
         SizedBox(width: _kColumnGap.sp),
         SizedBox(
           width: _kGamesColumnWidth.w,
-          child: _SortHeader(
-            label: 'Games',
-            field: ExplorerMoveSortField.games,
-            align: TextAlign.right,
-            sort: sort.value,
-            onSort: cycleSort,
-            color: kPrimaryColor,
+          child: Semantics(
+            label: 'Sort by games',
+            button: true,
+            child: _SortHeader(
+              label: '',
+              field: ExplorerMoveSortField.games,
+              align: TextAlign.right,
+              sort: sort.value,
+              onSort: cycleSort,
+              color: kPrimaryColor,
+            ),
           ),
         ),
         SizedBox(width: _kColumnGap.sp),
@@ -594,19 +599,6 @@ class MoveStatisticsPanel extends HookConsumerWidget {
       ],
     );
 
-    // Sticky label when the inline game cards section is under the header.
-    final gamesHeader = Align(
-      key: const ValueKey<String>('explorer_header_games'),
-      alignment: Alignment.centerLeft,
-      child: Text(
-        'Games',
-        style: TextStyle(
-          color: context.colors.textSecondary,
-          fontSize: 11.f,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
 
     final Widget mainContent = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -617,31 +609,26 @@ class MoveStatisticsPanel extends HookConsumerWidget {
             color: context.colors.textPrimary,
             backgroundColor: Colors.transparent,
           ),
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: 12.sp, vertical: 6.sp),
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 180),
-            switchInCurve: Curves.easeOut,
-            switchOutCurve: Curves.easeIn,
-            layoutBuilder: (currentChild, previousChildren) {
-              return Stack(
-                alignment: Alignment.centerLeft,
-                children: <Widget>[
-                  ...previousChildren,
-                  if (currentChild != null) currentChild,
-                ],
-              );
-            },
-            transitionBuilder: (child, animation) {
-              return FadeTransition(
-                opacity: animation,
-                child: child,
-              );
-            },
-            child: headerInGames.value ? gamesHeader : movesHeader,
-          ),
+        AnimatedSize(
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+          alignment: Alignment.topCenter,
+          child:
+              headerInGames.value
+                  ? const SizedBox.shrink()
+                  : Column(
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 12.sp,
+                          vertical: 6.sp,
+                        ),
+                        child: movesHeader,
+                      ),
+                      Divider(color: context.colors.divider, height: 1),
+                    ],
+                  ),
         ),
-        Divider(color: context.colors.divider, height: 1),
         // Move list
         Expanded(
           child: Builder(

--- a/lib/screens/gamebase/widgets/position_games_sheet.dart
+++ b/lib/screens/gamebase/widgets/position_games_sheet.dart
@@ -495,6 +495,30 @@ class _PositionGamesSheetState extends ConsumerState<PositionGamesSheet> {
 
 /// Maps a gamebase `GameSearchPreview` row into the app's [GamesTourModel].
 /// Shared by [PositionGamesSheet] and the explorer's inline games section.
+String sanitizeGamebaseEventLabel(Object? raw) {
+  final normalized =
+      (raw?.toString() ?? '').trim().replaceAll(RegExp(r'\s+'), ' ');
+  if (normalized.isEmpty) return '';
+
+  // Event APIs can return internal IDs in the same fields as display names.
+  // Never surface UUIDs, hash-like IDs, long numeric IDs, or private URLs.
+  final isOpaqueId =
+      RegExp(
+        r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$',
+      ).hasMatch(normalized) ||
+      RegExp(r'^[0-9a-fA-F]{24}$|^[0-9a-fA-F]{32}$').hasMatch(normalized) ||
+      RegExp(r'^\d{8,}$').hasMatch(normalized);
+  final lower = normalized.toLowerCase();
+  final isUrlLike =
+      lower.contains('://') ||
+      lower.startsWith('urn:') ||
+      lower.startsWith('www.') ||
+      RegExp(
+        r'^[a-z0-9.-]+\.[a-z]{2,}(?::\d+)?(?:[/?#]|$)',
+      ).hasMatch(lower);
+  return isOpaqueId || isUrlLike ? '' : normalized;
+}
+
 GamesTourModel mapGamebasePreviewToTourModel(Map<String, dynamic> row) {
   int parseInt(dynamic value) {
       if (value is int) return value;
@@ -523,7 +547,17 @@ GamesTourModel mapGamebasePreviewToTourModel(Map<String, dynamic> row) {
     final eco = row['eco']?.toString() ?? '';
     final opening = row['opening']?.toString() ?? '';
     final variation = row['variation']?.toString() ?? '';
-    final event = (row['event']?.toString() ?? '').trim();
+    final event = [
+      row['event_name'],
+      row['eventName'],
+      row['tournament_name'],
+      row['tournamentName'],
+      row['tour_name'],
+      row['tourName'],
+      row['event'],
+    ]
+        .map(sanitizeGamebaseEventLabel)
+        .firstWhere((value) => value.isNotEmpty, orElse: () => '');
     final tourId =
         (row['tour_id']?.toString() ??
                 row['tournament_id']?.toString() ??
@@ -600,7 +634,9 @@ GamesTourModel mapGamebasePreviewToTourModel(Map<String, dynamic> row) {
       roundId: 'opening_explorer',
       roundSlug: formatCode.isNotEmpty ? formatCode : null,
       tourId: tourId.isNotEmpty ? tourId : 'Gamebase',
-      tourSlug: null,
+      // Keep the display event separate from tourId, which is commonly an
+      // opaque Gamebase tournament UUID.
+      tourSlug: event.isNotEmpty ? event : null,
       fen: fen.isNotEmpty ? fen : null,
       lastMove: lastMove.isNotEmpty ? lastMove : null,
       lastMoveTime: date,

--- a/test/explorer_compact_game_rows_test.dart
+++ b/test/explorer_compact_game_rows_test.dart
@@ -15,7 +15,9 @@ import 'package:chessever2/screens/gamebase/providers/gamebase_explorer_state.da
 import 'package:chessever2/screens/gamebase/utils/continuation_line.dart';
 import 'package:chessever2/screens/chessboard/widgets/chess_board_bottom_nav_bar.dart';
 import 'package:chessever2/screens/chessboard/widgets/chess_board_from_fen_new.dart';
+import 'package:chessever2/screens/chessboard/chess_board_screen_new.dart';
 import 'package:chessever2/screens/gamebase/widgets/explorer_game_card.dart';
+import 'package:chessever2/screens/gamebase/widgets/position_games_sheet.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -42,6 +44,7 @@ GamesTourModel _game({
   String id = 'g1',
   String white = 'Magnus Carlsen',
   String black = 'Hikaru Nakamura',
+  String? eventName,
 }) {
   return GamesTourModel(
     gameId: id,
@@ -55,6 +58,7 @@ GamesTourModel _game({
     gameStatus: GameStatus.whiteWins,
     roundId: 'opening_explorer',
     tourId: 'Gamebase',
+    tourSlug: eventName,
     eco: 'C45',
     lastMoveTime: DateTime(2024, 5, 12),
   );
@@ -158,6 +162,7 @@ Future<void> _pumpCard(
                       line: line,
                       allGames: [game],
                       index: 0,
+                      playMoveSound: (_) {},
                     ),
                   ),
                 ),
@@ -204,7 +209,142 @@ Future<void> _pumpSection(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  testWidgets(
+    'compact pull-up keeps the board fixed while reclaiming PV space',
+    (tester) async {
+      Future<void> pump({required bool expanded}) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                ResponsiveHelper.init(context);
+                return Scaffold(
+                  body: SizedBox(
+                    width: 400,
+                    height: 700,
+                    child: CompactBoardPinnedAnalysisLayout(
+                      boardChildren: const [
+                        SizedBox(key: ValueKey('board_probe'), height: 420),
+                      ],
+                      collapsingChrome:
+                          expanded
+                              ? const SizedBox.shrink()
+                              : const SizedBox(height: 80),
+                      expandedOverChrome: expanded,
+                      analysis: const ColoredBox(
+                        key: ValueKey('analysis_probe'),
+                        color: Colors.blue,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      await pump(expanded: false);
+      final boardBefore = tester.getRect(
+        find.byKey(const ValueKey('board_probe')),
+      );
+      final analysisBefore = tester.getTopLeft(
+        find.byKey(const ValueKey('analysis_probe')),
+      );
+
+      await pump(expanded: true);
+      final boardAfter = tester.getRect(
+        find.byKey(const ValueKey('board_probe')),
+      );
+      final analysisAfter = tester.getTopLeft(
+        find.byKey(const ValueKey('analysis_probe')),
+      );
+
+      expect(boardAfter, boardBefore);
+      expect(analysisAfter.dy, lessThan(analysisBefore.dy));
+      expect(analysisAfter.dy, boardAfter.bottom);
+    },
+  );
+
+  test('focused-card sound follows forward, jump, and backward SAN', () {
+    ExplorerGameFocus focus(int ply) => ExplorerGameFocus(
+      gameId: 'g1',
+      anchorFen: _anchorFen,
+      sans: const ['e4', 'e5', 'Nf3'],
+      fens: const ['a', 'b', 'c', 'd'],
+      ply: ply,
+    );
+
+    expect(resolveExplorerFocusSoundSan(null, focus(0)), 'e4');
+    expect(resolveExplorerFocusSoundSan(focus(0), focus(2)), 'Nf3');
+    expect(resolveExplorerFocusSoundSan(focus(2), focus(1)), 'Nf3');
+    expect(resolveExplorerFocusSoundSan(focus(1), focus(1)), isNull);
+    expect(resolveExplorerFocusSoundSan(focus(0), null), isNull);
+  });
+
   group('ExplorerGameCard (original card)', () {
+    testWidgets('uses the center gap for the event instead of ECO and date', (
+      tester,
+    ) async {
+      final game = _game(eventName: 'Biel International Chess Festival');
+      await _pumpCard(tester, game: game, line: _lineFromUcis(const []));
+
+      expect(find.text('Biel International Chess Festival'), findsOneWidget);
+      expect(find.textContaining('C45'), findsNothing);
+      expect(find.textContaining('12/05/2024'), findsNothing);
+    });
+
+    test('never exposes UUID-like or URL event identifiers', () {
+      expect(
+        explorerGameEventLabel(
+          _game(eventName: '123e4567-e89b-12d3-a456-426614174000'),
+        ),
+        isEmpty,
+      );
+      expect(
+        explorerGameEventLabel(
+          _game(eventName: 'https://internal.example/events/private'),
+        ),
+        isEmpty,
+      );
+      expect(
+        explorerGameEventLabel(
+          _game(eventName: 'internal.example/events/private'),
+        ),
+        isEmpty,
+      );
+      expect(
+        explorerGameEventLabel(
+          _game(eventName: 'internal.example?token=private'),
+        ),
+        isEmpty,
+      );
+      expect(
+        explorerGameEventLabel(_game(eventName: 'U.S. Open')),
+        'U.S. Open',
+      );
+    });
+
+    test('preview mapping prefers a human event name and rejects raw IDs', () {
+      final human = mapGamebasePreviewToTourModel({
+        'id': 'g1',
+        'white': 'A',
+        'black': 'B',
+        'event_name': 'Brazilian Championship 2026',
+        'event': '123e4567-e89b-12d3-a456-426614174000',
+      });
+      expect(human.tourSlug, 'Brazilian Championship 2026');
+
+      final opaqueOnly = mapGamebasePreviewToTourModel({
+        'id': 'g2',
+        'white': 'A',
+        'black': 'B',
+        'event': '123e4567-e89b-12d3-a456-426614174000',
+      });
+      expect(opaqueOnly.tourSlug, isNull);
+    });
+
     testWidgets('shows mini board, players, scores, and SAN chips', (
       tester,
     ) async {
@@ -385,6 +525,66 @@ void main() {
   });
 
   group('ExplorerGamesSection', () {
+    testWidgets('starts directly with cards without a Games heading', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: _baseOverrides(
+          repo: _FakeGamebaseRepository([
+            {
+              'id': 'g1',
+              'white': 'Magnus Carlsen',
+              'black': 'Hikaru Nakamura',
+              'result': '1-0',
+              'event': 'Biel International Chess Festival',
+              'eco': 'C45',
+              'date': '2024-05-12',
+              'continuation': const ['e2e4'],
+            },
+          ]),
+        ),
+      );
+      addTearDown(container.dispose);
+
+      await _pumpSection(tester, container: container);
+
+      expect(find.text('Games'), findsNothing);
+      expect(find.textContaining('Magnus Carlsen'), findsOneWidget);
+    });
+
+    test('games pin removes sticky label chrome and keeps the board fixed', () {
+      final explorerSource =
+          io.File(
+            'lib/screens/gamebase/widgets/move_statistics_panel.dart',
+          ).readAsStringSync();
+      expect(explorerSource, isNot(contains('explorer_header_games')));
+      expect(explorerSource, isNot(contains("label: 'Games'")));
+      expect(explorerSource, contains('headerInGames.value'));
+      expect(explorerSource, contains('SizedBox.shrink'));
+
+      final boardSource =
+          io.File(
+            'lib/screens/chessboard/chess_board_screen_new.dart',
+          ).readAsStringSync();
+      expect(boardSource, contains('CompactBoardPinnedAnalysisLayout('));
+      expect(
+        boardSource,
+        contains("key: const ValueKey('compact_board_fixed')"),
+      );
+    });
+
+    test('focused-card navigation is wired to SAN-aware move sounds', () {
+      final source =
+          io.File(
+            'lib/screens/gamebase/widgets/explorer_game_card.dart',
+          ).readAsStringSync();
+      expect(source, contains('resolveExplorerFocusSoundSan('));
+      expect(
+        source,
+        contains('AudioPlayerService.instance.playSfxForSan(san)'),
+      );
+    });
+
     testWidgets('renders cards from position games response', (tester) async {
       final rows = [
         {
@@ -408,7 +608,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(ExplorerGameCard), findsOneWidget);
-      expect(find.text('Games'), findsOneWidget);
+      expect(find.text('Games'), findsNothing);
       expect(find.textContaining('Magnus Carlsen'), findsOneWidget);
       expect(find.byType(GameCardChessboard), findsOneWidget);
     });
@@ -545,6 +745,14 @@ void main() {
         expect(routing.canMoveBackward, isTrue);
         expect(routing.onRightMove, isNotNull);
         expect(routing.onLeftMove, isNotNull);
+
+        // Focus-mode long press is intentionally one step per gesture. The
+        // button owns no repeat timer, so there is nothing to cancel on end.
+        expect(routing.onLongPressForwardEnd, isNull);
+        routing.onLongPressForwardStart!();
+        expect(container.read(explorerFocusedGameProvider)!.ply, 1);
+        routing.onLongPressBackwardStart!();
+        expect(container.read(explorerFocusedGameProvider)!.ply, 0);
 
         routing.onRightMove!();
         expect(container.read(explorerFocusedGameProvider)!.ply, 1);


### PR DESCRIPTION
## Summary
- remove both redundant visible `Games` labels from the inline Opening Explorer transition while keeping game-count sorting accessible
- pin the complete phone board so pulling inline games upward reclaims engine/PV space without scrolling or clipping the board
- show the human event name in the compact game-card center slot instead of ECO/date, filtering opaque IDs and URL-like values
- play existing SAN-aware move sounds when focused mini-board notation/arrows change ply

## Why `stable`
The inline explorer-game-card feature shown in the reported phone recording exists on the current `stable` release line and is not present on `dev` in the same form. This is a narrow follow-up to the shipped 32.12.2 behavior.

## Validation
- `flutter analyze --no-pub lib/screens/chessboard/chess_board_screen_new.dart lib/screens/gamebase/widgets/move_statistics_panel.dart lib/screens/gamebase/widgets/explorer_game_card.dart lib/screens/gamebase/widgets/position_games_sheet.dart test/explorer_compact_game_rows_test.dart`
- focused explorer suite: 53 passed; 4 live Gamebase tests skipped because `GB_KEY` was unavailable
- `git diff --check`
- widget geometry regression confirms the board rect does not move when games reclaim PV space
- event tests cover human-name preference plus UUID/private-URL suppression
- focused-card tests cover tap, jump, backward, and one-step long-press navigation

## QA
1. Open Board → Opening Tree and reach a position with inline game cards.
2. Pull the cards upward on the first attempt: the full board and both player rows remain fixed; cards stop directly under the board and cover engine/PV space.
3. Confirm neither redundant `Games` word is visible; game-count sorting remains available to accessibility services.
4. Confirm each small card shows the event between the player rows, not ECO/date or an internal ID.
5. Tap notation and use bottom arrows: the mini-board advances with the configured move/check/capture/castling sounds.

## Review routing
Phone owner/reviewer: @devberkay

## Conflict note
PR #266 also touches the large board screen and audio service area on `stable`; this branch does not modify the audio service itself, but should be merged/rebased carefully.
