### PR TITLE
fix: simplify and rank phone Miniatures

### DIFF
--- a/lib/repository/gamebase/miniatures/miniatures_models.dart
+++ b/lib/repository/gamebase/miniatures/miniatures_models.dart
@@ -1,6 +1,36 @@
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 
+const int miniatureMissingRatingFallback = 1800;
+
+List<GamebaseMiniature> orderMiniaturesByDayAndAverageRating(
+  Iterable<GamebaseMiniature> games,
+) {
+  final ordered = games.toList(growable: false);
+  ordered.sort((left, right) {
+    final leftDay = _miniatureUtcDayKey(left.date);
+    final rightDay = _miniatureUtcDayKey(right.date);
+    if (leftDay != rightDay) {
+      if (leftDay == null) return 1;
+      if (rightDay == null) return -1;
+      return rightDay.compareTo(leftDay);
+    }
+
+    final ratingOrder = right.effectiveAverageRating.compareTo(
+      left.effectiveAverageRating,
+    );
+    if (ratingOrder != 0) return ratingOrder;
+    return left.gameId.compareTo(right.gameId);
+  });
+  return ordered;
+}
+
+int? _miniatureUtcDayKey(DateTime? date) {
+  if (date == null) return null;
+  final utc = date.toUtc();
+  return utc.year * 10000 + utc.month * 100 + utc.day;
+}
+
 /// Models for the community Miniatures database (`GET /api/miniatures`).
 ///
 /// Ported from the desktop app's miniatures implementation so mobile mirrors
@@ -437,6 +467,18 @@ class GamebaseMiniature {
   final String? whiteFed;
   final String? blackFed;
 
+  int get effectiveAverageRating {
+    final effectiveWhite =
+        whiteElo != null && whiteElo! > 0
+            ? whiteElo!
+            : miniatureMissingRatingFallback;
+    final effectiveBlack =
+        blackElo != null && blackElo! > 0
+            ? blackElo!
+            : miniatureMissingRatingFallback;
+    return ((effectiveWhite + effectiveBlack) / 2).round();
+  }
+
   factory GamebaseMiniature.fromJson(Map<String, dynamic> json) {
     return GamebaseMiniature(
       gameId: _readString(json['gameId']),
@@ -534,7 +576,7 @@ class GamebaseMiniature {
       eco: ecoClean.isNotEmpty ? ecoClean : null,
       openingName: openingDisplayName,
       timeControl: timeControl.trim().isNotEmpty ? timeControl.trim() : null,
-      avgElo: avgRating,
+      avgElo: effectiveAverageRating,
       isOnline: isOnline,
     );
   }

--- a/lib/repository/gamebase/miniatures/miniatures_models.dart
+++ b/lib/repository/gamebase/miniatures/miniatures_models.dart
@@ -135,8 +135,7 @@ class MiniatureGamesFilter {
   bool get hasActiveFilters => activeFilterCount > 0;
 
   /// Whether a non-default sort is applied. Sort shapes presentation, not the
-  /// result set, so it is kept out of [activeFilterCount] but still folds
-  /// into the filter-dialog badge alongside it (desktop parity).
+  /// result set, and the phone Miniatures filter does not expose sort controls.
   bool get hasActiveSort => sort != MiniatureGamesSort.recent;
 
   /// Count of everything that narrows the backend query (desktop parity).
@@ -164,10 +163,8 @@ class MiniatureGamesFilter {
     return activeFilterCount - windowActive;
   }
 
-  /// [dialogFilterCount] plus sort, since the filter dialog now surfaces both
-  /// behind a single icon (search field + one filter/sort button, mirroring
-  /// the Favorites and Countrymen games tabs — no separate sort dropdown).
-  int get dialogActiveCount => dialogFilterCount + (hasActiveSort ? 1 : 0);
+  /// Count shown on the phone Miniatures filter button.
+  int get dialogActiveCount => dialogFilterCount;
 
   MiniatureGamesFilter copyWith({
     MiniatureGamesWindow? window,

--- a/lib/screens/library/providers/miniatures_provider.dart
+++ b/lib/screens/library/providers/miniatures_provider.dart
@@ -24,7 +24,9 @@ final miniaturesTotalCountProvider = FutureProvider<int>((ref) async {
 final miniatureGamesProvider = Provider.autoDispose<List<GamesTourModel>>((
   ref,
 ) {
-  final items = ref.watch(miniaturesPaginatedProvider).items;
+  final items = orderMiniaturesByDayAndAverageRating(
+    ref.watch(miniaturesPaginatedProvider).items,
+  );
   return items.map((item) => item.toGamesTourModel()).toList(growable: false);
 });
 
@@ -340,8 +342,9 @@ final miniaturePlayerGamesPaginatedProvider = StateNotifierProvider.autoDispose
 /// [miniatureGamesProvider] for the `.family`-scoped scorecard screen.
 final miniaturePlayerGamesProvider = Provider.autoDispose
     .family<List<GamesTourModel>, String>((ref, playerId) {
-      final items =
-          ref.watch(miniaturePlayerGamesPaginatedProvider(playerId)).items;
+      final items = orderMiniaturesByDayAndAverageRating(
+        ref.watch(miniaturePlayerGamesPaginatedProvider(playerId)).items,
+      );
       return items
           .map((item) => item.toGamesTourModel())
           .toList(growable: false);

--- a/lib/screens/library/widgets/miniatures_filter_dialog.dart
+++ b/lib/screens/library/widgets/miniatures_filter_dialog.dart
@@ -5,13 +5,38 @@ import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/alert_dialog/alert_modal.dart';
-import 'package:chessever2/widgets/game_filter/eco_filter_dropdown.dart';
 import 'package:chessever2/widgets/game_filter/game_filter_model.dart';
 import 'package:chessever2/widgets/game_filter/rating_tier_filter.dart';
 import 'package:chessever2/widgets/game_filter/wheel_range_filter.dart';
 import 'package:flutter/material.dart';
 
-/// Shows the miniatures filter (and sort) dialog behind the single tune icon
+class MiniatureOpeningFilterInput {
+  const MiniatureOpeningFilterInput({
+    this.eco,
+    this.ecoCategories = const <String>{},
+    this.opening,
+  });
+
+  final String? eco;
+  final Set<String> ecoCategories;
+  final String? opening;
+
+  factory MiniatureOpeningFilterInput.parse(String value) {
+    final input = value.trim();
+    if (input.isEmpty) return const MiniatureOpeningFilterInput();
+
+    final upper = input.toUpperCase();
+    if (RegExp(r'^[A-E]\d{2}$').hasMatch(upper)) {
+      return MiniatureOpeningFilterInput(eco: upper);
+    }
+    if (RegExp(r'^[A-E]$').hasMatch(upper)) {
+      return MiniatureOpeningFilterInput(ecoCategories: <String>{upper});
+    }
+    return MiniatureOpeningFilterInput(opening: input);
+  }
+}
+
+/// Shows the miniatures filter dialog behind the single tune icon
 /// next to search — the same shape as the Favorites and Countrymen games tabs.
 /// Returns the new filter or null if cancelled. Window / search are owned by
 /// the screen's own controls and pass through unchanged.
@@ -40,8 +65,6 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
   static final int _maxYear = DateTime.now().year;
   static const int _minYear = GameFilter.absoluteMinYear;
 
-  late MiniatureGamesSort _sort;
-
   /// null = any result.
   MiniatureGameResult? _result;
 
@@ -51,9 +74,7 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
   /// null = default finish (by move 25, the index's outer bound).
   int? _maxMoves;
 
-  late GameEcoFilter _eco;
   late final TextEditingController _openingController;
-  late final TextEditingController _variationController;
   late RangeValues _yearRange;
   late int? _selectedMinRating;
 
@@ -63,7 +84,6 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
   void initState() {
     super.initState();
     final filter = widget.initialFilter;
-    _sort = filter.sort;
     _result = filter.results.length == 1 ? filter.results.first : null;
     _timeControl =
         filter.timeControls.length == 1 ? filter.timeControls.first : null;
@@ -71,9 +91,9 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
         (filter.maxMoves == null || filter.maxMoves == _defaultMaxMoves)
             ? null
             : filter.maxMoves;
-    _eco = _ecoFromFilter(filter);
-    _openingController = TextEditingController(text: filter.opening ?? '');
-    _variationController = TextEditingController(text: filter.variation ?? '');
+    _openingController = TextEditingController(
+      text: _openingInputFromFilter(filter),
+    );
     _yearRange = RangeValues(
       (_yearFromDate(filter.dateFrom) ?? _minYear).toDouble(),
       (_yearFromDate(filter.dateTo) ?? _maxYear).toDouble(),
@@ -84,18 +104,19 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
   @override
   void dispose() {
     _openingController.dispose();
-    _variationController.dispose();
     _scrollController.dispose();
     super.dispose();
   }
 
-  static GameEcoFilter _ecoFromFilter(MiniatureGamesFilter filter) {
-    final eco = filter.eco?.trim().toUpperCase();
-    if (eco != null && eco.isNotEmpty) return GameEcoFilter.forCode(eco);
+  static String _openingInputFromFilter(MiniatureGamesFilter filter) {
+    final eco = filter.eco?.trim();
+    if (eco != null && eco.isNotEmpty) return eco.toUpperCase();
     if (filter.ecoCategories.length == 1) {
-      return GameEcoFilter.forCode(filter.ecoCategories.first);
+      return filter.ecoCategories.first.toUpperCase();
     }
-    return GameEcoFilter.all;
+    final opening = filter.opening?.trim();
+    if (opening != null && opening.isNotEmpty) return opening;
+    return filter.variation?.trim() ?? '';
   }
 
   static int? _yearFromDate(String? value) {
@@ -133,31 +154,15 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    _sectionLabel('Sort'),
+                    _sectionLabel('Ended by move'),
                     SizedBox(height: 8.h),
-                    _chipGrid<MiniatureGamesSort>(
-                      values: MiniatureGamesSort.values,
-                      selected: _sort,
-                      label: (v) => v.label,
+                    _chipGrid<int?>(
+                      values: const <int?>[null, 20, 15],
+                      selected: _maxMoves,
+                      label: (v) => '≤ ${v ?? _defaultMaxMoves}',
                       onTap: (v) {
                         HapticFeedbackService.selection();
-                        setState(() => _sort = v);
-                      },
-                    ),
-                    SizedBox(height: 20.h),
-
-                    _sectionLabel('Result'),
-                    SizedBox(height: 8.h),
-                    _chipGrid<MiniatureGameResult?>(
-                      values: <MiniatureGameResult?>[
-                        null,
-                        ...MiniatureGameResult.values,
-                      ],
-                      selected: _result,
-                      label: (v) => v == null ? 'All' : v.label,
-                      onTap: (v) {
-                        HapticFeedbackService.selection();
-                        setState(() => _result = v);
+                        setState(() => _maxMoves = v);
                       },
                     ),
                     SizedBox(height: 20.h),
@@ -178,56 +183,38 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
                     ),
                     SizedBox(height: 20.h),
 
-                    _sectionLabel('Finish'),
+                    _sectionLabel('Level'),
                     SizedBox(height: 8.h),
-                    _chipGrid<int?>(
-                      values: const <int?>[null, 20, 15],
-                      selected: _maxMoves,
-                      label: (v) => v == null ? 'By move 25' : 'By move $v',
-                      onTap: (v) {
+                    RatingTierFilter(
+                      selectedMinRating: _selectedMinRating,
+                      onChanged: (value) {
                         HapticFeedbackService.selection();
-                        setState(() => _maxMoves = v);
+                        setState(() => _selectedMinRating = value);
                       },
                     ),
                     SizedBox(height: 20.h),
 
                     _sectionLabel('Opening'),
                     SizedBox(height: 8.h),
-                    // ECO category shortcut (desktop parity): a bare letter
-                    // maps to the `ecoCategory` API param; a full code picked
-                    // in the dropdown below maps to `eco`.
-                    _chipGrid<String?>(
-                      values: const <String?>[null, 'A', 'B', 'C', 'D', 'E'],
-                      selected:
-                          (_eco.code != null && _eco.code!.length == 1)
-                              ? _eco.code
-                              : (_eco.isAll ? null : '__code__'),
-                      label: (v) => v ?? 'All',
-                      onTap: (v) {
-                        HapticFeedbackService.selection();
-                        setState(
-                          () =>
-                              _eco =
-                                  v == null
-                                      ? GameEcoFilter.all
-                                      : GameEcoFilter.forCode(v),
-                        );
-                      },
-                    ),
-                    SizedBox(height: 8.h),
-                    EcoFilterDropdown(
-                      value: _eco,
-                      onChanged: (v) => setState(() => _eco = v),
-                    ),
-                    SizedBox(height: 8.h),
                     _textField(
                       controller: _openingController,
-                      hint: 'Opening name, e.g. Sicilian Defense',
+                      hint: 'Example: B90 or Sicilian Defense',
                     ),
+                    SizedBox(height: 20.h),
+
+                    _sectionLabel('Result'),
                     SizedBox(height: 8.h),
-                    _textField(
-                      controller: _variationController,
-                      hint: 'Variation, e.g. Najdorf',
+                    _chipGrid<MiniatureGameResult?>(
+                      values: <MiniatureGameResult?>[
+                        null,
+                        ...MiniatureGameResult.values,
+                      ],
+                      selected: _result,
+                      label: (v) => v == null ? 'All' : v.label,
+                      onTap: (v) {
+                        HapticFeedbackService.selection();
+                        setState(() => _result = v);
+                      },
                     ),
                     SizedBox(height: 20.h),
 
@@ -240,17 +227,6 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
                       currentEnd: _yearRange.end,
                       divisions: _maxYear - _minYear,
                       onChanged: (v) => setState(() => _yearRange = v),
-                    ),
-                    SizedBox(height: 20.h),
-
-                    _sectionLabel('Level'),
-                    SizedBox(height: 8.h),
-                    RatingTierFilter(
-                      selectedMinRating: _selectedMinRating,
-                      onChanged: (value) {
-                        HapticFeedbackService.selection();
-                        setState(() => _selectedMinRating = value);
-                      },
                     ),
                     SizedBox(height: 12.h),
                   ],
@@ -297,13 +273,6 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
       );
     }
 
-    if (_sort != MiniatureGamesSort.recent) {
-      activeChipWidgets.add(
-        buildChip('Sort: ${_sort.label}', () {
-          setState(() => _sort = MiniatureGamesSort.recent);
-        }),
-      );
-    }
     if (_result != null) {
       activeChipWidgets.add(
         buildChip('Result: ${_result!.label}', () {
@@ -320,15 +289,8 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
     }
     if (_maxMoves != null) {
       activeChipWidgets.add(
-        buildChip('Finish: move $_maxMoves', () {
+        buildChip('Ended by move: ≤ $_maxMoves', () {
           setState(() => _maxMoves = null);
-        }),
-      );
-    }
-    if (!_eco.isAll) {
-      activeChipWidgets.add(
-        buildChip('ECO: ${_eco.code}', () {
-          setState(() => _eco = GameEcoFilter.all);
         }),
       );
     }
@@ -339,13 +301,7 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
         }),
       );
     }
-    if (_variationController.text.trim().isNotEmpty) {
-      activeChipWidgets.add(
-        buildChip('Variation: ${_variationController.text.trim()}', () {
-          setState(() => _variationController.clear());
-        }),
-      );
-    }
+
     if (_yearRange.start.round() > _minYear ||
         _yearRange.end.round() < _maxYear) {
       activeChipWidgets.add(
@@ -457,8 +413,8 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
 
   void _resetFilters() {
     HapticFeedbackService.buttonPress();
-    // Preserve everything owned by the screen's own controls; sort resets to
-    // its default since this dialog now owns it.
+    // Preserve everything owned by the screen's own controls. Hidden legacy
+    // sort/opening variants reset to the phone defaults.
     final initial = widget.initialFilter;
     Navigator.of(context).pop(
       MiniatureGamesFilter(
@@ -473,9 +429,9 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
     FocusScope.of(context).unfocus();
     HapticFeedbackService.buttonPress();
     final initial = widget.initialFilter;
-
-    final ecoCode = _eco.code?.trim().toUpperCase();
-    final isCategory = ecoCode != null && ecoCode.length == 1;
+    final openingInput = MiniatureOpeningFilterInput.parse(
+      _openingController.text,
+    );
 
     final yearFrom = _yearRange.start.round();
     final yearTo = _yearRange.end.round();
@@ -483,27 +439,17 @@ class _MiniaturesFilterDialogState extends State<MiniaturesFilterDialog> {
     Navigator.of(context).pop(
       MiniatureGamesFilter(
         window: initial.window,
-        sort: _sort,
-        // "Fewest moves" reads ascending; the rest read best/newest first.
-        order:
-            _sort == MiniatureGamesSort.moves
-                ? MiniatureGamesSortOrder.asc
-                : MiniatureGamesSortOrder.desc,
+        sort: MiniatureGamesSort.recent,
+        order: MiniatureGamesSortOrder.desc,
         search: initial.search,
         playerId: initial.playerId,
         results: _result == null ? const {} : {_result!},
         timeControls: _timeControl == null ? const {} : {_timeControl!},
         maxMoves: _maxMoves,
-        eco: (ecoCode == null || isCategory) ? null : ecoCode,
-        ecoCategories: isCategory ? {ecoCode} : const <String>{},
-        opening:
-            _openingController.text.trim().isEmpty
-                ? null
-                : _openingController.text.trim(),
-        variation:
-            _variationController.text.trim().isEmpty
-                ? null
-                : _variationController.text.trim(),
+        eco: openingInput.eco,
+        ecoCategories: openingInput.ecoCategories,
+        opening: openingInput.opening,
+        variation: null,
         minRating: _selectedMinRating,
         dateFrom: yearFrom > _minYear ? '$yearFrom-01-01' : null,
         dateTo: yearTo < _maxYear ? '$yearTo-12-31' : null,

--- a/test/miniatures_day_rating_order_test.dart
+++ b/test/miniatures_day_rating_order_test.dart
@@ -1,0 +1,74 @@
+import 'package:chessever2/repository/gamebase/miniatures/miniatures_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+GamebaseMiniature _miniature({
+  required String id,
+  required DateTime date,
+  int? whiteElo,
+  int? blackElo,
+}) {
+  return GamebaseMiniature(
+    gameId: id,
+    avgRating: null,
+    plyCount: 20,
+    finalMoveNumber: 10,
+    result: 'W',
+    timeControl: 'CLASSICAL',
+    isOnline: false,
+    date: date,
+    whiteElo: whiteElo,
+    blackElo: blackElo,
+  );
+}
+
+void main() {
+  test('missing Miniatures ratings use 1800 in the effective average', () {
+    final oneMissing = _miniature(
+      id: 'one-missing',
+      date: DateTime.utc(2026, 7, 22),
+      whiteElo: 2400,
+    );
+    final bothMissing = _miniature(
+      id: 'both-missing',
+      date: DateTime.utc(2026, 7, 22),
+    );
+
+    expect(oneMissing.effectiveAverageRating, 2100);
+    expect(bothMissing.effectiveAverageRating, 1800);
+    expect(oneMissing.toGamesTourModel().avgElo, 2100);
+    expect(bothMissing.toGamesTourModel().avgElo, 1800);
+  });
+
+  test(
+    'Miniatures stay newest-day first and strongest-first within each day',
+    () {
+      final today = DateTime.utc(2026, 7, 22);
+      final yesterday = DateTime.utc(2026, 7, 21);
+      final games = <GamebaseMiniature>[
+        _miniature(id: 'today-both-missing', date: today),
+        _miniature(
+          id: 'yesterday-strongest',
+          date: yesterday,
+          whiteElo: 2800,
+          blackElo: 2800,
+        ),
+        _miniature(
+          id: 'today-strongest',
+          date: today,
+          whiteElo: 2500,
+          blackElo: 2500,
+        ),
+        _miniature(id: 'today-one-missing', date: today, whiteElo: 2400),
+      ];
+
+      final ordered = orderMiniaturesByDayAndAverageRating(games);
+
+      expect(ordered.map((game) => game.gameId), <String>[
+        'today-strongest',
+        'today-one-missing',
+        'today-both-missing',
+        'yesterday-strongest',
+      ]);
+    },
+  );
+}

--- a/test/miniatures_filter_dialog_test.dart
+++ b/test/miniatures_filter_dialog_test.dart
@@ -1,0 +1,86 @@
+import 'package:chessever2/repository/gamebase/miniatures/miniatures_models.dart';
+import 'package:chessever2/screens/library/widgets/miniatures_filter_dialog.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _MiniaturesFilterHarness extends StatelessWidget {
+  const _MiniaturesFilterHarness();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: Builder(
+        builder: (context) {
+          ResponsiveHelper.init(context);
+          return const Scaffold(
+            body: Center(
+              child: MiniaturesFilterDialog(
+                initialFilter: MiniatureGamesFilter(),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+void main() {
+  test('sort does not count as an active Miniatures dialog filter', () {
+    const filter = MiniatureGamesFilter(sort: MiniatureGamesSort.rating);
+
+    expect(filter.dialogActiveCount, 0);
+  });
+
+  test('single opening input maps ECO codes and opening names', () {
+    final eco = MiniatureOpeningFilterInput.parse(' b90 ');
+    expect(eco.eco, 'B90');
+    expect(eco.opening, isNull);
+    expect(eco.ecoCategories, isEmpty);
+
+    final opening = MiniatureOpeningFilterInput.parse(' Sicilian Defense ');
+    expect(opening.eco, isNull);
+    expect(opening.opening, 'Sicilian Defense');
+    expect(opening.ecoCategories, isEmpty);
+  });
+
+  testWidgets('Miniatures filters use the compact approved order', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(const _MiniaturesFilterHarness());
+    await tester.pumpAndSettle();
+
+    const orderedSections = <String>[
+      'Ended by move',
+      'Time Control',
+      'Level',
+      'Opening',
+      'Result',
+      'Year',
+    ];
+    final sectionOffsets = <double>[];
+    for (final label in orderedSections) {
+      expect(find.text(label), findsOneWidget);
+      sectionOffsets.add(tester.getTopLeft(find.text(label)).dy);
+    }
+    expect(sectionOffsets, orderedEquals([...sectionOffsets]..sort()));
+
+    expect(find.text('≤ 25'), findsOneWidget);
+    expect(find.text('≤ 20'), findsOneWidget);
+    expect(find.text('≤ 15'), findsOneWidget);
+    expect(find.text('By move 25'), findsNothing);
+    expect(find.text('Sort'), findsNothing);
+
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.text('Example: B90 or Sicilian Defense'), findsOneWidget);
+    for (final category in const ['A', 'B', 'C', 'D', 'E']) {
+      expect(find.text(category), findsNothing);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- move `Ended by move` to the top of the phone Miniatures filter and use compact `≤ 25`, `≤ 20`, and `≤ 15` chips
- order the remaining filters as Time Control, Level, Opening, Result, and Year
- remove the phone sort controls and the A–E/ECO dropdown plus separate variation field
- use one Opening field that accepts an ECO code such as `B90` or an opening name such as `Sicilian Defense`
- keep hidden legacy sort state out of the filter badge and reset it to Most recent when filters are applied
- keep day sections newest-first while ordering games inside each day by strongest effective average rating
- calculate that effective average with `1800` for either missing player rating, including `1800` for both when both are missing

## Base
This targets `stable` because the current phone Miniatures screen and filter implementation exist there; `dev` does not yet contain these files.

## Validation
- `dart format` on all five touched Dart files
- focused `flutter analyze --no-pub` on all touched source/test files
- `flutter test --no-pub test/miniatures_day_rating_order_test.dart test/miniatures_filter_dialog_test.dart test/miniatures_day_header_test.dart test/miniatures_stats_parsing_test.dart test/widgets/rating_tier_filter_test.dart test/widgets/wheel_range_filter_test.dart` — 29 passed
- `git diff --check`

All focused checks passed. The rating fallback and day ordering are calculated from the player ratings already returned to the phone; no production database mutation or backfill is included. Production is unchanged until review, merge, and release.
