### PR TITLE
Standardize phone PGN exports with Lichess-style headers

### DIFF
--- a/lib/screens/chessboard/chess_board_screen_new.dart
+++ b/lib/screens/chessboard/chess_board_screen_new.dart
@@ -67,6 +67,7 @@ import 'package:chessever2/providers/pip_mode_provider.dart';
 // import 'package:chessever2/providers/keyboard_total_height_provider.dart'; // UNUSED: Removed with old dialog
 import 'package:chessever2/utils/figurine_notation.dart';
 import 'package:chessever2/utils/logger/logger.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/string_utils.dart';
 import 'package:chessever2/utils/user_error_message.dart';
@@ -3901,7 +3902,9 @@ class _AppBarState extends ConsumerState<_AppBar> {
         showAppSnack(context, 'No PGN available for this game');
         return;
       }
-      await Clipboard.setData(ClipboardData(text: resolved.pgn));
+      await Clipboard.setData(
+        ClipboardData(text: canonicalizePgnForExport(resolved.pgn)),
+      );
       HapticFeedback.lightImpact();
       if (!mounted) return;
       showAppSnack(context, 'PGN copied to clipboard');

--- a/lib/screens/chessboard/notation/notation_tree.dart
+++ b/lib/screens/chessboard/notation/notation_tree.dart
@@ -1,5 +1,6 @@
 import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
 import 'package:chessever2/screens/chessboard/analysis/chess_game_navigator.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:chessever2/screens/chessboard/notation/notation_pointer.dart';
 import 'package:dartchess/dartchess.dart'
     show PgnChildNode, PgnGame, PgnNode, PgnNodeData;
@@ -192,15 +193,11 @@ const _standardStartingFen =
     'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
 Map<String, String> _buildPgnHeaders(ChessGame game) {
-  final sortedEntries =
-      game.metadata.entries.toList()..sort((a, b) => a.key.compareTo(b.key));
   final headers = <String, String>{};
 
-  for (final entry in sortedEntries) {
+  for (final entry in game.metadata.entries) {
     headers[entry.key] = entry.value?.toString() ?? '';
   }
-
-  headers.putIfAbsent('Result', () => '*');
 
   final hasCustomStart =
       game.startingFen.trim().isNotEmpty &&
@@ -212,7 +209,7 @@ Map<String, String> _buildPgnHeaders(ChessGame game) {
     headers.putIfAbsent('FEN', () => game.startingFen);
   }
 
-  return headers;
+  return canonicalPgnHeaders(headers);
 }
 
 void _appendLineToPgnNode(PgnNode<PgnNodeData> parent, ChessLine line) {

--- a/lib/screens/chessboard/widgets/share_game_card_overlay.dart
+++ b/lib/screens/chessboard/widgets/share_game_card_overlay.dart
@@ -20,6 +20,7 @@ import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/theme/app_theme.dart';
 import 'package:chessever2/utils/app_typography.dart';
 import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/share_card.dart';
 import 'package:chessever2/utils/location_service_provider.dart';
@@ -609,7 +610,9 @@ class _ShareGameCardOverlayState extends State<ShareGameCardOverlay> {
 
   Future<void> _copyPgn() async {
     try {
-      await Clipboard.setData(ClipboardData(text: widget.pgn));
+      await Clipboard.setData(
+        ClipboardData(text: canonicalizePgnForExport(widget.pgn)),
+      );
       HapticFeedback.lightImpact();
       _showMessage('PGN copied to clipboard!', isError: false);
     } catch (e) {

--- a/lib/screens/library/utils/gamebase_pgn_builder.dart
+++ b/lib/screens/library/utils/gamebase_pgn_builder.dart
@@ -1,4 +1,5 @@
 import 'package:chessever2/utils/pgn_clock_utils.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:dartchess/dartchess.dart';
 import 'package:flutter/foundation.dart';
 
@@ -156,8 +157,9 @@ String? buildPgnFromGamebaseData(Map<String, dynamic>? data) {
     debugPrint('[GamebasePgnBuilder] Successfully parsed ${sans.length} moves');
   }
 
+  final exportedHeaders = canonicalPgnHeaders(headers);
   final sb = StringBuffer();
-  for (final entry in headers.entries) {
+  for (final entry in exportedHeaders.entries) {
     sb.writeln('[${entry.key} "${entry.value}"]');
   }
   sb.writeln();
@@ -175,7 +177,7 @@ String? buildPgnFromGamebaseData(Map<String, dynamic>? data) {
     sb.write(' ');
   }
 
-  sb.write(headers['Result'] ?? '*');
+  sb.write(exportedHeaders['Result'] ?? '*');
 
   return sb.toString().trim();
 }
@@ -284,8 +286,9 @@ String buildHeaderOnlyPgn({
     headers['SetUp'] = '1';
   }
 
+  final exportedHeaders = canonicalPgnHeaders(headers);
   final sb = StringBuffer();
-  for (final entry in headers.entries) {
+  for (final entry in exportedHeaders.entries) {
     sb.writeln('[${entry.key} "${entry.value}"]');
   }
   sb.writeln();

--- a/lib/screens/library/widgets/archive_game_actions.dart
+++ b/lib/screens/library/widgets/archive_game_actions.dart
@@ -6,6 +6,7 @@ import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/utils/logger/logger.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/widgets/alert_dialog/alert_modal.dart';
 import 'package:chessever2/widgets/app_snack.dart';
@@ -125,7 +126,9 @@ Future<void> copyArchiveGamePgn({
     game,
     failureMessage: 'No PGN available for this game',
     (pgn) async {
-      await Clipboard.setData(ClipboardData(text: pgn));
+      await Clipboard.setData(
+        ClipboardData(text: canonicalizePgnForExport(pgn)),
+      );
       HapticFeedback.lightImpact();
       if (!context.mounted) return;
       showAppSnack(context, 'PGN copied to clipboard');

--- a/lib/screens/library/widgets/saved_game_actions.dart
+++ b/lib/screens/library/widgets/saved_game_actions.dart
@@ -6,6 +6,7 @@ import 'package:chessever2/screens/library/widgets/library_context_menu.dart';
 import 'package:chessever2/screens/library/widgets/move_game_to_database_sheet.dart';
 import 'package:chessever2/screens/tour_detail/games_tour/models/games_tour_model.dart';
 import 'package:chessever2/utils/logger/logger.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:chessever2/widgets/app_snack.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -121,7 +122,7 @@ Future<void> _copyPgn(BuildContext context, SavedAnalysis analysis) async {
       showAppSnack(context, 'No PGN available for this game');
       return;
     }
-    await Clipboard.setData(ClipboardData(text: pgn));
+    await Clipboard.setData(ClipboardData(text: canonicalizePgnForExport(pgn)));
     HapticFeedback.lightImpact();
     if (!context.mounted) return;
     showAppSnack(context, 'PGN copied to clipboard');

--- a/lib/utils/pgn_export_utils.dart
+++ b/lib/utils/pgn_export_utils.dart
@@ -1,0 +1,109 @@
+const pgnHeaderOrder = <String>[
+  'Event',
+  'Site',
+  'Date',
+  'Round',
+  'White',
+  'Black',
+  'Result',
+  'WhiteElo',
+  'BlackElo',
+  'WhiteTitle',
+  'BlackTitle',
+  'WhiteFideId',
+  'BlackFideId',
+  'ECO',
+  'Opening',
+  'EventDate',
+];
+
+const pgnSevenTagDefaults = <String, String>{
+  'Event': '?',
+  'Site': '?',
+  'Date': '????.??.??',
+  'Round': '?',
+  'White': '?',
+  'Black': '?',
+  'Result': '*',
+};
+
+const internalPgnMetadataKeys = <String>{
+  'allowMainlineExtension',
+  'isLiveGame',
+  'gameEndingPlyIndex',
+};
+
+/// Returns user-facing PGN headers in deterministic interchange order.
+///
+/// The Seven Tag Roster is always present first. Public source metadata is
+/// retained, while ChessEver runtime/editing fields are omitted.
+Map<String, String> canonicalPgnHeaders(Map<String, String> source) {
+  final headers = <String, String>{};
+  for (final entry in source.entries) {
+    final key = entry.key.trim();
+    if (key.isEmpty || internalPgnMetadataKeys.contains(key)) continue;
+    headers[key] = entry.value;
+  }
+
+  for (final entry in pgnSevenTagDefaults.entries) {
+    final current = headers[entry.key]?.trim();
+    if (current == null || current.isEmpty) {
+      headers[entry.key] = entry.value;
+    }
+  }
+
+  final ordered = <String, String>{};
+  for (final key in pgnHeaderOrder) {
+    final value = headers[key];
+    if (value != null) ordered[key] = value;
+  }
+
+  final remaining =
+      headers.keys.where((key) => !ordered.containsKey(key)).toList()..sort();
+  for (final key in remaining) {
+    ordered[key] = headers[key]!;
+  }
+  return ordered;
+}
+
+/// Rewrites only the PGN tag-pair section and preserves movetext verbatim.
+///
+/// This lets clipboard/share exports follow the same standard order as
+/// Lichess without dropping clock/evaluation comments, NAGs, or variations.
+String canonicalizePgnForExport(String rawPgn) {
+  final normalized = rawPgn.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  final lines = normalized.split('\n');
+  final headers = <String, String>{};
+  var movetextStart = lines.length;
+  var sawHeader = false;
+  final tagPattern = RegExp(r'^\[([^\s\]]+)\s+"((?:\\.|[^"\\])*)"\]\s*$');
+
+  for (var i = 0; i < lines.length; i++) {
+    final trimmed = lines[i].trim();
+    if (trimmed.isEmpty) continue;
+    final match = tagPattern.firstMatch(trimmed);
+    if (match != null) {
+      sawHeader = true;
+      headers[match.group(1)!] = match.group(2)!;
+      continue;
+    }
+    movetextStart = i;
+    break;
+  }
+
+  if (!sawHeader && normalized.trim().isEmpty) return '';
+
+  final movetext =
+      movetextStart < lines.length
+          ? lines.sublist(movetextStart).join('\n').trim()
+          : '';
+  final output = StringBuffer();
+  for (final entry in canonicalPgnHeaders(headers).entries) {
+    output.writeln('[${entry.key} "${entry.value}"]');
+  }
+  if (movetext.isNotEmpty) {
+    output.writeln();
+    output.write(movetext);
+  }
+  return output.toString().trimRight();
+}

--- a/lib/widgets/event_card/event_context_menu.dart
+++ b/lib/widgets/event_card/event_context_menu.dart
@@ -5,6 +5,7 @@ import 'package:chessever2/services/analytics/analytics_service.dart';
 import 'package:chessever2/theme/app_colors.dart';
 import 'package:chessever2/utils/haptic_feedback_service.dart';
 import 'package:chessever2/utils/pgn_link_rebrand.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
 import 'package:chessever2/utils/responsive_helper.dart';
 import 'package:chessever2/utils/tablet_safe_menu.dart';
 import 'package:chessever2/widgets/app_snack.dart';
@@ -231,7 +232,9 @@ Future<void> _copyEventPgn({
         final pgn = g.pgn;
         if (pgn == null || pgn.trim().isEmpty) continue;
         if (copied > 0) pgnBuffer.write('\n\n');
-        pgnBuffer.write(rebrandPgnLinks(pgn.trim()));
+        pgnBuffer.write(
+          canonicalizePgnForExport(rebrandPgnLinks(pgn.trim())),
+        );
         copied++;
       }
 

--- a/test/pgn_export_compatibility_test.dart
+++ b/test/pgn_export_compatibility_test.dart
@@ -1,0 +1,114 @@
+import 'package:chessever2/screens/chessboard/analysis/chess_game.dart';
+import 'package:chessever2/screens/chessboard/notation/notation_tree.dart';
+import 'package:chessever2/screens/library/utils/gamebase_pgn_builder.dart';
+import 'package:chessever2/utils/pgn_export_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('canonicalizePgnForExport', () {
+    test(
+      'writes Lichess-style identity headers first without changing movetext',
+      () {
+        const raw = '''[Black "So, Wesley"]
+[BlackElo "2719"]
+[Event "USA - Uzbekistan WR Chess Match"]
+[Result "0-1"]
+[Round "1.3"]
+[Site "Miami, United States"]
+[White "Madaminov, Mukhiddin"]
+[WhiteElo "2501"]
+[BroadcastURL "https://chessever.com/broadcast/example"]
+[allowMainlineExtension "true"]
+[isLiveGame "false"]
+
+1. e4 {[%clk 0:15:16]} e5 {[%eval 0.20]} 2. Nf3 Nc6 0-1''';
+
+        final exported = canonicalizePgnForExport(raw);
+
+        expect(exported.split('\n').take(9).toList(), [
+          '[Event "USA - Uzbekistan WR Chess Match"]',
+          '[Site "Miami, United States"]',
+          '[Date "????.??.??"]',
+          '[Round "1.3"]',
+          '[White "Madaminov, Mukhiddin"]',
+          '[Black "So, Wesley"]',
+          '[Result "0-1"]',
+          '[WhiteElo "2501"]',
+          '[BlackElo "2719"]',
+        ]);
+        expect(
+          exported,
+          contains('[BroadcastURL "https://chessever.com/broadcast/example"]'),
+        );
+        expect(exported, isNot(contains('allowMainlineExtension')));
+        expect(exported, isNot(contains('isLiveGame')));
+        expect(
+          exported,
+          endsWith('1. e4 {[%clk 0:15:16]} e5 {[%eval 0.20]} 2. Nf3 Nc6 0-1'),
+        );
+        expect(exported, contains('\n\n1. e4'));
+      },
+    );
+  });
+
+  group('notation PGN export', () {
+    test('adds standard defaults and removes internal ChessEver metadata', () {
+      final game = ChessGame.fromPgn('manual-analysis', '''[Result "*"]
+[allowMainlineExtension "true"]
+[isLiveGame "false"]
+[gameEndingPlyIndex "2"]
+
+1. e4 {[%clk 0:15:00]} e5 {[%eval 0.18]} *''');
+
+      final exported = exportGameToPgn(game);
+
+      expect(exported.split('\n').take(7).toList(), [
+        '[Event "?"]',
+        '[Site "?"]',
+        '[Date "????.??.??"]',
+        '[Round "?"]',
+        '[White "?"]',
+        '[Black "?"]',
+        '[Result "*"]',
+      ]);
+      expect(exported, isNot(contains('allowMainlineExtension')));
+      expect(exported, isNot(contains('isLiveGame')));
+      expect(exported, isNot(contains('gameEndingPlyIndex')));
+      expect(exported, contains('[%clk 0:15:00]'));
+      expect(exported, contains('[%eval 0.18]'));
+    });
+  });
+
+  group('Gamebase PGN export', () {
+    test('writes the Seven Tag Roster before Gamebase metadata', () {
+      final pgn = buildPgnFromGamebaseData({
+        'md': {
+          'Black': 'So, Wesley',
+          'BlackElo': '2719',
+          'Event': 'USA - Uzbekistan WR Chess Match',
+          'Result': '0-1',
+          'White': 'Madaminov, Mukhiddin',
+          'WhiteElo': '2501',
+        },
+        'm': [
+          {'u': 'e2e4', 'ct': '0:15:16'},
+          {'u': 'e7e5', 'ct': '0:15:16'},
+        ],
+      });
+
+      expect(pgn, isNotNull);
+      expect(pgn!.split('\n').take(9).toList(), [
+        '[Event "USA - Uzbekistan WR Chess Match"]',
+        '[Site "?"]',
+        '[Date "????.??.??"]',
+        '[Round "?"]',
+        '[White "Madaminov, Mukhiddin"]',
+        '[Black "So, Wesley"]',
+        '[Result "0-1"]',
+        '[WhiteElo "2501"]',
+        '[BlackElo "2719"]',
+      ]);
+      expect(pgn, contains('1. e4 {[%clk 0:15:16]} e5'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- standardize phone PGN copy/export headers around the Seven Tag Roster
- preserve public metadata plus clocks, evaluations, comments, NAGs, and variations
- strip ChessEver-only runtime metadata from user-facing PGN
- apply the same serializer to board, share, event, archive, saved-game, Gamebase, and folder/export paths

## Behavior
Exports now begin with:

```pgn
[Event "..."]
[Site "..."]
[Date "..."]
[Round "..."]
[White "..."]
[Black "..."]
[Result "..."]
```

Additional metadata follows in stable order. Existing movetext is preserved verbatim when normalizing a raw source PGN.

## Validation
- RED: focused regression initially failed because the canonical PGN exporter did not exist
- GREEN: `flutter test test/pgn_export_compatibility_test.dart`
- focused tests: PGN compatibility, clock parsing, notation export, event/team share URL, and Library context menu — 47 tests passed
- focused touched-file analyze: no issues found
- `git diff --check`: passed

## Base
Targets `stable`, the current phone shipping line verified from repository history. No backend, schema, production-data, or release change.
