### PR TITLE
feat(player): open filtered website profiles in the app

### DIFF
--- a/lib/screens/player_profile/player_profile_screen.dart
+++ b/lib/screens/player_profile/player_profile_screen.dart
@@ -14,6 +14,7 @@ import 'package:chessever2/screens/player_profile/tabs/player_about_tab.dart';
 import 'package:chessever2/screens/player_profile/utils/player_profile_share_utils.dart';
 import 'package:chessever2/screens/player_profile/widgets/player_profile_share_image_card.dart';
 import 'package:chessever2/screens/player_profile/widgets/save_to_library_sheet.dart';
+import 'package:chessever2/services/player_profile_deep_link.dart';
 import 'package:chessever2/screens/player_profile/tabs/player_events_tab.dart';
 import 'package:chessever2/screens/player_profile/tabs/player_games_tab.dart';
 import 'package:chessever2/services/fide_photo_service.dart';
@@ -72,6 +73,7 @@ class PlayerProfileScreen extends ConsumerStatefulWidget {
     this.federation,
     this.rating,
     this.gamebasePlayerId,
+    this.initialDeepLink,
   });
 
   /// FIDE ID - can be null for players without official FIDE registration
@@ -81,6 +83,7 @@ class PlayerProfileScreen extends ConsumerStatefulWidget {
   final String? federation;
   final int? rating;
   final String? gamebasePlayerId;
+  final PlayerProfileDeepLink? initialDeepLink;
 
   /// Create from SearchPlayer model
   factory PlayerProfileScreen.fromSearchPlayer(SearchPlayer player) {
@@ -147,7 +150,13 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
   void initState() {
     super.initState();
     _currentGamebasePlayerId = _normalizePlayerId(widget.gamebasePlayerId);
-    final initialTab = ref.read(selectedPlayerProfileTabProvider);
+    final initialTab =
+        widget.initialDeepLink != null
+            ? PlayerProfileTab.games
+            : ref.read(selectedPlayerProfileTabProvider);
+    if (widget.initialDeepLink != null) {
+      ref.read(selectedPlayerProfileTabProvider.notifier).state = initialTab;
+    }
     _pageController = PageController(
       initialPage: PlayerProfileTab.values.indexOf(initialTab),
     );
@@ -160,6 +169,43 @@ class _PlayerProfileScreenState extends ConsumerState<PlayerProfileScreen>
       CurvedAnimation(
         parent: _favoriteAnimationController,
         curve: Curves.easeInOut,
+      ),
+    );
+    if (widget.initialDeepLink?.hasFilters ?? false) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _applyInitialDeepLinkFilters();
+      });
+    }
+  }
+
+  void _applyInitialDeepLinkFilters() {
+    final link = widget.initialDeepLink;
+    if (link == null) return;
+
+    final timeControl = switch (link.timeControl) {
+      'classical' => GameTimeControlFilter.classical,
+      'rapid' => GameTimeControlFilter.rapid,
+      'blitz' => GameTimeControlFilter.blitz,
+      _ => null,
+    };
+    final color = switch (link.color) {
+      'white' => GameColorFilter.white,
+      'black' => GameColorFilter.black,
+      _ => null,
+    };
+    final playerResult = switch (link.result) {
+      'win' => PlayerResultFilter.win,
+      'draw' => PlayerResultFilter.draw,
+      'loss' => PlayerResultFilter.loss,
+      _ => null,
+    };
+
+    unawaited(
+      _openGames(
+        timeControl: timeControl,
+        color: color,
+        eco: link.eco == null ? null : GameEcoFilter(code: link.eco),
+        playerResultFilter: playerResult,
       ),
     );
   }

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -43,6 +43,7 @@ import 'package:chessever2/screens/player_profile/player_profile_data_source.dar
 import 'package:chessever2/screens/player_profile/player_profile_screen.dart'
     show PlayerProfileScreen;
 import 'package:chessever2/services/pgn_file_intake_service.dart';
+import 'package:chessever2/services/player_profile_deep_link.dart';
 import 'package:chessever2/widgets/event_card/event_context_menu.dart'
     show kEventTabQueryParam;
 import 'package:flutter/material.dart';
@@ -199,6 +200,8 @@ class DeepLinkService {
       int? playerFideId;
       String? teamName;
       int? profileFideId;
+      final profileDeepLink = parsePlayerProfileDeepLink(uri);
+      profileFideId = profileDeepLink?.fideId;
 
       // Universal link: https://chessever.com/games/<id>
       if (uri.pathSegments.length >= 2 && uri.pathSegments[0] == 'games') {
@@ -240,7 +243,9 @@ class DeepLinkService {
       // Player profile: https://chessever.com/player/<fideId>, plus the
       // canonical SEO form https://chessever.com/player/<name-slug>/<fideId>.
       // The FIDE id is always the last segment.
-      if (uri.pathSegments.length >= 2 && uri.pathSegments[0] == 'player') {
+      if (profileFideId == null &&
+          uri.pathSegments.length >= 2 &&
+          uri.pathSegments[0] == 'player') {
         profileFideId = int.tryParse(uri.pathSegments.last);
       }
 
@@ -390,7 +395,12 @@ class DeepLinkService {
           'routing to player profile',
           data: {'fideId': profileFideId.toString()},
         );
-        _navigateToPlayerProfile(profileFideId, navigatorKey, ref);
+        _navigateToPlayerProfile(
+          profileFideId,
+          navigatorKey,
+          ref,
+          initialDeepLink: profileDeepLink,
+        );
       } else {
         _addBreadcrumb(
           'deep link ignored',
@@ -1448,8 +1458,9 @@ class DeepLinkService {
   Future<void> _navigateToPlayerProfile(
     int fideId,
     GlobalKey<NavigatorState> navigatorKey,
-    WidgetRef ref,
-  ) async {
+    WidgetRef ref, {
+    PlayerProfileDeepLink? initialDeepLink,
+  }) async {
     if (_isNavigating) {
       debugPrint('DeepLinkService: Navigation already in progress, ignoring');
       return;
@@ -1505,6 +1516,7 @@ class DeepLinkService {
                 title: player.title,
                 federation: player.country,
                 rating: player.rating,
+                initialDeepLink: initialDeepLink,
               ),
         ),
       );

--- a/lib/services/player_profile_deep_link.dart
+++ b/lib/services/player_profile_deep_link.dart
@@ -1,0 +1,59 @@
+class PlayerProfileDeepLink {
+  const PlayerProfileDeepLink({
+    required this.fideId,
+    this.timeControl,
+    this.result,
+    this.color,
+    this.eco,
+  });
+
+  final int fideId;
+  final String? timeControl;
+  final String? result;
+  final String? color;
+  final String? eco;
+
+  bool get hasFilters =>
+      timeControl != null || result != null || color != null || eco != null;
+}
+
+const _timeControls = {'classical', 'rapid', 'blitz'};
+const _results = {'win', 'draw', 'loss'};
+const _colors = {'white', 'black'};
+
+PlayerProfileDeepLink? parsePlayerProfileDeepLink(Uri uri) {
+  List<String> segments;
+  if (uri.host == 'player') {
+    segments = uri.pathSegments;
+  } else if (uri.pathSegments.isNotEmpty &&
+      uri.pathSegments.first == 'player') {
+    segments = uri.pathSegments.skip(1).toList(growable: false);
+  } else {
+    return null;
+  }
+
+  final gamesIndex = segments.lastIndexOf('games');
+  if (gamesIndex <= 0 || gamesIndex != segments.length - 1) return null;
+
+  final fideId = int.tryParse(segments[gamesIndex - 1]);
+  if (fideId == null || fideId <= 0) return null;
+
+  String? supported(String key, Set<String> allowed) {
+    final value = uri.queryParameters[key]?.trim().toLowerCase();
+    return value != null && allowed.contains(value) ? value : null;
+  }
+
+  final rawEco = uri.queryParameters['eco']?.trim().toUpperCase();
+  final eco =
+      rawEco != null && RegExp(r'^[A-E]\d{2}$').hasMatch(rawEco)
+          ? rawEco
+          : null;
+
+  return PlayerProfileDeepLink(
+    fideId: fideId,
+    timeControl: supported('time', _timeControls),
+    result: supported('result', _results),
+    color: supported('color', _colors),
+    eco: eco,
+  );
+}

--- a/test/services/player_profile_deep_link_test.dart
+++ b/test/services/player_profile_deep_link_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:chessever2/services/player_profile_deep_link.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'parses canonical website player games links with supported filters',
+    () {
+      final link = parsePlayerProfileDeepLink(
+        Uri.parse(
+          'https://chessever.com/player/erigaisi-arjun/35009192/games'
+          '?time=blitz&result=loss&color=black&eco=b22',
+        ),
+      );
+
+      expect(link, isNotNull);
+      expect(link!.fideId, 35009192);
+      expect(link.timeControl, 'blitz');
+      expect(link.result, 'loss');
+      expect(link.color, 'black');
+      expect(link.eco, 'B22');
+    },
+  );
+
+  test('parses custom-scheme player games links', () {
+    final link = parsePlayerProfileDeepLink(
+      Uri.parse('com.chessever.app://player/35009192/games?time=rapid'),
+    );
+
+    expect(link, isNotNull);
+    expect(link!.fideId, 35009192);
+    expect(link.timeControl, 'rapid');
+  });
+
+  test(
+    'rejects malformed ids, unsupported views, and unknown filter values',
+    () {
+      expect(
+        parsePlayerProfileDeepLink(
+          Uri.parse('https://chessever.com/player/not-an-id/games'),
+        ),
+        isNull,
+      );
+      expect(
+        parsePlayerProfileDeepLink(
+          Uri.parse('com.chessever.app://player/35009192/about'),
+        ),
+        isNull,
+      );
+
+      final link = parsePlayerProfileDeepLink(
+        Uri.parse(
+          'com.chessever.app://player/35009192/games'
+          '?time=bullet&result=white&color=blue&eco=S99',
+        ),
+      );
+      expect(link, isNotNull);
+      expect(link!.timeControl, isNull);
+      expect(link.result, isNull);
+      expect(link.color, isNull);
+      expect(link.eco, isNull);
+    },
+  );
+
+  test('deep-link routing opens the player profile games tab with filters', () {
+    final service =
+        File('lib/services/deep_link_service.dart').readAsStringSync();
+    final screen =
+        File(
+          'lib/screens/player_profile/player_profile_screen.dart',
+        ).readAsStringSync();
+
+    expect(service, contains('parsePlayerProfileDeepLink(uri)'));
+    expect(service, contains('_navigateToPlayerProfile'));
+    expect(service, contains('initialDeepLink: profileDeepLink'));
+    expect(screen, contains('this.initialDeepLink'));
+    expect(screen, contains('_applyInitialDeepLinkFilters'));
+  });
+}


### PR DESCRIPTION
## Summary
- accept canonical website and custom-scheme player Games deep links
- open the matching player directly on the Games tab
- preserve supported time-control, result, color, and ECO filters through existing auth/Premium guards
- reject malformed IDs and unsupported filter values

## Validation
- `flutter test --no-pub test/services/player_profile_deep_link_test.dart`
- touched-file `flutter analyze --no-pub` (no issues)
- `dart format --output=none --set-exit-if-changed`
- `git diff --check`

## Coordination
Companion to Chessever/chessever-web-frontend#101. This changes app routing only; no release or deployment is included.

## Queue note
The phone queue is currently heavy. This branch is based cleanly on current `origin/dev`; the only open same-file overlap found is PR #266 against `stable`, not `dev`.