### PR TITLE
Rename positive Game Report labels

### DIFF
--- a/lib/screens/chessboard/game_review/game_analysis_report.dart
+++ b/lib/screens/chessboard/game_review/game_analysis_report.dart
@@ -13,8 +13,8 @@ enum GameReportStatus { idle, running, completed, cancelled, failed }
 
 enum GameMoveClassification {
   brilliant('Brilliant'),
-  goodMove('Best'),
-  bestMove('Great'),
+  goodMove('Great move'),
+  bestMove('Top move'),
   missedWin('Missed Win'),
   inaccuracy('Inaccuracy'),
   mistake('Mistake'),

--- a/test/game_analysis_report_test.dart
+++ b/test/game_analysis_report_test.dart
@@ -248,6 +248,12 @@ void main() {
   group('move classification', () {
     final game = ChessGame.fromPgn('classify', '1. e4 *');
 
+    test('positive labels use the approved visible names', () {
+      expect(GameMoveClassification.goodMove.label, 'Great move');
+      expect(GameMoveClassification.bestMove.label, 'Top move');
+      expect(GameMoveClassification.brilliant.label, 'Brilliant');
+    });
+
     test('engine top among near-equals stays untagged', () {
       expect(
         _classifyWin(
@@ -261,7 +267,7 @@ void main() {
       );
     });
 
-    test('engine top with a PV moat is Best', () {
+    test('engine top with a PV moat enters the lower positive tier', () {
       expect(
         _classifyWin(
           game,
@@ -373,7 +379,7 @@ void main() {
         positions: positions,
       );
       expect(report.moves.single.bestAlternative, 'd2d4');
-      // Tiny multipv gap → not Best
+      // Tiny MultiPV gap → no positive tier.
       expect(report.moves.single.classification, isNull);
     });
   });

--- a/test/game_review_widget_test.dart
+++ b/test/game_review_widget_test.dart
@@ -526,8 +526,8 @@ void main() {
       findsAtLeastNWidgets(1),
     );
     expect(find.text('Forced'), findsNothing);
-    expect(find.text('Best'), findsOneWidget);
-    expect(find.text('Great'), findsOneWidget);
+    expect(find.text('Great move'), findsOneWidget);
+    expect(find.text('Top move'), findsOneWidget);
     expect(find.text('Missed Win'), findsOneWidget);
     expect(find.text('1-0'), findsNothing);
     expect(find.byType(CircleAvatar), findsNothing);


### PR DESCRIPTION
## Summary
- rename the visible `! Best` report label to `! Great move`
- rename the visible `★ Great` report label to `★ Top move`
- keep `!! Brilliant` unchanged
- preserve the existing classifier behavior, thresholds, icon assets, and report persistence in this narrow commit
- add direct label and widget regressions

## Follow-up classifier tuning brief

The approved product hierarchy is:

1. `★ Top move` — engine-top and meaningfully separated
2. `! Great move` — substantially game-changing and non-routine
3. `!! Brilliant` — exceptional and rare

This PR changes names only. Before changing classifier behavior, implement and corpus-validate a Draft against identical cached engine snapshots:

### Top move
- played move is stable PV1
- initial hypothesis: PV1 is about 0.35–0.4 pawns better than PV2 in a non-decided position
- compare at the same stable depth and MultiPV snapshot, from the mover's perspective
- exclude book, forced moves, routine recaptures, and trivial/routine material recovery
- do not award it when candidate lines are effectively equivalent

### Great move
- a large PV gap alone is insufficient
- require near-best engine quality plus a substantial reason: preserve win/draw across an outcome-band change, avoid mate, find a non-obvious tactical resource, win/save meaningful material, strongly punish an error, or remain the only successful move under deeper confirmation
- quiet normal defence remains Top move unless it genuinely changes/saves the outcome and contains a non-routine resource

### Decided-position guard
- when all relevant lines remain in the same clearly decisive WDL/outcome band, raw centipawn movement must not by itself create Top, Great, Inaccuracy, Mistake, Blunder, or Missed Win
- Brilliant may still qualify only through independent exceptional evidence

### Evaluation pipeline and acceptance
- normal single-PV pass nominates candidates
- only candidates receive deeper stable MultiPV + WDL confirmation
- apply book/forced/routine guards after confirmation
- show the exact structured reason for every positive label
- no per-game quotas
- validate elite, club, tactical, quiet, conversion, defensive-save, and routine hard-negative cases
- review false `!!` first, then false Great, then Top precision/recall
- define the exact decided-position WDL cutoff and Great semantic evidence before release

## Validation
- `flutter test --no-pub test/game_analysis_report_test.dart` — 19 passed
- `flutter test --no-pub test/game_review_widget_test.dart` — 14 passed
- `flutter analyze --no-pub --no-fatal-infos lib/screens/chessboard/game_review/game_analysis_report.dart test/game_analysis_report_test.dart test/game_review_widget_test.dart` — no issues
- `git diff --check` — clean

## Scope
- base: `stable` (current shipping line)
- no production-data, migration, backend, notification, entitlement, or release change
- not shipped until reviewed, merged, released, and device-verified
