### PR TITLE
Keep cross-month event ratings visible

### DIFF
--- a/lib/widgets/event_card/event_card.dart
+++ b/lib/widgets/event_card/event_card.dart
@@ -13,6 +13,7 @@ import 'package:chessever2/utils/svg_asset.dart';
 import 'package:chessever2/utils/time_utils.dart';
 import 'package:chessever2/widgets/app_button.dart';
 import 'package:chessever2/widgets/auth/auth_upgrade_sheet.dart';
+import 'package:chessever2/widgets/event_card/event_card_meta_format.dart';
 import 'package:chessever2/widgets/event_card/event_context_menu.dart';
 import 'package:chessever2/widgets/event_card/event_image_provider.dart';
 import 'package:chessever2/widgets/event_card/event_next_round_provider.dart';
@@ -185,7 +186,11 @@ class EventCard extends ConsumerWidget {
                         showLocation: false,
                         location: null,
                         showElo: tourEventCardModel.maxAvgElo > 0,
-                        elo: tourEventCardModel.maxAvgElo,
+                        eloLabel: formatEventAverageRating(
+                          elo: tourEventCardModel.maxAvgElo,
+                          startDate: tourEventCardModel.startDate,
+                          endDate: tourEventCardModel.endDate,
+                        ),
                         onLight: true,
                       ),
                     ),
@@ -291,7 +296,11 @@ class EventCard extends ConsumerWidget {
                         tourEventCardModel.eventSource !=
                             EventSource.communityEvent &&
                         tourEventCardModel.maxAvgElo > 0,
-                    elo: tourEventCardModel.maxAvgElo,
+                    eloLabel: formatEventAverageRating(
+                      elo: tourEventCardModel.maxAvgElo,
+                      startDate: tourEventCardModel.startDate,
+                      endDate: tourEventCardModel.endDate,
+                    ),
                   ),
                   _NextRoundLine(
                     eventId: tourEventCardModel.id,
@@ -366,7 +375,7 @@ class _MetaLine extends StatelessWidget {
     required this.showLocation,
     required this.location,
     required this.showElo,
-    required this.elo,
+    required this.eloLabel,
     this.onLight = false,
   });
 
@@ -375,7 +384,7 @@ class _MetaLine extends StatelessWidget {
   final bool showLocation;
   final String? location;
   final bool showElo;
-  final int elo;
+  final String eloLabel;
   final bool onLight;
 
   @override
@@ -422,7 +431,7 @@ class _MetaLine extends StatelessWidget {
       spans.add(TextSpan(text: location!));
     } else if (showElo) {
       spans.add(_dotSpan(baseColor));
-      spans.add(TextSpan(text: 'Ø $elo'));
+      spans.add(TextSpan(text: eloLabel));
     }
 
     return Text.rich(

--- a/lib/widgets/event_card/event_card_meta_format.dart
+++ b/lib/widgets/event_card/event_card_meta_format.dart
@@ -1,0 +1,16 @@
+/// Formats the compact average-rating metadata used by event cards.
+///
+/// Cross-month date ranges already consume more horizontal space, so their
+/// rating keeps the numeric value and drops the optional average marker.
+String formatEventAverageRating({
+  required int elo,
+  required DateTime? startDate,
+  required DateTime? endDate,
+}) {
+  final spansMultipleMonths =
+      startDate != null &&
+      endDate != null &&
+      (startDate.year != endDate.year || startDate.month != endDate.month);
+
+  return spansMultipleMonths ? '$elo' : 'Ø $elo';
+}

--- a/test/event_card_meta_format_test.dart
+++ b/test/event_card_meta_format_test.dart
@@ -1,0 +1,39 @@
+import 'package:chessever2/widgets/event_card/event_card_meta_format.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('formatEventAverageRating', () {
+    test('drops the average marker for events spanning different months', () {
+      expect(
+        formatEventAverageRating(
+          elo: 2486,
+          startDate: DateTime(2026, 7, 16),
+          endDate: DateTime(2026, 8, 1),
+        ),
+        '2486',
+      );
+    });
+
+    test('keeps the average marker for events contained in one month', () {
+      expect(
+        formatEventAverageRating(
+          elo: 2486,
+          startDate: DateTime(2026, 7, 16),
+          endDate: DateTime(2026, 7, 30),
+        ),
+        'Ø 2486',
+      );
+    });
+
+    test('keeps the average marker when the date range is incomplete', () {
+      expect(
+        formatEventAverageRating(
+          elo: 2486,
+          startDate: DateTime(2026, 7, 16),
+          endDate: null,
+        ),
+        'Ø 2486',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- keep the full numeric event average rating visible when an event spans multiple calendar months
- omit only the optional `Ø` marker for cross-month event cards
- preserve the existing marker for same-month and incomplete date ranges

## Validation
- `flutter test test/event_card_meta_format_test.dart`
- `flutter analyze --no-pub lib/widgets/event_card/event_card.dart lib/widgets/event_card/event_card_meta_format.dart test/event_card_meta_format_test.dart`
- `git diff --check`

## Queue context
- Phone queue preflight: 17 open PRs targeting `dev`, 10 dirty/conflicting, 16 requesting `devberkay`; `pause_new_requests=true`
- This branch was created fresh from current `origin/dev`, had `0 behind / 0 ahead` before the commit, and has no touched-file overlap with open phone PRs

## Device check requested
On a narrow phone, verify an event spanning two months (for example Jul 16–Aug 1) shows the complete rating number without the average marker, while a same-month event still shows `Ø`.

Source report: Vasif’s Events-page screenshot showing the Czech Open 2026 rating truncated after the cross-month date range.
