### PR TITLE
Teach users to like completed games

### DIFF
--- a/lib/repository/liked_games/liked_games_provider.dart
+++ b/lib/repository/liked_games/liked_games_provider.dart
@@ -8,6 +8,7 @@ import 'package:chessever2/repository/library/models/saved_analysis.dart';
 import 'package:chessever2/repository/supabase/game/game_repository.dart';
 import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
 import 'package:chessever2/screens/chessboard/models/like_tag.dart';
+import 'package:chessever2/screens/chessboard/utils/like_learning_prompt_tracker.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:flutter/foundation.dart';
@@ -155,6 +156,15 @@ class LikedGamesNotifier extends AsyncNotifier<List<SavedAnalysis>> {
             ..removeWhere((a) => a.id.isEmpty && a.sourceGameId == likeId)
             ..insert(0, displayCreated);
       state = AsyncValue.data(reconciled);
+      try {
+        await ref
+            .read(likeLearningPromptTrackerProvider)
+            .recordLike(userId: userId);
+      } catch (error) {
+        // Liking is the primary action. A local teaching-cadence write must
+        // never roll back or report failure for a successfully saved like.
+        debugPrint('[LikedGames] prompt cadence reset failed: $error');
+      }
       return true;
     } catch (e) {
       debugPrint('[LikedGames] toggle failed: $e');

--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import 'dart:math' as math;
 import 'dart:ui';
 import 'package:chessever2/e2e/e2e_ids.dart';
+import 'package:chessever2/providers/auth_state_provider.dart';
 import 'package:chessever2/providers/for_you_games_provider.dart';
 import 'package:chessever2/screens/standings/score_card_screen.dart';
 import 'package:skeletonizer/skeletonizer.dart';
@@ -97,6 +98,8 @@ import 'package:chessever2/screens/chessboard/widgets/heart_burst.dart';
 import 'package:chessever2/screens/chessboard/widgets/like_flight.dart';
 import 'package:chessever2/screens/chessboard/widgets/like_tag_chip.dart';
 import 'package:chessever2/screens/chessboard/widgets/like_tag_offer.dart';
+import 'package:chessever2/screens/chessboard/widgets/like_learning_prompt_sheet.dart';
+import 'package:chessever2/screens/chessboard/utils/like_learning_prompt_tracker.dart';
 import 'package:chessever2/screens/gamebase/widgets/board_opening_explorer_panel.dart';
 import 'package:chessever2/screens/gamebase/widgets/position_games_sheet.dart';
 import 'package:chessever2/screens/gamebase/providers/gamebase_explorer_state.dart';
@@ -7100,6 +7103,7 @@ class _TabletBoardWithSidebar extends ConsumerWidget {
           size: boardSize,
           chessBoardState: state,
           isFlipped: state.isBoardFlipped,
+          isActivePage: index == currentPageIndex,
           index: index,
           game: state.game,
         ),
@@ -7227,6 +7231,7 @@ class _BoardWithSidebar extends ConsumerWidget {
                     size: boardSize,
                     chessBoardState: state,
                     isFlipped: state.isBoardFlipped,
+                    isActivePage: index == currentPageIndex,
                     index: index,
                     game: state.game,
                   ),
@@ -7257,6 +7262,7 @@ class _AnalysisBoard extends ConsumerStatefulWidget {
   final double size;
   final ChessBoardStateNew chessBoardState;
   final bool isFlipped;
+  final bool isActivePage;
   final int index;
   final GamesTourModel game;
 
@@ -7264,6 +7270,7 @@ class _AnalysisBoard extends ConsumerStatefulWidget {
     required this.size,
     required this.chessBoardState,
     this.isFlipped = false,
+    required this.isActivePage,
     required this.index,
     required this.game,
   });
@@ -7349,6 +7356,8 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
   OverlayEntry? _flyingHeartEntry;
   bool _likeInteractionInProgress = false;
   int _likeInteractionToken = 0;
+  bool _likePromptCheckInProgress = false;
+  bool _likePromptVisible = false;
   // Same-square double-tap-to-like tracking. We detect the "like" double-tap
   // with a passive Listener (raw pointer events) instead of a
   // DoubleTapGestureRecognizer. A DoubleTapGestureRecognizer lives in the
@@ -7396,6 +7405,110 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
       analysisState: s,
       game: widget.game,
     );
+  }
+
+  bool get _isFinishedGame {
+    final status = widget.game.gameStatus;
+    return status == GameStatus.whiteWins ||
+        status == GameStatus.blackWins ||
+        status == GameStatus.draw;
+  }
+
+  void _scheduleLikeLearningPromptCheck() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_maybeShowLikeLearningPrompt());
+    });
+  }
+
+  Future<void> _maybeShowLikeLearningPrompt() async {
+    if (!mounted ||
+        !widget.isActivePage ||
+        !_isFinishedGame ||
+        !_isAtGameEnd(widget.chessBoardState.analysisState) ||
+        !_isLikeableSource(widget.game.source) ||
+        _isOwnDatabaseGame(widget.game) ||
+        _likePromptCheckInProgress ||
+        _likePromptVisible) {
+      return;
+    }
+
+    final userId = ref.read(currentUserProvider)?.id;
+    if (userId == null || userId.isEmpty) return;
+
+    _likePromptCheckInProgress = true;
+    try {
+      final likedGames = await ref.read(likedGamesProvider.future);
+      final tracker = ref.read(likeLearningPromptTrackerProvider);
+      await tracker.initialize(
+        userId: userId,
+        hasExistingLikes: likedGames.isNotEmpty,
+      );
+
+      if (!mounted ||
+          !widget.isActivePage ||
+          !_isAtGameEnd(widget.chessBoardState.analysisState)) {
+        return;
+      }
+
+      // An already-liked game is not an inactivity completion. The like itself
+      // reset the cadence when it was confirmed.
+      if (likedGames.any((game) => game.sourceGameId == widget.game.likeId)) {
+        return;
+      }
+
+      final shouldPrompt = await tracker.recordCompletedGame(
+        userId: userId,
+        gameId: widget.game.likeId,
+      );
+      if (!shouldPrompt || !mounted || !widget.isActivePage) return;
+
+      _likePromptVisible = true;
+      final shouldLike = await showModalBottomSheet<bool>(
+        context: context,
+        isScrollControlled: true,
+        backgroundColor: Colors.transparent,
+        constraints: ResponsiveHelper.bottomSheetConstraints,
+        builder:
+            (sheetContext) => LikeLearningPromptSheet(
+              onResult:
+                  (liked) => Navigator.of(sheetContext).pop<bool>(liked),
+            ),
+      );
+      _likePromptVisible = false;
+
+      if (shouldLike == true && mounted && widget.isActivePage) {
+        _setPromptLikeAnimationOrigin();
+        _handleDoubleTapLike(onLiked: _showLikeLearningConfirmation);
+      }
+    } catch (error) {
+      debugPrint('[LikeLearningPrompt] check failed: $error');
+    } finally {
+      _likePromptCheckInProgress = false;
+      _likePromptVisible = false;
+    }
+  }
+
+  void _setPromptLikeAnimationOrigin() {
+    final center = Offset(widget.size / 2, widget.size / 2);
+    _lastTapPosition = center;
+    final renderBox = context.findRenderObject();
+    _lastTapGlobalPosition =
+        renderBox is RenderBox ? renderBox.localToGlobal(center) : center;
+  }
+
+  void _showLikeLearningConfirmation() {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          duration: const Duration(seconds: 3),
+          content: const Text(
+            'Liked. Double-tap the board anytime to like a game.',
+          ),
+        ),
+      );
   }
 
   // Map an author-supplied PGN NAG to a Lichess SVG annotation type — but
@@ -7670,6 +7783,12 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
       _showDelayedGameEndingEffect = false;
     }
 
+    if (shouldShowEffect &&
+        widget.isActivePage &&
+        (!_wasAtEnd || !oldWidget.isActivePage)) {
+      _scheduleLikeLearningPromptCheck();
+    }
+
     _wasAtEnd = isAtGameEnd;
 
     // External flip (e.g., bottom-nav button): if orientation changed
@@ -7744,6 +7863,9 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
         gameStatus != GameStatus.ongoing && gameStatus != GameStatus.unknown;
     if (isGameOver && _wasAtEnd) {
       _showDelayedGameEndingEffect = true;
+      if (widget.isActivePage && _isFinishedGame) {
+        _scheduleLikeLearningPromptCheck();
+      }
     }
 
     _flipProgress = ValueNotifier<double>(0.0);
@@ -8157,7 +8279,7 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
   ///      from the burst's screen position to the save-button slot.
   ///   4. On landing, the save/edit icon remains visible with a small red heart
   ///      badge under it (game is now liked).
-  void _handleDoubleTapLike() {
+  void _handleDoubleTapLike({VoidCallback? onLiked}) {
     final game = widget.game;
     debugPrint('[HeartFlight] like-trigger fired source=${game.source.name}');
     if (!_isLikeableSource(game.source)) return;
@@ -8225,7 +8347,9 @@ class _AnalysisBoardState extends ConsumerState<_AnalysisBoard>
     final toggleFuture = ref
         .read(likedGamesProvider.notifier)
         .toggle(game)
-        .then<void>((_) {});
+        .then<void>((isLiked) {
+          if (!wasLiked && isLiked) onLiked?.call();
+        });
     final visualFloor = Future<void>.delayed(
       wasLiked ? _likeInteractionUnlikeDuration : _likeInteractionLikeDuration,
     );

--- a/lib/screens/chessboard/utils/like_learning_prompt_tracker.dart
+++ b/lib/screens/chessboard/utils/like_learning_prompt_tracker.dart
@@ -1,0 +1,205 @@
+import 'package:chessever2/repository/sqlite/app_database.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Persisted cadence for the contextual "Did you like this game?" teaching.
+///
+/// New users are prompted after 10, 20, and 40 distinct completed games. After
+/// that, prompts repeat every 40 games. Any confirmed like restarts the cadence
+/// at 40 games.
+class LikeLearningPromptProgress {
+  const LikeLearningPromptProgress({
+    required this.initialized,
+    required this.hasEverLiked,
+    required this.completedSinceLike,
+    required this.nextPromptAt,
+    required this.countedGameIds,
+  });
+
+  factory LikeLearningPromptProgress.initial() {
+    return const LikeLearningPromptProgress(
+      initialized: false,
+      hasEverLiked: false,
+      completedSinceLike: 0,
+      nextPromptAt: 10,
+      countedGameIds: <String>{},
+    );
+  }
+
+  factory LikeLearningPromptProgress.fromJson(Map<String, Object?> json) {
+    final rawIds = json['countedGameIds'];
+    final ids =
+        rawIds is List
+            ? rawIds.whereType<String>().where((id) => id.isNotEmpty).toSet()
+            : <String>{};
+    final hasEverLiked = json['hasEverLiked'] == true;
+    final nextPromptAt = json['nextPromptAt'];
+    return LikeLearningPromptProgress(
+      initialized: json['initialized'] == true,
+      hasEverLiked: hasEverLiked,
+      completedSinceLike:
+          (json['completedSinceLike'] as num?)?.toInt().clamp(0, 1 << 30) ?? 0,
+      nextPromptAt:
+          nextPromptAt is num
+              ? nextPromptAt.toInt().clamp(1, 1 << 30)
+              : (hasEverLiked ? 40 : 10),
+      countedGameIds: ids,
+    );
+  }
+
+  final bool initialized;
+  final bool hasEverLiked;
+  final int completedSinceLike;
+  final int nextPromptAt;
+  final Set<String> countedGameIds;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'initialized': initialized,
+    'hasEverLiked': hasEverLiked,
+    'completedSinceLike': completedSinceLike,
+    'nextPromptAt': nextPromptAt,
+    'countedGameIds': countedGameIds.toList(growable: false),
+  };
+
+  LikeLearningPromptProgress copyWith({
+    bool? initialized,
+    bool? hasEverLiked,
+    int? completedSinceLike,
+    int? nextPromptAt,
+    Set<String>? countedGameIds,
+  }) {
+    return LikeLearningPromptProgress(
+      initialized: initialized ?? this.initialized,
+      hasEverLiked: hasEverLiked ?? this.hasEverLiked,
+      completedSinceLike: completedSinceLike ?? this.completedSinceLike,
+      nextPromptAt: nextPromptAt ?? this.nextPromptAt,
+      countedGameIds: countedGameIds ?? this.countedGameIds,
+    );
+  }
+}
+
+abstract class LikeLearningPromptStore {
+  Future<Map<String, Object?>?> read(String userId);
+
+  Future<void> write(String userId, Map<String, Object?> value);
+}
+
+class AppDatabaseLikeLearningPromptStore implements LikeLearningPromptStore {
+  AppDatabaseLikeLearningPromptStore(this._database);
+
+  static const String _keyPrefix = 'like_learning_prompt_v1';
+  final AppDatabase _database;
+
+  String _key(String userId) => '$_keyPrefix:$userId';
+
+  @override
+  Future<Map<String, Object?>?> read(String userId) async {
+    final value = await _database.getJson<Object>(_key(userId));
+    if (value is! Map) return null;
+    return value.map(
+      (key, dynamic item) => MapEntry(key.toString(), item as Object?),
+    );
+  }
+
+  @override
+  Future<void> write(String userId, Map<String, Object?> value) {
+    return _database.setJson(_key(userId), value);
+  }
+}
+
+class LikeLearningPromptTracker {
+  LikeLearningPromptTracker(this._store);
+
+  final LikeLearningPromptStore _store;
+
+  Future<LikeLearningPromptProgress> loadProgress({
+    required String userId,
+  }) async {
+    final stored = await _store.read(userId);
+    return stored == null
+        ? LikeLearningPromptProgress.initial()
+        : LikeLearningPromptProgress.fromJson(stored);
+  }
+
+  /// Seeds the cadence once for users who already had likes before this feature
+  /// shipped. Repeated initialization never resets accumulated progress.
+  Future<void> initialize({
+    required String userId,
+    required bool hasExistingLikes,
+  }) async {
+    final progress = await loadProgress(userId: userId);
+    if (progress.initialized) return;
+
+    await _store.write(
+      userId,
+      progress
+          .copyWith(
+            initialized: true,
+            hasEverLiked: hasExistingLikes,
+            nextPromptAt: hasExistingLikes ? 40 : 10,
+          )
+          .toJson(),
+    );
+  }
+
+  /// Records one distinct eligible finished game. Returns true exactly when the
+  /// UI should ask the contextual like question.
+  Future<bool> recordCompletedGame({
+    required String userId,
+    required String gameId,
+  }) async {
+    if (gameId.isEmpty) return false;
+
+    var progress = await loadProgress(userId: userId);
+    if (!progress.initialized) {
+      progress = progress.copyWith(initialized: true);
+    }
+    if (progress.countedGameIds.contains(gameId)) return false;
+
+    final countedIds = Set<String>.from(progress.countedGameIds)..add(gameId);
+    final completed = progress.completedSinceLike + 1;
+    final shouldPrompt = completed >= progress.nextPromptAt;
+    final nextPromptAt =
+        shouldPrompt
+            ? _nextPromptTarget(progress.nextPromptAt)
+            : progress.nextPromptAt;
+
+    progress = progress.copyWith(
+      completedSinceLike: completed,
+      nextPromptAt: nextPromptAt,
+      countedGameIds: countedIds,
+    );
+    await _store.write(userId, progress.toJson());
+    return shouldPrompt;
+  }
+
+  /// A confirmed new like restarts the inactivity counter. The lifetime set of
+  /// counted games remains, so reopening an old game cannot advance the count.
+  Future<void> recordLike({required String userId}) async {
+    final progress = await loadProgress(userId: userId);
+    await _store.write(
+      userId,
+      progress
+          .copyWith(
+            initialized: true,
+            hasEverLiked: true,
+            completedSinceLike: 0,
+            nextPromptAt: 40,
+          )
+          .toJson(),
+    );
+  }
+
+  int _nextPromptTarget(int currentTarget) {
+    if (currentTarget < 20) return 20;
+    if (currentTarget < 40) return 40;
+    return currentTarget + 40;
+  }
+}
+
+final likeLearningPromptTrackerProvider = Provider<LikeLearningPromptTracker>((
+  ref,
+) {
+  return LikeLearningPromptTracker(
+    AppDatabaseLikeLearningPromptStore(AppDatabase.instance),
+  );
+});

--- a/lib/screens/chessboard/widgets/like_learning_prompt_sheet.dart
+++ b/lib/screens/chessboard/widgets/like_learning_prompt_sheet.dart
@@ -1,0 +1,106 @@
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:chessever2/widgets/app_button.dart';
+import 'package:flutter/material.dart';
+
+/// Compact, contextual question shown after the user reaches the end of an
+/// eligible completed game at the configured learning cadence.
+class LikeLearningPromptSheet extends StatelessWidget {
+  const LikeLearningPromptSheet({super.key, required this.onResult});
+
+  final ValueChanged<bool> onResult;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Container(
+        width: double.infinity,
+        padding: EdgeInsets.fromLTRB(20.w, 10.h, 20.w, 20.h),
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(22.br)),
+          border: Border(
+            top: BorderSide(
+              color: context.colors.divider.withValues(alpha: 0.55),
+            ),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 40.w,
+              height: 4.h,
+              decoration: BoxDecoration(
+                color: context.colors.textSecondary.withValues(alpha: 0.35),
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+            SizedBox(height: 18.h),
+            Container(
+              width: 46.w,
+              height: 46.w,
+              decoration: BoxDecoration(
+                color: context.colors.danger.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(14.br),
+              ),
+              child: Icon(
+                Icons.favorite_rounded,
+                size: 25.sp,
+                color: context.colors.danger,
+              ),
+            ),
+            SizedBox(height: 12.h),
+            Text(
+              'Did you like this game?',
+              textAlign: TextAlign.center,
+              style: AppTypography.textLgBold.copyWith(
+                color: context.colors.textPrimary,
+              ),
+            ),
+            SizedBox(height: 7.h),
+            Text(
+              'Like it to save it in My Likes and find it again later.',
+              textAlign: TextAlign.center,
+              style: AppTypography.textSmRegular.copyWith(
+                color: context.colors.textSecondary,
+                height: 1.4,
+              ),
+            ),
+            SizedBox(height: 20.h),
+            Row(
+              children: [
+                Flexible(
+                  flex: 1,
+                  child: AppButton(
+                    key: const ValueKey('like-learning-no'),
+                    text: 'No',
+                    height: 48.h,
+                    padding: EdgeInsets.symmetric(horizontal: 8.w),
+                    isOutlined: true,
+                    onPressed: () => onResult(false),
+                  ),
+                ),
+                SizedBox(width: 10.w),
+                Expanded(
+                  flex: 2,
+                  child: AppButton(
+                    key: const ValueKey('like-learning-yes'),
+                    text: 'Yes, like it',
+                    height: 48.h,
+                    padding: EdgeInsets.symmetric(horizontal: 8.w),
+                    backgroundColor: context.colors.brand,
+                    textColor: Colors.white,
+                    onPressed: () => onResult(true),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/like_learning_prompt_sheet_test.dart
+++ b/test/like_learning_prompt_sheet_test.dart
@@ -1,0 +1,72 @@
+import 'package:chessever2/screens/chessboard/widgets/like_learning_prompt_sheet.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders the ChessEver like-learning question and actions', (
+    tester,
+  ) async {
+    await _pumpSheet(tester);
+
+    expect(find.text('Did you like this game?'), findsOneWidget);
+    expect(
+      find.text('Like it to save it in My Likes and find it again later.'),
+      findsOneWidget,
+    );
+    expect(find.text('No'), findsOneWidget);
+    expect(find.text('Yes, like it'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('returns false from the secondary No action', (tester) async {
+    bool? result;
+    await _pumpSheet(tester, onResult: (value) => result = value);
+
+    await tester.tap(find.text('No'));
+    await tester.pump();
+
+    expect(result, isFalse);
+  });
+
+  testWidgets('returns true from the primary like action', (tester) async {
+    bool? result;
+    await _pumpSheet(tester, onResult: (value) => result = value);
+
+    await tester.tap(find.text('Yes, like it'));
+    await tester.pump();
+
+    expect(result, isTrue);
+  });
+}
+
+Future<void> _pumpSheet(
+  WidgetTester tester, {
+  ValueChanged<bool>? onResult,
+}) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: Builder(
+        builder: (context) {
+          ResponsiveHelper.init(context);
+          return Scaffold(
+            backgroundColor: context.colors.background,
+            body: Align(
+              alignment: Alignment.bottomCenter,
+              child: LikeLearningPromptSheet(onResult: onResult ?? (_) {}),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}

--- a/test/like_learning_prompt_tracker_test.dart
+++ b/test/like_learning_prompt_tracker_test.dart
@@ -1,0 +1,174 @@
+import 'package:chessever2/screens/chessboard/utils/like_learning_prompt_tracker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LikeLearningPromptTracker', () {
+    test('prompts at 10, 20, 40, then every 40 completed games', () async {
+      final tracker = LikeLearningPromptTracker(_MemoryStore());
+      await tracker.initialize(userId: 'user-1', hasExistingLikes: false);
+
+      final promptGames = <int>[];
+      for (var game = 1; game <= 120; game++) {
+        final shouldPrompt = await tracker.recordCompletedGame(
+          userId: 'user-1',
+          gameId: 'game-$game',
+        );
+        if (shouldPrompt) promptGames.add(game);
+      }
+
+      expect(promptGames, [10, 20, 40, 80, 120]);
+    });
+
+    test('a confirmed like restarts the next prompt at 40 games', () async {
+      final tracker = LikeLearningPromptTracker(_MemoryStore());
+      await tracker.initialize(userId: 'user-1', hasExistingLikes: false);
+
+      for (var game = 1; game <= 20; game++) {
+        await tracker.recordCompletedGame(
+          userId: 'user-1',
+          gameId: 'before-like-$game',
+        );
+      }
+      await tracker.recordLike(userId: 'user-1');
+
+      for (var game = 1; game < 40; game++) {
+        expect(
+          await tracker.recordCompletedGame(
+            userId: 'user-1',
+            gameId: 'after-like-$game',
+          ),
+          isFalse,
+        );
+      }
+      expect(
+        await tracker.recordCompletedGame(
+          userId: 'user-1',
+          gameId: 'after-like-40',
+        ),
+        isTrue,
+      );
+    });
+
+    test('any later like restarts an active 40-game interval', () async {
+      final tracker = LikeLearningPromptTracker(_MemoryStore());
+      await tracker.initialize(userId: 'user-1', hasExistingLikes: true);
+
+      for (var game = 1; game <= 25; game++) {
+        await tracker.recordCompletedGame(
+          userId: 'user-1',
+          gameId: 'first-run-$game',
+        );
+      }
+      await tracker.recordLike(userId: 'user-1');
+
+      for (var game = 1; game < 40; game++) {
+        expect(
+          await tracker.recordCompletedGame(
+            userId: 'user-1',
+            gameId: 'second-run-$game',
+          ),
+          isFalse,
+        );
+      }
+      expect(
+        await tracker.recordCompletedGame(
+          userId: 'user-1',
+          gameId: 'second-run-40',
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'counts each completed game only once across tracker instances',
+      () async {
+        final store = _MemoryStore();
+        final tracker = LikeLearningPromptTracker(store);
+        await tracker.initialize(userId: 'user-1', hasExistingLikes: false);
+
+        for (var game = 1; game <= 9; game++) {
+          expect(
+            await tracker.recordCompletedGame(
+              userId: 'user-1',
+              gameId: 'game-$game',
+            ),
+            isFalse,
+          );
+        }
+        expect(
+          await tracker.recordCompletedGame(userId: 'user-1', gameId: 'game-9'),
+          isFalse,
+        );
+
+        final restoredTracker = LikeLearningPromptTracker(store);
+        expect(
+          await restoredTracker.recordCompletedGame(
+            userId: 'user-1',
+            gameId: 'game-10',
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'existing liked games start directly on the 40-game cadence',
+      () async {
+        final tracker = LikeLearningPromptTracker(_MemoryStore());
+        await tracker.initialize(userId: 'user-1', hasExistingLikes: true);
+
+        for (var game = 1; game < 40; game++) {
+          expect(
+            await tracker.recordCompletedGame(
+              userId: 'user-1',
+              gameId: 'game-$game',
+            ),
+            isFalse,
+          );
+        }
+        expect(
+          await tracker.recordCompletedGame(
+            userId: 'user-1',
+            gameId: 'game-40',
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'initialization is one-time and does not repeatedly reset progress',
+      () async {
+        final tracker = LikeLearningPromptTracker(_MemoryStore());
+        await tracker.initialize(userId: 'user-1', hasExistingLikes: true);
+        for (var game = 1; game <= 12; game++) {
+          await tracker.recordCompletedGame(
+            userId: 'user-1',
+            gameId: 'game-$game',
+          );
+        }
+
+        await tracker.initialize(userId: 'user-1', hasExistingLikes: true);
+        final progress = await tracker.loadProgress(userId: 'user-1');
+
+        expect(progress.completedSinceLike, 12);
+        expect(progress.nextPromptAt, 40);
+      },
+    );
+  });
+}
+
+class _MemoryStore implements LikeLearningPromptStore {
+  final Map<String, Map<String, Object?>> _data = {};
+
+  @override
+  Future<Map<String, Object?>?> read(String userId) async {
+    final value = _data[userId];
+    return value == null ? null : Map<String, Object?>.from(value);
+  }
+
+  @override
+  Future<void> write(String userId, Map<String, Object?> value) async {
+    _data[userId] = Map<String, Object?>.from(value);
+  }
+}

--- a/test/liked_games_provider_test.dart
+++ b/test/liked_games_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:chessever2/repository/library/models/saved_analysis.dart';
 import 'package:chessever2/repository/liked_games/liked_games_provider.dart';
 import 'package:chessever2/revenue_cat_service/subscribe_state.dart';
 import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
+import 'package:chessever2/screens/chessboard/utils/like_learning_prompt_tracker.dart';
 import 'package:chessever2/screens/my_likes/provider/my_likes_provider.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/widgets/game_filter/game_filter.dart';
@@ -212,6 +213,36 @@ void main() {
       container.read(likedGamesProvider).valueOrNull!.single.sourceGameId,
       game.gameId,
     );
+  });
+
+  test('a confirmed new like resets the learning prompt cadence', () async {
+    final repository = _FakeLibraryRepository();
+    final promptStore = _MemoryLikePromptStore();
+    final promptTracker = LikeLearningPromptTracker(promptStore);
+    await promptTracker.initialize(
+      userId: _currentUser.id,
+      hasExistingLikes: false,
+    );
+    for (var game = 1; game <= 12; game++) {
+      await promptTracker.recordCompletedGame(
+        userId: _currentUser.id,
+        gameId: 'completed-$game',
+      );
+    }
+
+    final container = _container(repository, promptTracker: promptTracker);
+    addTearDown(container.dispose);
+    await container.read(likedGamesProvider.future);
+
+    final toggle = container.read(likedGamesProvider.notifier).toggle(_game());
+    await repository.createStarted.future;
+    repository.allowCreate.complete();
+    expect(await toggle, isTrue);
+
+    final progress = await promptTracker.loadProgress(userId: _currentUser.id);
+    expect(progress.hasEverLiked, isTrue);
+    expect(progress.completedSinceLike, 0);
+    expect(progress.nextPromptAt, 40);
   });
 
   test('rapid repeated unlikes delete one liked game', () async {
@@ -421,11 +452,34 @@ void main() {
   });
 }
 
-ProviderContainer _container(_FakeLibraryRepository repository) {
+class _MemoryLikePromptStore implements LikeLearningPromptStore {
+  final Map<String, Map<String, Object?>> _values = {};
+
+  @override
+  Future<Map<String, Object?>?> read(String userId) async {
+    final value = _values[userId];
+    return value == null ? null : Map<String, Object?>.from(value);
+  }
+
+  @override
+  Future<void> write(String userId, Map<String, Object?> value) async {
+    _values[userId] = Map<String, Object?>.from(value);
+  }
+}
+
+ProviderContainer _container(
+  _FakeLibraryRepository repository, {
+  LikeLearningPromptTracker? promptTracker,
+}) {
+  final resolvedPromptTracker =
+      promptTracker ?? LikeLearningPromptTracker(_MemoryLikePromptStore());
   return ProviderContainer(
     overrides: [
       currentUserProvider.overrideWithValue(_currentUser),
       libraryRepositoryProvider.overrideWithValue(repository),
+      likeLearningPromptTrackerProvider.overrideWithValue(
+        resolvedPromptTracker,
+      ),
     ],
   );
 }


### PR DESCRIPTION
## Summary
- teaches the existing double-tap like gesture with a contextual finished-game prompt
- prompts after 10, 20, and 40 distinct eligible completions, then every 40
- resets the next prompt to 40 games after any confirmed new like
- persists user-scoped progress locally and never counts the same game twice
- reuses the existing My Likes save path, heart animation, and app theme components

## Eligibility and safety
- only the active board at the final original-mainline position can count
- excludes live, unfinished, move-less, unsupported, already-liked, and own-database games
- adjacent prebuilt PageView boards cannot advance the counter
- local cadence-write failures cannot roll back a successfully saved like
- no backend, schema, migration, production-data, notification, billing, or release changes

## Validation
- 42 focused Flutter tests passed
- focused Flutter analyzer: no issues
- `git diff --check`: clean
- 390×844 real Flutter component render checked with no overflow or clipping

## QA
1. Reach the end of distinct eligible completed games and verify prompts at 10, 20, 40, then 80.
2. Choose **No** and verify no like action occurs.
3. Choose **Yes, like it** and verify the existing heart flight/My Likes flow runs.
4. After a confirmed like, verify no prompt appears until 40 more distinct eligible completions.
5. Reopen a counted game and verify it does not advance the cadence.
