### PR TITLE
Suppress Game Report praise in decided conversions

### DIFF
--- a/lib/screens/chessboard/game_review/game_analysis_report.dart
+++ b/lib/screens/chessboard/game_review/game_analysis_report.dart
@@ -1292,8 +1292,12 @@ GameMoveClassification? _classifyGameReportMoveCore({
   final alternatives = before.lines
       .where((line) => line.moves.isNotEmpty && line.moves.first != move.uci)
       .toList(growable: false);
-  final alternativeWin =
-      alternatives.isEmpty ? null : gameReportWinPercentage(alternatives.first);
+  final alternativeWin = alternatives.isEmpty
+      ? null
+      : gameReportWinPercentage(alternatives.first);
+  final alternativeMoverWin = alternativeWin == null
+      ? null
+      : (isWhite ? alternativeWin : (100 - alternativeWin));
 
   // Gap: played result vs next-best path (pp, mover's favour).
   final alternativeGap =
@@ -1348,6 +1352,30 @@ GameMoveClassification? _classifyGameReportMoveCore({
   // in a losing position is unreachable today — a known gap, tracked separately
   // rather than papered over here.
   var greatAndBestEligible = positiveLabelsEligible;
+
+  // Once the played move and the first real alternative both keep a clearly
+  // won position clearly won, their gap is conversion noise rather than a
+  // prestigious decision. Brilliant remains separate: an independently
+  // verified exceptional idea may still qualify on its own evidence.
+  final saturatedWinningConversion =
+      moverBefore >= kBandBetterMax &&
+      moverAfter >= kBandBetterMax &&
+      alternativeMoverWin != null &&
+      alternativeMoverWin >= kBandBetterMax;
+  if (saturatedWinningConversion) greatAndBestEligible = false;
+
+  // Do not let routine captures inherit the prestige of the tactic that made
+  // them possible. A capture can still earn praise in a competitive position,
+  // by crossing an outcome band, or by producing a substantial win% gain.
+  final beforeBand = outcomeBandFor(moverBefore);
+  final afterBand = outcomeBandFor(moverAfter);
+  final routineConversionCapture =
+      facts.isCapture &&
+      beforeBand == afterBand &&
+      beforeBand != OutcomeBand.competitive &&
+      moverChange < kRoutinePraiseMinWinGainPp;
+  if (routineConversionCapture) greatAndBestEligible = false;
+
   if (moverAfter <= kPositivePraiseWinFloorPp &&
       (facts.isCapture || facts.isRoutineRetreat || facts.isForcedRecapture)) {
     final earnsException =
@@ -1415,8 +1443,7 @@ GameMoveClassification? _classifyGameReportMoveCore({
           playedIsBest: playedIsBest,
           moverBefore: moverBefore,
           moverAfter: moverAfter,
-          alternativeMoverWin:
-              isWhite ? alternativeWin : (100 - alternativeWin),
+          alternativeMoverWin: alternativeMoverWin!,
           alternativeGap: alternativeGap,
         );
         if (defensiveSave ||

--- a/lib/screens/chessboard/game_review/game_analysis_report_store.dart
+++ b/lib/screens/chessboard/game_review/game_analysis_report_store.dart
@@ -242,8 +242,9 @@ class _MemoryEntry {
 /// mate handling and the rule that the engine's own move is never an error all
 /// changed, so every stored report still carries the old symbols. v5: Best PV
 /// moat and Great only-reliable gap relaxed (★ / ! less conservative); same
-/// games can gain positive labels they did not under v4.
-const int gameAnalysisReportSchemaVersion = 5;
+/// games can gain positive labels they did not under v4. v6: routine tactical
+/// continuation and saturated won-position praise are suppressed.
+const int gameAnalysisReportSchemaVersion = 6;
 
 Map<String, dynamic> gameAnalysisReportToJson(GameAnalysisReport report) {
   return <String, dynamic>{

--- a/test/game_classification_v2_test.dart
+++ b/test/game_classification_v2_test.dart
@@ -163,6 +163,78 @@ void main() {
       );
     });
 
+    test('Sitges quiet king conversion remains Great', () {
+      expect(
+        _classify(
+          _sitgesKg7Game,
+          moverBefore: 81,
+          moverAfter: 94,
+          bestMove: 'h7g7',
+          alternativeMoverWin: 79,
+        ),
+        GameMoveClassification.bestMove,
+      );
+    });
+
+    test('Sitges knight sacrifice remains Great', () {
+      expect(
+        _classify(
+          _sitgesNg3Game,
+          moverBefore: 86,
+          moverAfter: 85,
+          bestMove: 'h5g3',
+          alternativeMoverWin: 6,
+        ),
+        GameMoveClassification.bestMove,
+      );
+    });
+
+    test('Sitges tactical continuation captures earn no praise', () {
+      expect(
+        _classify(
+          _sitgesRxe7Game,
+          moverBefore: 14,
+          moverAfter: 19,
+          bestMove: 'a7e7',
+          alternativeMoverWin: 0,
+        ),
+        isNull,
+      );
+      expect(
+        _classify(
+          _sitgesGxf4Game,
+          moverBefore: 19,
+          moverAfter: 15,
+          bestMove: 'g3f4',
+          alternativeMoverWin: 1,
+        ),
+        isNull,
+      );
+      expect(
+        _classify(
+          _sitgesBxg1Game,
+          moverBefore: 82,
+          moverAfter: 82,
+          bestMove: 'd4g1',
+          alternativeMoverWin: 70,
+        ),
+        isNull,
+      );
+    });
+
+    test('Sitges saturated conversion stops positive labels after Nb5', () {
+      expect(
+        _classify(
+          _sitgesQe3Game,
+          moverBefore: 99,
+          moverAfter: 99,
+          bestMove: 'f4e3',
+          alternativeMoverWin: 91,
+        ),
+        isNull,
+      );
+    });
+
     test('an attacked rook stepping away earns no symbol', () {
       expect(
         _classify(
@@ -581,6 +653,16 @@ const _onlyMoveFen = 'Q6k/8/8/8/8/8/8/K5R1 b - - 0 1';
 /// is still materially worse afterwards.
 const _looseCaptureFen = '2r1k3/8/2B5/8/8/8/8/R3K2R b - - 0 1';
 
+/// Owner-reviewed Sitges regression positions from Nidhish–Asis, round 8.
+const _sitgesNg3Fen =
+    '5q2/R3r1bk/3p2p1/3P3n/2pBPp1p/2Nn3P/1P4QP/6RK b - - 11 37';
+const _sitgesRxe7Fen =
+    '5q2/R3r2k/3p2p1/3P4/2pbPp1p/2Nn2PP/1P4Q1/6RK w - - 0 39';
+const _sitgesGxf4Fen = '8/4q2k/3p2p1/3P4/2pbPp1p/2Nn2PP/1P4Q1/6RK w - - 0 40';
+const _sitgesBxg1Fen = '8/4q2k/3p2p1/3P4/2pbPP1p/2Nn3P/1P4Q1/6RK b - - 0 40';
+const _sitgesKg7Fen = '8/7k/3p2p1/3P2q1/2p1Pn1p/2N2Q1P/1P6/7K b - - 3 43';
+const _sitgesQe3Fen = '8/6k1/3p2p1/1N1P4/2p1Pq1p/3n3P/1P4Q1/6K1 b - - 11 47';
+
 final _openingGame = ChessGame.fromPgn(
   'opening',
   '[White "Ada"]\n[Black "Grace"]\n\n1. e4 e5 *',
@@ -589,6 +671,12 @@ final _openingGame = ChessGame.fromPgn(
 final _retreatGame = _gameFromFen(_retreatFen, '1... Rd8 *');
 final _onlyMoveGame = _gameFromFen(_onlyMoveFen, '1... Kh7 *');
 final _looseCaptureGame = _gameFromFen(_looseCaptureFen, '1... Rxc6 *');
+final _sitgesNg3Game = _gameFromFen(_sitgesNg3Fen, '37... Ng3+ *');
+final _sitgesRxe7Game = _gameFromFen(_sitgesRxe7Fen, '39. Rxe7+ *');
+final _sitgesGxf4Game = _gameFromFen(_sitgesGxf4Fen, '40. gxf4 *');
+final _sitgesBxg1Game = _gameFromFen(_sitgesBxg1Fen, '40... Bxg1 *');
+final _sitgesKg7Game = _gameFromFen(_sitgesKg7Fen, '43... Kg7 *');
+final _sitgesQe3Game = _gameFromFen(_sitgesQe3Fen, '47... Qe3+ *');
 
 /// Positions for the loose-capture fixture, scored so the mover sits well above
 /// the praise floor — isolating [verifyBrilliantMove]'s own verdict from it.


### PR DESCRIPTION
## Summary
- suppress `★ Top move` and `! Great` when the played line and first alternative all remain clearly winning
- suppress prestigious labels on routine captures that stay in the same non-competitive outcome band without a substantial winning-chance gain
- preserve the owner-reviewed `37...Ng3+` and `43...Kg7` Great classifications
- bump persisted report schema to v6 so reports generated under the previous rules are recomputed

## Regression fixture
Uses exact positions from Nidhish Shyamal–Hipolito Asis Gargatagli, Sitges Round 8:

- `37...Ng3+` → Great
- `39.Rxe7+` → no positive label
- `40.gxf4` → no positive label
- `40...Bxg1` → no positive label
- `43...Kg7` → Great
- after `44.Nb5`, saturated winning conversion moves → no positive label

`!! Brilliant` remains on its independent deeper-verification path.

## Validation
- RED: the new routine-capture and saturated-conversion fixtures failed against the old classifier as Great
- GREEN: 68 focused Game Report/classification/persistence tests passed
- focused Flutter analyze on all three touched files: no issues
- `git diff --check`: clean
- direct Dart format gate still reports the same pre-existing drift on the classifier/test files; untouched `origin/stable` reports formatter changes on those same files, so no broad formatting churn is included

## Scope
Phone Game Report classifier/cache/tests only. No backend, production-data, release, or deployment changes.
