### PR TITLE
Fix Miniatures final-position evaluation bars

### DIFF
--- a/lib/screens/chessboard/widgets/evaluation_bar_widget.dart
+++ b/lib/screens/chessboard/widgets/evaluation_bar_widget.dart
@@ -296,6 +296,17 @@ class _EvaluationBarWidgetForGamesState
   _EvalBarDisplay? _lastDisplay;
 
   @override
+  void didUpdateWidget(covariant EvaluationBarWidgetForGames oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Keep scroll/rebuild stability only for the same position. Archive cards
+    // can hydrate from a temporary starting FEN to the real final FEN, where
+    // retaining the old display would show the starting-position evaluation.
+    if (oldWidget.fen != widget.fen) {
+      _lastDisplay = null;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     // First, check if position is checkmate - handle immediately without external eval
     // Uses the cached provider for better scroll performance

--- a/test/evaluation_bar_widget_test.dart
+++ b/test/evaluation_bar_widget_test.dart
@@ -12,10 +12,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 const _fen = 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1';
+const _finalFen =
+    'r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3';
 
-CloudEval _cloudEval(int cp) {
+CloudEval _cloudEval(int cp, {String fen = _fen}) {
   return CloudEval(
-    fen: _fen,
+    fen: fen,
     knodes: 0,
     depth: 12,
     pvs: [Pv(moves: 'e7e5', cp: cp)],
@@ -55,12 +57,16 @@ Future<void> _pumpEvalBar(
   WidgetTester tester, {
   required bool allowStockfishFallback,
   required Future<CloudEval> Function() cacheOnlyEval,
+  String fen = _fen,
+  Future<CloudEval> Function(String fen)? stockfishEval,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         gameCardEvalWithStockfishFallbackProvider.overrideWith(
-          (ref, fen) async => _cloudEval(120),
+          (ref, fen) =>
+              stockfishEval?.call(fen) ??
+              Future.value(_cloudEval(120, fen: fen)),
         ),
         gameCardEvalCacheOnlyProvider.overrideWith(
           (ref, fen) => cacheOnlyEval(),
@@ -74,7 +80,7 @@ Future<void> _pumpEvalBar(
               body: EvaluationBarWidgetForGames(
                 width: 24,
                 height: 240,
-                fen: _fen,
+                fen: fen,
                 playerView: PlayerView.listView,
                 allowStockfishFallback: allowStockfishFallback,
               ),
@@ -120,6 +126,41 @@ Future<void> _pumpChessProgressBar(
 }
 
 void main() {
+  testWidgets(
+    'does not retain a previous-position eval after the FEN changes',
+    (tester) async {
+      final pendingFinalEval = Completer<CloudEval>();
+
+      await _pumpEvalBar(
+        tester,
+        allowStockfishFallback: true,
+        cacheOnlyEval: () async => _cloudEval(120),
+        stockfishEval: (fen) async => _cloudEval(20, fen: fen),
+      );
+      await tester.pump();
+
+      expect(find.text('+0.2'), findsOneWidget);
+
+      await _pumpEvalBar(
+        tester,
+        fen: _finalFen,
+        allowStockfishFallback: true,
+        cacheOnlyEval: () => pendingFinalEval.future,
+        stockfishEval: (_) => pendingFinalEval.future,
+      );
+      await tester.pump();
+
+      expect(find.text('+0.2'), findsNothing);
+      expect(find.text('...'), findsOneWidget);
+
+      pendingFinalEval.complete(_cloudEval(450, fen: _finalFen));
+      await tester.pumpAndSettle();
+
+      expect(find.text('+4.5'), findsOneWidget);
+      expect(find.text('...'), findsNothing);
+    },
+  );
+
   testWidgets('retains previous eval while scroll cache-only eval is loading', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- clear a game-card evaluation when its FEN changes
- preserve the existing anti-flicker retention only while rendering the same position
- prevent Miniatures from showing a temporary starting-position evaluation beside the hydrated final board
- add a widget regression covering start FEN → pending final FEN → final evaluation

## Why

Miniature cards initially render from lightweight header data, then hydrate to the full Gamebase final position. The eval bar widget kept `_lastDisplay` across that FEN change, so the final board could continue showing the starting-position evaluation while the final lookup loaded or returned no data.

## Validation

- RED regression reproduced the stale `+0.2` starting-position evaluation
- 18 focused tests passed across eval-bar, Gamebase card hydration, and Miniatures ordering/header coverage
- focused Flutter analyzer: no issues
- `git diff --check`: clean

## Scope

Phone Flutter only. No backend, database, production data, release, or deployment changes.

## Base exception

This targets `stable` because the Miniatures surface exists there and is absent from current `dev`.
