### PR TITLE
Clarify event game ordering menu

### DIFF
--- a/lib/screens/tour_detail/widgets/tournament_menu_button.dart
+++ b/lib/screens/tour_detail/widgets/tournament_menu_button.dart
@@ -51,6 +51,10 @@ enum TournamentMenuAction {
   shareBrackets,
 }
 
+String gameDisplayModeMenuLabel({required bool isFocusingLiveGames}) {
+  return isFocusingLiveGames ? 'Board order' : 'Live games first';
+}
+
 class TournamentMenuButton extends ConsumerWidget {
   const TournamentMenuButton({super.key, required this.tourData});
 
@@ -191,7 +195,7 @@ class TournamentMenuButton extends ConsumerWidget {
     final isFocusingLiveGames =
         gamesScreenState?.gameDisplayMode == GameDisplayMode.hideFinishedGames;
 
-    // 1. Focus on live games / Show all games
+    // 1. Live games first / Board order
     items.add(
       PopupMenuItem<TournamentMenuAction>(
         value:
@@ -212,7 +216,9 @@ class TournamentMenuButton extends ConsumerWidget {
           }
         },
         child: _MenuDropDownItem(
-          text: isFocusingLiveGames ? "Show all games" : "Focus on live games",
+          text: gameDisplayModeMenuLabel(
+            isFocusingLiveGames: isFocusingLiveGames,
+          ),
           fontFamily: 'InterDisplay',
           icon: Icon(
             isFocusingLiveGames

--- a/test/screens/tour_detail/widgets/tournament_menu_button_test.dart
+++ b/test/screens/tour_detail/widgets/tournament_menu_button_test.dart
@@ -2,6 +2,22 @@ import 'package:chessever2/screens/tour_detail/widgets/tournament_menu_button.da
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('gameDisplayModeMenuLabel', () {
+    test('offers board order while live games are focused', () {
+      expect(
+        gameDisplayModeMenuLabel(isFocusingLiveGames: true),
+        'Board order',
+      );
+    });
+
+    test('offers live games first while using board order', () {
+      expect(
+        gameDisplayModeMenuLabel(isFocusingLiveGames: false),
+        'Live games first',
+      );
+    });
+  });
+
   group('areAllVisibleSectionsCollapsed', () {
     test('treats missing round state as expanded by default', () {
       expect(


### PR DESCRIPTION
## Summary
- rename the event-games menu action from `Show all games` to `Board order`
- rename the reciprocal action from `Focus on live games` to `Live games first`
- keep the existing filtering and ordering behavior unchanged
- add focused regression coverage for both dynamic labels

## Validation
- `flutter test test/screens/tour_detail/widgets/tournament_menu_button_test.dart` — 5/5 passed
- `flutter analyze lib/screens/tour_detail/widgets/tournament_menu_button.dart test/screens/tour_detail/widgets/tournament_menu_button_test.dart` — no issues
- `git diff --check` — passed

## Scope
PR only. No release or production change.
