### PR TITLE
Add phone player rankings filters

### DIFF
--- a/lib/repository/supabase/chess_player/chess_player_repository.dart
+++ b/lib/repository/supabase/chess_player/chess_player_repository.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:chessever2/repository/supabase/base_repository.dart';
+import 'package:chessever2/screens/favorites/rankings/ranking_filters.dart';
 import 'package:chessever2/utils/country_utils.dart';
 
 // --- Model ---
@@ -9,14 +10,24 @@ class ChessPlayer {
   final String name;
   final String? title;
   final int? rating;
+  final int? rapidRating;
+  final int? blitzRating;
   final String? country;
+  final String? sex;
+  final int? birthYear;
+  final String? flag;
 
   const ChessPlayer({
     required this.fideid,
     required this.name,
     this.title,
     this.rating,
+    this.rapidRating,
+    this.blitzRating,
     this.country,
+    this.sex,
+    this.birthYear,
+    this.flag,
   });
 
   factory ChessPlayer.fromMap(Map<String, dynamic> map) {
@@ -24,10 +35,23 @@ class ChessPlayer {
       fideid: map['fideid'] as int,
       name: map['name'] as String? ?? '',
       title: map['title'] as String?,
-      rating: map['rating'] as int?,
+      rating: (map['rating'] as num?)?.toInt(),
+      rapidRating: (map['rapid_rating'] as num?)?.toInt(),
+      blitzRating: (map['blitz_rating'] as num?)?.toInt(),
       country: map['country'] as String?,
+      sex: map['sex'] as String?,
+      birthYear: (map['birthday'] as num?)?.toInt(),
+      flag: map['flag'] as String?,
     );
   }
+
+  int? ratingFor(RankingTimeControl timeControl) => switch (timeControl) {
+    RankingTimeControl.classical => rating,
+    RankingTimeControl.rapid => rapidRating,
+    RankingTimeControl.blitz => blitzRating,
+  };
+
+  bool get isInactive => isFideInactiveFlag(flag);
 }
 
 // --- Provider ---
@@ -53,6 +77,48 @@ class ChessPlayerRepository extends BaseRepository {
         .gt('rating', 0)
         .lt('rating', 3300)
         .order('rating', ascending: false)
+        .range(offset, offset + limit - 1);
+
+    return (data as List).map((row) => ChessPlayer.fromMap(row)).toList();
+  }
+
+  /// Fetch a stable page from the canonical FIDE monthly ranking fields.
+  Future<List<ChessPlayer>> getRankedPlayers({
+    required RankingFilters filters,
+    String searchQuery = '',
+    int limit = 30,
+    int offset = 0,
+    DateTime? now,
+  }) async {
+    final ratingColumn = filters.timeControl.ratingColumn;
+    var query = supabase
+        .from('chess_players')
+        .select(
+          'fideid, name, title, rating, rapid_rating, blitz_rating, '
+          'country, sex, birthday, flag',
+        )
+        .not(ratingColumn, 'is', null)
+        .gt(ratingColumn, 0)
+        .lt(ratingColumn, 3300);
+
+    if (filters.activity == RankingActivity.active) {
+      query = query.or('flag.is.null,flag.not.ilike.*i*');
+    }
+    if (filters.category.requiresFemale) {
+      query = query.eq('sex', 'F');
+    }
+    if (filters.category.requiresJunior) {
+      query = query.gte('birthday', (now ?? DateTime.now()).year - 20);
+    }
+
+    final normalizedSearch = searchQuery.trim();
+    if (normalizedSearch.isNotEmpty) {
+      query = query.ilike('name', '%$normalizedSearch%');
+    }
+
+    final data = await query
+        .order(ratingColumn, ascending: false)
+        .order('fideid', ascending: true)
         .range(offset, offset + limit - 1);
 
     return (data as List).map((row) => ChessPlayer.fromMap(row)).toList();

--- a/lib/screens/favorites/provider/favorites_mode_provider.dart
+++ b/lib/screens/favorites/provider/favorites_mode_provider.dart
@@ -15,5 +15,5 @@ final selectedFavoritesModeProvider =
 const favoritesModeNames = {
   FavoritesScreenMode.favorites: 'Favorites',
   FavoritesScreenMode.games: 'Games',
-  FavoritesScreenMode.players: 'Players',
+  FavoritesScreenMode.players: 'Rankings',
 };

--- a/lib/screens/favorites/rankings/ranking_filter_controls.dart
+++ b/lib/screens/favorites/rankings/ranking_filter_controls.dart
@@ -1,0 +1,216 @@
+import 'package:chessever2/screens/favorites/rankings/ranking_filters.dart';
+import 'package:chessever2/theme/app_colors.dart';
+import 'package:chessever2/utils/app_typography.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+
+class RankingActivityControl extends StatelessWidget {
+  const RankingActivityControl({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final RankingActivity value;
+  final ValueChanged<RankingActivity> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 44.h,
+      padding: EdgeInsets.all(3.sp),
+      decoration: BoxDecoration(
+        color: context.colors.popup,
+        borderRadius: BorderRadius.circular(12.br),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children:
+            RankingActivity.values.map((activity) {
+              final selected = activity == value;
+              final label =
+                  activity == RankingActivity.active ? 'Active' : 'All';
+              return Semantics(
+                selected: selected,
+                button: true,
+                child: InkWell(
+                  key: ValueKey('ranking-activity-${activity.name}'),
+                  borderRadius: BorderRadius.circular(9.br),
+                  onTap: () => onChanged(activity),
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 160),
+                    alignment: Alignment.center,
+                    padding: EdgeInsets.symmetric(horizontal: 11.w),
+                    decoration: BoxDecoration(
+                      color:
+                          selected
+                              ? context.colors.brand.withValues(alpha: 0.18)
+                              : Colors.transparent,
+                      borderRadius: BorderRadius.circular(9.br),
+                      border: Border.all(
+                        color:
+                            selected
+                                ? context.colors.brand
+                                : Colors.transparent,
+                      ),
+                    ),
+                    child: Text(
+                      label,
+                      style: AppTypography.textXsMedium.copyWith(
+                        color:
+                            selected
+                                ? context.colors.brand
+                                : context.colors.textSecondary,
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+      ),
+    );
+  }
+}
+
+class RankingFilterControls extends StatelessWidget {
+  const RankingFilterControls({
+    super.key,
+    required this.filters,
+    required this.onChanged,
+    this.showActivity = true,
+  });
+
+  final RankingFilters filters;
+  final ValueChanged<RankingFilters> onChanged;
+  final bool showActivity;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (showActivity) ...[
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: RankingActivityControl(
+              value: filters.activity,
+              onChanged:
+                  (value) => onChanged(filters.copyWith(activity: value)),
+            ),
+          ),
+          SizedBox(height: 10.h),
+        ],
+        _HorizontalOptions<RankingTimeControl>(
+          values: RankingTimeControl.values,
+          selected: filters.timeControl,
+          labelFor: (value) => value.label,
+          iconAssetFor:
+              (value) =>
+                  'assets/pngs/${value.name == 'classical' ? 'classical' : value.name}.png',
+          keyPrefix: 'ranking-time-control',
+          onSelected:
+              (value) => onChanged(filters.copyWith(timeControl: value)),
+        ),
+        SizedBox(height: 8.h),
+        _HorizontalOptions<RankingCategory>(
+          values: RankingCategory.values,
+          selected: filters.category,
+          labelFor: (value) => value.label,
+          keyPrefix: 'ranking-category',
+          onSelected: (value) => onChanged(filters.copyWith(category: value)),
+        ),
+      ],
+    );
+  }
+}
+
+class _HorizontalOptions<T> extends StatelessWidget {
+  const _HorizontalOptions({
+    required this.values,
+    required this.selected,
+    required this.labelFor,
+    required this.keyPrefix,
+    required this.onSelected,
+    this.iconAssetFor,
+  });
+
+  final List<T> values;
+  final T selected;
+  final String Function(T) labelFor;
+  final String? Function(T)? iconAssetFor;
+  final String keyPrefix;
+  final ValueChanged<T> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      physics: const BouncingScrollPhysics(),
+      child: Row(
+        children:
+            values.map((value) {
+              final isSelected = value == selected;
+              final asset = iconAssetFor?.call(value);
+              return Padding(
+                padding: EdgeInsets.only(right: 8.w),
+                child: Semantics(
+                  selected: isSelected,
+                  button: true,
+                  child: InkWell(
+                    key: ValueKey(
+                      '$keyPrefix-${labelFor(value).toLowerCase()}',
+                    ),
+                    borderRadius: BorderRadius.circular(12.br),
+                    onTap: () => onSelected(value),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 160),
+                      constraints: BoxConstraints(minHeight: 44.h),
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 13.w,
+                        vertical: 8.h,
+                      ),
+                      decoration: BoxDecoration(
+                        color:
+                            isSelected
+                                ? context.colors.brand.withValues(alpha: 0.16)
+                                : context.colors.popup,
+                        borderRadius: BorderRadius.circular(12.br),
+                        border: Border.all(
+                          color:
+                              isSelected
+                                  ? context.colors.brand
+                                  : context.colors.divider,
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (asset != null) ...[
+                            Image.asset(
+                              asset,
+                              width: 24.ic,
+                              height: 24.ic,
+                              fit: BoxFit.contain,
+                            ),
+                            SizedBox(width: 7.w),
+                          ],
+                          Text(
+                            labelFor(value),
+                            style: AppTypography.textXsMedium.copyWith(
+                              color:
+                                  isSelected
+                                      ? context.colors.textPrimary
+                                      : context.colors.textSecondary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/screens/favorites/rankings/ranking_filters.dart
+++ b/lib/screens/favorites/rankings/ranking_filters.dart
@@ -1,0 +1,78 @@
+enum RankingActivity { active, all }
+
+enum RankingTimeControl { classical, rapid, blitz }
+
+extension RankingTimeControlData on RankingTimeControl {
+  String get ratingColumn => switch (this) {
+    RankingTimeControl.classical => 'rating',
+    RankingTimeControl.rapid => 'rapid_rating',
+    RankingTimeControl.blitz => 'blitz_rating',
+  };
+
+  String get label => switch (this) {
+    RankingTimeControl.classical => 'Classical',
+    RankingTimeControl.rapid => 'Rapid',
+    RankingTimeControl.blitz => 'Blitz',
+  };
+}
+
+enum RankingCategory { overall, women, juniors, girls }
+
+extension RankingCategoryData on RankingCategory {
+  bool get requiresFemale =>
+      this == RankingCategory.women || this == RankingCategory.girls;
+
+  bool get requiresJunior =>
+      this == RankingCategory.juniors || this == RankingCategory.girls;
+
+  String get label => switch (this) {
+    RankingCategory.overall => 'Overall',
+    RankingCategory.women => 'Women',
+    RankingCategory.juniors => 'Juniors',
+    RankingCategory.girls => 'Girls',
+  };
+}
+
+bool isFideInactiveFlag(String? flag) =>
+    flag?.toLowerCase().contains('i') ?? false;
+
+class RankingFilters {
+  const RankingFilters({
+    required this.activity,
+    required this.timeControl,
+    required this.category,
+  });
+
+  static const defaults = RankingFilters(
+    activity: RankingActivity.active,
+    timeControl: RankingTimeControl.classical,
+    category: RankingCategory.overall,
+  );
+
+  final RankingActivity activity;
+  final RankingTimeControl timeControl;
+  final RankingCategory category;
+
+  RankingFilters copyWith({
+    RankingActivity? activity,
+    RankingTimeControl? timeControl,
+    RankingCategory? category,
+  }) {
+    return RankingFilters(
+      activity: activity ?? this.activity,
+      timeControl: timeControl ?? this.timeControl,
+      category: category ?? this.category,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is RankingFilters &&
+        other.activity == activity &&
+        other.timeControl == timeControl &&
+        other.category == category;
+  }
+
+  @override
+  int get hashCode => Object.hash(activity, timeControl, category);
+}

--- a/lib/screens/favorites/tabs/favorites_players_tab.dart
+++ b/lib/screens/favorites/tabs/favorites_players_tab.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:chessever2/repository/supabase/chess_player/chess_player_repository.dart';
 import 'package:chessever2/providers/favorite_players_provider.dart';
+import 'package:chessever2/screens/favorites/rankings/ranking_filter_controls.dart';
+import 'package:chessever2/screens/favorites/rankings/ranking_filters.dart';
 import 'package:chessever2/utils/favorite_constants.dart';
 import 'package:chessever2/widgets/paywall/premium_paywall_sheet.dart';
 import 'package:chessever2/screens/standings/player_standing_model.dart';
@@ -33,7 +35,7 @@ final playerPhotoProvider = FutureProvider.autoDispose.family<String?, int?>((
   return FidePhotoService.getPhotoUrlOrNull(fideId.toString());
 });
 
-// Provider for world players search
+// Provider for world rankings search
 final worldPlayersSearchProvider = StateNotifierProvider.autoDispose<
   WorldPlayersSearchNotifier,
   WorldPlayersSearchState
@@ -41,6 +43,8 @@ final worldPlayersSearchProvider = StateNotifierProvider.autoDispose<
 
 class WorldPlayersSearchState {
   final List<PlayerStandingModel> players;
+  final Set<int> inactivePlayerIds;
+  final RankingFilters filters;
   final bool isLoading;
   final bool hasMore;
   final int offset;
@@ -49,6 +53,8 @@ class WorldPlayersSearchState {
 
   const WorldPlayersSearchState({
     this.players = const [],
+    this.inactivePlayerIds = const {},
+    this.filters = RankingFilters.defaults,
     this.isLoading = false,
     this.hasMore = true,
     this.offset = 0,
@@ -60,6 +66,8 @@ class WorldPlayersSearchState {
 
   WorldPlayersSearchState copyWith({
     List<PlayerStandingModel>? players,
+    Set<int>? inactivePlayerIds,
+    RankingFilters? filters,
     bool? isLoading,
     bool? hasMore,
     int? offset,
@@ -68,6 +76,8 @@ class WorldPlayersSearchState {
   }) {
     return WorldPlayersSearchState(
       players: players ?? this.players,
+      inactivePlayerIds: inactivePlayerIds ?? this.inactivePlayerIds,
+      filters: filters ?? this.filters,
       isLoading: isLoading ?? this.isLoading,
       hasMore: hasMore ?? this.hasMore,
       offset: offset ?? this.offset,
@@ -79,13 +89,14 @@ class WorldPlayersSearchState {
 
 class WorldPlayersSearchNotifier
     extends StateNotifier<WorldPlayersSearchState> {
-  final Ref _ref;
-  static const int _pageSize = 30;
-
   WorldPlayersSearchNotifier(this._ref)
     : super(const WorldPlayersSearchState(isLoading: true)) {
     _loadInitial();
   }
+
+  final Ref _ref;
+  static const int _pageSize = 30;
+  int _requestGeneration = 0;
 
   Future<void> _loadInitial() async {
     await _fetchPlayers(isInitial: true);
@@ -94,55 +105,59 @@ class WorldPlayersSearchNotifier
   Future<void> _fetchPlayers({required bool isInitial}) async {
     if (!mounted) return;
 
+    final generation = _requestGeneration;
+    final requestedFilters = state.filters;
+    final requestedSearch = state.searchQuery;
+    final offset = isInitial ? 0 : state.offset;
     state = state.copyWith(isLoading: true);
 
     try {
       final repo = _ref.read(chessPlayerRepositoryProvider);
-      final offset = isInitial ? 0 : state.offset;
-
       final players = await retryTransientRead(
-        () =>
-            state.isSearching
-                ? repo.searchAllPlayers(
-                  query: state.searchQuery,
-                  limit: _pageSize,
-                  offset: offset,
-                )
-                : repo.getTopPlayers(limit: _pageSize, offset: offset),
+        () => repo.getRankedPlayers(
+          filters: requestedFilters,
+          searchQuery: requestedSearch,
+          limit: _pageSize,
+          offset: offset,
+        ),
       );
+
+      if (!mounted || generation != _requestGeneration) return;
 
       final playerModels =
           players
               .map(
-                (p) => PlayerStandingModel(
-                  name: p.name,
-                  countryCode: _fideFedToCountryCode(p.country),
-                  score: p.rating ?? 0,
+                (player) => PlayerStandingModel(
+                  name: player.name,
+                  countryCode: _fideFedToCountryCode(player.country),
+                  score: player.ratingFor(requestedFilters.timeControl) ?? 0,
                   scoreChange: 0,
                   matchScore: null,
-                  title: p.title,
-                  fideId: p.fideid,
+                  title: player.title,
+                  fideId: player.fideid,
                 ),
               )
               .toList();
-
       final allPlayers =
           isInitial ? playerModels : [...state.players, ...playerModels];
-
-      if (!mounted) return;
+      final inactiveIds = <int>{
+        if (!isInitial) ...state.inactivePlayerIds,
+        ...players.where((player) => player.isInactive).map((p) => p.fideid),
+      };
 
       state = state.copyWith(
         players: allPlayers,
+        inactivePlayerIds: inactiveIds,
         isLoading: false,
         hasMore: players.length >= _pageSize,
         offset: offset + players.length,
       );
     } catch (e) {
       debugPrint('[WorldPlayersSearch] Error: $e');
-      if (!mounted) return;
+      if (!mounted || generation != _requestGeneration) return;
       final error = userFacingError(
         e,
-        fallback: 'Could not load players. Please try again.',
+        fallback: 'Could not load rankings. Please try again.',
       );
       state = state.copyWith(
         isLoading: false,
@@ -158,38 +173,47 @@ class WorldPlayersSearchNotifier
 
   Future<void> search(String query) async {
     final trimmed = query.trim();
+    if (trimmed == state.searchQuery) return;
 
-    if (trimmed.isEmpty) {
-      await clearSearch();
-      return;
-    }
-
+    _requestGeneration++;
     state = state.copyWith(
       searchQuery: trimmed,
+      players: const [],
+      inactivePlayerIds: const {},
       offset: 0,
       hasMore: true,
-      error: null,
+      isLoading: true,
     );
-
     await _fetchPlayers(isInitial: true);
   }
 
-  Future<void> clearSearch() async {
-    if (!state.isSearching) return;
+  Future<void> clearSearch() => search('');
 
+  Future<void> updateFilters(RankingFilters filters) async {
+    if (filters == state.filters) return;
+
+    _requestGeneration++;
     state = state.copyWith(
-      searchQuery: '',
+      filters: filters,
+      players: const [],
+      inactivePlayerIds: const {},
       offset: 0,
       hasMore: true,
-      error: null,
+      isLoading: true,
     );
-
     await _fetchPlayers(isInitial: true);
   }
 
   Future<void> refresh() async {
-    state = const WorldPlayersSearchState(isLoading: true);
-    await _loadInitial();
+    _requestGeneration++;
+    state = state.copyWith(
+      players: const [],
+      inactivePlayerIds: const {},
+      offset: 0,
+      hasMore: true,
+      isLoading: true,
+    );
+    await _fetchPlayers(isInitial: true);
   }
 
   /// Convert FIDE federation code to ISO country code
@@ -428,6 +452,18 @@ class _FavoritesPlayersTabState extends ConsumerState<FavoritesPlayersTab>
     ref.read(worldPlayersSearchProvider.notifier).clearSearch();
   }
 
+  Future<void> _onFiltersChanged(RankingFilters filters) async {
+    HapticFeedback.selectionClick();
+    _searchFocusNode.unfocus();
+    await ref.read(worldPlayersSearchProvider.notifier).updateFilters(filters);
+    if (!mounted || !_scrollController.hasClients) return;
+    await _scrollController.animateTo(
+      0,
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOut,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -457,18 +493,41 @@ class _FavoritesPlayersTabState extends ConsumerState<FavoritesPlayersTab>
           parent: BouncingScrollPhysics(),
         ),
         slivers: [
-          // Search bar
           SliverToBoxAdapter(
             child: Padding(
               padding: EdgeInsets.fromLTRB(16.w, 12.h, 16.w, 8.h),
-              child: SearchBarWidget(
-                hintText: 'Search Player',
-                margin: 0.sp,
-                autoFocus: false,
-                controller: _searchController,
-                focusNode: _searchFocusNode,
-                onChanged: _onSearchChanged,
-                onClose: _clearSearch,
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: SearchBarWidget(
+                          hintText: 'Search',
+                          margin: 0.sp,
+                          autoFocus: false,
+                          controller: _searchController,
+                          focusNode: _searchFocusNode,
+                          onChanged: _onSearchChanged,
+                          onClose: _clearSearch,
+                        ),
+                      ),
+                      SizedBox(width: 8.w),
+                      RankingActivityControl(
+                        value: state.filters.activity,
+                        onChanged:
+                            (value) => _onFiltersChanged(
+                              state.filters.copyWith(activity: value),
+                            ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 10.h),
+                  RankingFilterControls(
+                    filters: state.filters,
+                    showActivity: false,
+                    onChanged: _onFiltersChanged,
+                  ),
+                ],
               ),
             ),
           ),
@@ -599,6 +658,9 @@ class _FavoritesPlayersTabState extends ConsumerState<FavoritesPlayersTab>
             isFavorite: isFavorite,
             rank: index + 1,
             showFavoriteButton: true,
+            isInactive:
+                player.fideId != null &&
+                state.inactivePlayerIds.contains(player.fideId),
             onTap: () => _navigateToPlayerDetail(player),
             onToggleFavorite: () => _toggleFavorite(player, isFavorite),
           );

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -167,7 +167,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         MaterialPageRoute(
           builder:
               (_) => const FavoritesTabScreen(
-                initialMode: FavoritesScreenMode.favorites,
+                initialMode: FavoritesScreenMode.players,
               ),
         ),
       );

--- a/lib/widgets/figma_player_card.dart
+++ b/lib/widgets/figma_player_card.dart
@@ -25,6 +25,7 @@ class FigmaPlayerCard extends ConsumerWidget {
   final int? rank;
   final bool isFavorite;
   final bool showFavoriteButton;
+  final bool isInactive;
   final VoidCallback onTap;
   final VoidCallback? onToggleFavorite;
   final ValueChanged<LongPressStartDetails>? onLongPress;
@@ -35,6 +36,7 @@ class FigmaPlayerCard extends ConsumerWidget {
     required this.rank,
     this.isFavorite = false,
     this.showFavoriteButton = true,
+    this.isInactive = false,
     required this.onTap,
     this.onToggleFavorite,
     this.onLongPress,
@@ -116,6 +118,8 @@ class FigmaPlayerCard extends ConsumerWidget {
                     size: avatarSize,
                     borderRadius: 8.br,
                     title: player.title,
+                    titleBadgeColor:
+                        isInactive ? context.colors.dangerMuted : null,
                   ),
               loading:
                   () => skel.Skeletonizer(
@@ -139,6 +143,8 @@ class FigmaPlayerCard extends ConsumerWidget {
                     size: avatarSize,
                     borderRadius: 8.br,
                     title: player.title,
+                    titleBadgeColor:
+                        isInactive ? context.colors.dangerMuted : null,
                   ),
             ),
             SizedBox(width: 12.w),

--- a/lib/widgets/hamburger_menu/hamburger_menu.dart
+++ b/lib/widgets/hamburger_menu/hamburger_menu.dart
@@ -170,8 +170,8 @@ class HamburgerMenu extends HookConsumerWidget {
                       // recolour to `iconPrimary` only when the theme is light;
                       // dark theme renders the asset unchanged.
                       _MenuItem(
-                        icon: Icons.favorite_border,
-                        title: 'Favorites',
+                        icon: Icons.leaderboard_outlined,
+                        title: 'Rankings',
                         textStyle: AppTypography.textSmRegular.copyWith(
                           color: context.colors.iconPrimary,
                           height: 20.h / 14.h,

--- a/lib/widgets/player_initials_avatar.dart
+++ b/lib/widgets/player_initials_avatar.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
@@ -30,6 +29,9 @@ class PlayerInitialsAvatar extends StatelessWidget {
   /// Optional title badge (e.g., "GM", "IM") shown at the bottom
   final String? title;
 
+  /// Optional ranking-specific override for the title badge background.
+  final Color? titleBadgeColor;
+
   /// Whether to use circular shape instead of rounded rectangle
   final bool isCircular;
 
@@ -40,6 +42,7 @@ class PlayerInitialsAvatar extends StatelessWidget {
     required this.size,
     this.borderRadius,
     this.title,
+    this.titleBadgeColor,
     this.isCircular = false,
   });
 
@@ -77,7 +80,7 @@ class PlayerInitialsAvatar extends StatelessWidget {
               child: Container(
                 padding: EdgeInsets.symmetric(horizontal: 3.w, vertical: 1.5.h),
                 decoration: BoxDecoration(
-                  color: getTitleBadgeColor(title!),
+                  color: titleBadgeColor ?? getTitleBadgeColor(title!),
                   borderRadius: BorderRadius.only(
                     bottomLeft: Radius.circular(effectiveBorderRadius - 2),
                     bottomRight: Radius.circular(effectiveBorderRadius - 2),

--- a/test/repository/chess_player_ranking_model_test.dart
+++ b/test/repository/chess_player_ranking_model_test.dart
@@ -1,0 +1,27 @@
+import 'package:chessever2/repository/supabase/chess_player/chess_player_repository.dart';
+import 'package:chessever2/screens/favorites/rankings/ranking_filters.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ChessPlayer maps ranking fields and selected ratings', () {
+    final player = ChessPlayer.fromMap({
+      'fideid': 1503014,
+      'name': 'Carlsen, Magnus',
+      'title': 'GM',
+      'rating': 2839,
+      'rapid_rating': 2824,
+      'blitz_rating': 2881,
+      'country': 'NOR',
+      'sex': 'M',
+      'birthday': 1990,
+      'flag': 'i',
+    });
+
+    expect(player.ratingFor(RankingTimeControl.classical), 2839);
+    expect(player.ratingFor(RankingTimeControl.rapid), 2824);
+    expect(player.ratingFor(RankingTimeControl.blitz), 2881);
+    expect(player.isInactive, isTrue);
+    expect(player.sex, 'M');
+    expect(player.birthYear, 1990);
+  });
+}

--- a/test/screens/favorites/ranking_filter_controls_test.dart
+++ b/test/screens/favorites/ranking_filter_controls_test.dart
@@ -1,0 +1,70 @@
+import 'package:chessever2/screens/favorites/rankings/ranking_filter_controls.dart';
+import 'package:chessever2/screens/favorites/rankings/ranking_filters.dart';
+import 'package:chessever2/theme/app_theme.dart';
+import 'package:chessever2/utils/responsive_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<void> _pumpControls(
+  WidgetTester tester, {
+  RankingFilters filters = RankingFilters.defaults,
+  ValueChanged<RankingFilters>? onChanged,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(393, 852));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.darkTheme,
+      home: Builder(
+        builder: (context) {
+          ResponsiveHelper.init(context);
+          return Scaffold(
+            body: RankingFilterControls(
+              filters: filters,
+              onChanged: onChanged ?? (_) {},
+            ),
+          );
+        },
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows phone ranking selectors with default selections', (
+    tester,
+  ) async {
+    await _pumpControls(tester);
+
+    expect(find.text('Active'), findsOneWidget);
+    expect(find.text('All'), findsOneWidget);
+    expect(find.text('Classical'), findsOneWidget);
+    expect(find.text('Rapid'), findsOneWidget);
+    expect(find.text('Blitz'), findsOneWidget);
+    expect(find.text('Overall'), findsOneWidget);
+    expect(find.text('Women'), findsOneWidget);
+    expect(find.text('Juniors'), findsOneWidget);
+    expect(find.text('Girls'), findsOneWidget);
+
+    final selected = tester.widgetList<Semantics>(
+      find.byWidgetPredicate(
+        (widget) => widget is Semantics && widget.properties.selected == true,
+      ),
+    );
+    expect(selected.length, 3);
+  });
+
+  testWidgets('changing time control preserves activity and category', (
+    tester,
+  ) async {
+    RankingFilters? changed;
+    await _pumpControls(tester, onChanged: (value) => changed = value);
+
+    await tester.tap(find.text('Rapid'));
+    await tester.pump();
+
+    expect(changed?.activity, RankingActivity.active);
+    expect(changed?.timeControl, RankingTimeControl.rapid);
+    expect(changed?.category, RankingCategory.overall);
+  });
+}

--- a/test/screens/favorites/ranking_filters_test.dart
+++ b/test/screens/favorites/ranking_filters_test.dart
@@ -1,0 +1,38 @@
+import 'package:chessever2/screens/favorites/provider/favorites_mode_provider.dart';
+import 'package:chessever2/screens/favorites/rankings/ranking_filters.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('rankings default to active classical overall', () {
+    expect(RankingFilters.defaults.activity, RankingActivity.active);
+    expect(RankingFilters.defaults.timeControl, RankingTimeControl.classical);
+    expect(RankingFilters.defaults.category, RankingCategory.overall);
+  });
+
+  test('third Favorites mode is labelled Rankings', () {
+    expect(favoritesModeNames[FavoritesScreenMode.players], 'Rankings');
+  });
+
+  test('time controls map to canonical chess_players rating columns', () {
+    expect(RankingTimeControl.classical.ratingColumn, 'rating');
+    expect(RankingTimeControl.rapid.ratingColumn, 'rapid_rating');
+    expect(RankingTimeControl.blitz.ratingColumn, 'blitz_rating');
+  });
+
+  test('ranking categories expose canonical eligibility requirements', () {
+    expect(RankingCategory.overall.requiresFemale, isFalse);
+    expect(RankingCategory.women.requiresFemale, isTrue);
+    expect(RankingCategory.juniors.requiresJunior, isTrue);
+    expect(RankingCategory.girls.requiresFemale, isTrue);
+    expect(RankingCategory.girls.requiresJunior, isTrue);
+  });
+
+  test('FIDE inactive flags include combined flags containing i', () {
+    expect(isFideInactiveFlag(null), isFalse);
+    expect(isFideInactiveFlag(''), isFalse);
+    expect(isFideInactiveFlag('w'), isFalse);
+    expect(isFideInactiveFlag('i'), isTrue);
+    expect(isFideInactiveFlag('wi'), isTrue);
+    expect(isFideInactiveFlag('I'), isTrue);
+  });
+}

--- a/test/screens/favorites/rankings_navigation_contract_test.dart
+++ b/test/screens/favorites/rankings_navigation_contract_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('drawer Rankings opens the Rankings tab', () {
+    final drawer =
+        File(
+          'lib/widgets/hamburger_menu/hamburger_menu.dart',
+        ).readAsStringSync();
+    final home = File('lib/screens/home/home_screen.dart').readAsStringSync();
+
+    expect(drawer, contains("title: 'Rankings'"));
+    expect(drawer, contains('icon: Icons.leaderboard_outlined'));
+    expect(home, contains('initialMode: FavoritesScreenMode.players'));
+  });
+
+  test('For You Favorites keeps its existing Games entry path', () {
+    final modeProvider =
+        File(
+          'lib/screens/favorites/provider/favorites_mode_provider.dart',
+        ).readAsStringSync();
+    final forYouCard =
+        File(
+          'lib/screens/group_event/widget/premium_collection_cards.dart',
+        ).readAsStringSync();
+
+    expect(modeProvider, contains('(ref) => FavoritesScreenMode.games'));
+    expect(forYouCard, contains('builder: (_) => const FavoritesTabScreen()'));
+    expect(
+      forYouCard,
+      isNot(contains('initialMode: FavoritesScreenMode.players')),
+    );
+  });
+}

--- a/test/widgets/figma_player_card_flag_test.dart
+++ b/test/widgets/figma_player_card_flag_test.dart
@@ -1,18 +1,28 @@
+import 'package:chessever2/screens/favorites/tabs/favorites_players_tab.dart';
 import 'package:chessever2/screens/standings/player_standing_model.dart';
+import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/figma_player_card.dart';
+import 'package:chessever2/widgets/player_initials_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_country_flags/flutter_country_flags.dart' as fcf;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-Future<void> _pumpCard(WidgetTester tester, String countryCode) async {
+Future<void> _pumpCard(
+  WidgetTester tester,
+  String countryCode, {
+  bool isInactive = false,
+}) async {
   await tester.binding.setSurfaceSize(const Size(393, 852));
   addTearDown(() => tester.binding.setSurfaceSize(null));
 
   await tester.pumpWidget(
     ProviderScope(
+      overrides: [
+        playerPhotoProvider.overrideWith((ref, fideId) async => null),
+      ],
       child: MaterialApp(
         theme: AppTheme.darkTheme,
         home: Builder(
@@ -30,6 +40,7 @@ Future<void> _pumpCard(WidgetTester tester, String countryCode) async {
                 ),
                 rank: 1,
                 showFavoriteButton: false,
+                isInactive: isInactive,
                 onTap: () {},
               ),
             );
@@ -38,6 +49,7 @@ Future<void> _pumpCard(WidgetTester tester, String countryCode) async {
       ),
     ),
   );
+  await tester.pump();
 }
 
 void main() {
@@ -55,5 +67,16 @@ void main() {
 
     expect(find.byType(Image), findsNothing);
     expect(find.byType(fcf.FlutterCountryFlags), findsNothing);
+  });
+
+  testWidgets('uses muted danger title badge for inactive ranking rows', (
+    tester,
+  ) async {
+    await _pumpCard(tester, 'NOR', isInactive: true);
+
+    final avatar = tester.widget<PlayerInitialsAvatar>(
+      find.byType(PlayerInitialsAvatar),
+    );
+    expect(avatar.titleBadgeColor, AppColors.dark.dangerMuted);
   });
 }


### PR DESCRIPTION
## Summary

- rename the phone Players tab and drawer entry to Rankings while keeping the Favorites screen title and For You Favorites flow unchanged
- add phone-native Active/All, Classical/Rapid/Blitz, and Overall/Women/Juniors/Girls ranking controls
- query canonical FIDE monthly rating fields with stable pagination and scoped search
- show inactive ranking titles with a muted danger treatment in the All view
- preserve favorite hearts, profile navigation, pull-to-refresh, pagination, and stale-request protection

## Defaults

- Active
- Classical
- Overall

## Validation

- `flutter analyze --no-pub` on all touched production files — clean
- focused Flutter tests — 13 passed
- `git diff --check` — passed
- phone-sized Flutter render at 393×852 — completed with no layout overflow in the ranking controls/list geometry

## Scope

Phone frontend only. No migration, backfill, production-data mutation, release, or deployment.
