### PR TITLE
fix: restore notification dispatcher authentication

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,7 @@
+project_id = "chessever-frontend"
+
+# The database trigger and one-minute fallback heartbeat authenticate with the
+# private x-stream-token header, not a Supabase user JWT. Keep gateway JWT
+# verification disabled and enforce the stream token inside the function.
+[functions.onesignal-dispatch]
+verify_jwt = false

--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -88,7 +88,7 @@ Deno.serve(async (req) => {
   }
   const requiredToken = await resolveDispatchToken();
   const providedToken = req.headers.get("x-stream-token");
-  if (providedToken && requiredToken && providedToken !== requiredToken) {
+  if (requiredToken && providedToken !== requiredToken) {
     return new Response("Unauthorized", { status: 401 });
   }
 

--- a/supabase/functions/onesignal-dispatch/index.ts
+++ b/supabase/functions/onesignal-dispatch/index.ts
@@ -88,7 +88,7 @@ Deno.serve(async (req) => {
   }
   const requiredToken = await resolveDispatchToken();
   const providedToken = req.headers.get("x-stream-token");
-  if (requiredToken && providedToken !== requiredToken) {
+  if (providedToken !== requiredToken) {
     return new Response("Unauthorized", { status: 401 });
   }
 
@@ -124,23 +124,24 @@ Deno.serve(async (req) => {
   );
 });
 
-async function resolveDispatchToken(): Promise<string | null> {
+async function resolveDispatchToken(): Promise<string> {
   const now = Date.now();
-  if (dispatchTokenCache.expiresAtMs > now) return dispatchTokenCache.token;
+  if (dispatchTokenCache.expiresAtMs > now && dispatchTokenCache.token) {
+    return dispatchTokenCache.token;
+  }
 
   const { data, error } = await supabase.rpc("get_vault_secret", {
     secret_name: "live_dispatch_token",
   });
 
   if (error) {
-    // Fail-open on vault lookup errors so pg_net trigger dispatch does not
-    // break when DB-side token forwarding is not configured.
-    dispatchTokenCache.token = null;
-    dispatchTokenCache.expiresAtMs = now + 15_000;
-    return null;
+    throw new Error(`Dispatch token lookup failed: ${error.message}`);
   }
 
   const vaultToken = typeof data === "string" && data.length > 0 ? data : null;
+  if (!vaultToken) {
+    throw new Error("Dispatch token is not configured");
+  }
   dispatchTokenCache.token = vaultToken;
   dispatchTokenCache.expiresAtMs = now + 60_000;
   return vaultToken;

--- a/test_notification_dispatch_dedupe.py
+++ b/test_notification_dispatch_dedupe.py
@@ -15,8 +15,17 @@ def _source() -> str:
 def test_dispatch_requires_the_configured_stream_token() -> None:
     source = _source()
 
-    assert "if (requiredToken && providedToken !== requiredToken)" in source
+    assert "if (providedToken !== requiredToken)" in source
     assert "if (providedToken && requiredToken" not in source
+    assert "if (requiredToken && providedToken" not in source
+
+
+def test_dispatch_fails_closed_when_vault_token_is_unavailable() -> None:
+    source = _source()
+
+    assert 'throw new Error(`Dispatch token lookup failed: ${error.message}`)' in source
+    assert 'throw new Error("Dispatch token is not configured")' in source
+    assert "Fail-open on vault lookup errors" not in source
 
 
 def test_dispatch_function_keeps_gateway_jwt_verification_disabled() -> None:

--- a/test_notification_dispatch_dedupe.py
+++ b/test_notification_dispatch_dedupe.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 EDGE_FUNCTION = Path("supabase/functions/onesignal-dispatch/index.ts")
+SUPABASE_CONFIG = Path("supabase/config.toml")
 ROUND_START_DEDUPE_MIGRATION = Path(
     "supabase/migrations/20260527232342_grouped_round_start_exact_time_dedupe.sql"
 )
@@ -9,6 +10,20 @@ ROUND_START_DEDUPE_MIGRATION = Path(
 
 def _source() -> str:
     return EDGE_FUNCTION.read_text(encoding="utf-8")
+
+
+def test_dispatch_requires_the_configured_stream_token() -> None:
+    source = _source()
+
+    assert "if (requiredToken && providedToken !== requiredToken)" in source
+    assert "if (providedToken && requiredToken" not in source
+
+
+def test_dispatch_function_keeps_gateway_jwt_verification_disabled() -> None:
+    config = SUPABASE_CONFIG.read_text(encoding="utf-8")
+
+    assert "[functions.onesignal-dispatch]" in config
+    assert "verify_jwt = false" in config
 
 
 def test_onesignal_targets_are_deduped_before_send() -> None:


### PR DESCRIPTION
## Summary
- persist `verify_jwt = false` for `onesignal-dispatch`, matching the database trigger and fallback heartbeat authentication contract
- reject missing or incorrect `x-stream-token` whenever a dispatch token is configured
- add focused regression coverage for both authentication layers

## Production incident
The dispatcher gateway had JWT verification re-enabled, so trigger/heartbeat requests were rejected before queue claiming. Already-due pending notifications were explicitly marked skipped at the recovery cutoff; they must not be replayed. Fresh rows were manually dispatched after the cutoff.

## Required deployment
Deploy `onesignal-dispatch` from this branch with gateway JWT verification disabled. Do not replay skipped backlog rows.

```bash
supabase functions deploy onesignal-dispatch --no-verify-jwt --project-ref <project-ref>
```

## Validation
- focused RED confirmed both protections were absent
- focused GREEN: 2 passed
- `supabase/config.toml` parsed with Python `tomllib`
- Edge Function bundled successfully with esbuild
- `git diff --check` passed
- full source-contract file has one stale baseline failure on `origin/stable` because its old test still expects the removed `live_game_update` branch; no new test fails

## Deployment blocker in Hermes environment
The Supabase CLI is available, but the environment does not have a Supabase personal access token. Production deployment therefore requires an authenticated owner environment. The queue must continue from the recovery cutoff only.
